### PR TITLE
[RFC PATCH] Add 128bit xxhash function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ xxhsum: xxhash.c xxhsum.c
 	$(CC)      $(CFLAGS) $^ -o $@$(EXT)
 	ln -sf $@ xxh32sum
 	ln -sf $@ xxh64sum
+	ln -sf $@ xxh128sum
 
 xxhsum32: xxhash.c xxhsum.c
 	$(CC) -m32 $(CFLAGS) $^ -o $@$(EXT)
@@ -63,5 +64,3 @@ test-all: test xxhsum32
 clean:
 	@rm -f core *.o xxhsum$(EXT) xxhsum32$(EXT) xxh32sum xxh64sum
 	@echo cleaning completed
-
-

--- a/xxhash.h
+++ b/xxhash.h
@@ -83,6 +83,7 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 
 unsigned int       XXH32 (const void* input, size_t length, unsigned seed);
 unsigned long long XXH64 (const void* input, size_t length, unsigned long long seed);
+void XXH128 (const void* input, size_t len, unsigned long long seed, void *out);
 
 /*
 XXH32() :
@@ -102,6 +103,7 @@ XXH64() :
 *****************************/
 typedef struct { long long ll[ 6]; } XXH32_state_t;
 typedef struct { long long ll[11]; } XXH64_state_t;
+typedef struct { long long ll[22]; } XXH128_state_t;
 
 /*
 These structures allow static allocation of XXH states.
@@ -116,6 +118,9 @@ XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
 XXH64_state_t* XXH64_createState(void);
 XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
 
+XXH128_state_t* XXH128_createState(void);
+XXH_errorcode XXH128_freeState(XXH128_state_t* statePtr);
+
 /*
 These functions create and release memory for XXH state.
 States must then be initialized using XXHnn_reset() before first use.
@@ -129,6 +134,10 @@ unsigned int  XXH32_digest (const XXH32_state_t* statePtr);
 XXH_errorcode      XXH64_reset  (XXH64_state_t* statePtr, unsigned long long seed);
 XXH_errorcode      XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length);
 unsigned long long XXH64_digest (const XXH64_state_t* statePtr);
+
+XXH_errorcode XXH128_reset (XXH128_state_t* statePtr, unsigned long long seed);
+XXH_errorcode XXH128_update(XXH128_state_t* statePtr, const void* input, size_t length);
+void XXH128_digest(XXH128_state_t* statePtr, void *out);
 
 /*
 These functions calculate the xxHash of an input provided in multiple smaller packets,
@@ -149,7 +158,6 @@ and therefore get some new hashes, by calling again XXHnn_digest().
 
 When you are done, don't forget to free XXH state space, using typically XXHnn_freeState().
 */
-
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
For some tasks one needed hash value what biggest then 64 bit (128, 256...)

Use as base 64bit function, working on the comparable speed:
[$]: fallocate -l 1G /tmp/test
[$]: ./xxhsum -i3 -b -H3 /tmp/test
**\* ./xxhsum 64-bits , by Yann Collet (Nov 27 2014) ***
Loading /tmp/test...
XXH32            : 1073741826 ->  5335.9 MB/s   0xB97A86C1  
XXH32 (unaligned : 1073741825 ->  5626.4 MB/s  
XXH64            : 1073741826 ->  9662.0 MB/s   0x6E8BEE355402863F  
XXH128           : 1073741826 ->  8460.0 MB/s   0x08F69772BFF465696F251EA5F1D49192

Also it a good example for create big hashes for another tasks

Signed-off-by: Timofey Titovets nefelim4ag@gmail.com

P.S.
I just want to hear comments, code can be ugly and may be useless.

P.P.S
After deletion return values from XXH128_\* functions speed can be 1 in 1 as for naked 64bit hash and i preferable make this functions void
