### PR TITLE
Fix Travis CI URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ It successfully passes the [SMHasher](http://code.google.com/p/smhasher/wiki/SMH
 
 |Branch      |Status   |
 |------------|---------|
-|master      | [![Build Status](https://travis-ci.org/Cyan4973/lz4.svg?branch=master)](https://travis-ci.org/Cyan4973/xxhash) |
-|dev         | [![Build Status](https://travis-ci.org/Cyan4973/lz4.svg?branch=dev)](https://travis-ci.org/Cyan4973/xxhash) |
+|master      | [![Build Status](https://travis-ci.org/Cyan4973/xxHash.svg?branch=master)](https://travis-ci.org/Cyan4973/xxHash?branch=master) |
+|dev         | [![Build Status](https://travis-ci.org/Cyan4973/xxHash.svg?branch=dev)](https://travis-ci.org/Cyan4973/xxHash?branch=dev) |
 
 
 Benchmarks


### PR DESCRIPTION
- Fix badge image URL
- Fix branch status URL

Trivial fix.
note : Travis CI recognize small/capital letter. So we should use `xxHash` instead of `xxhash`.
