### PR TITLE
Added XXH128 and XXH256

### DIFF
--- a/xxhash.c
+++ b/xxhash.c
@@ -72,11 +72,11 @@ You can contact the author at :
 #  define FORCE_INLINE static __forceinline
 #else
 #  if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
-#  ifdef __GNUC__
-#    define FORCE_INLINE static inline __attribute__((always_inline))
-#  else
-#    define FORCE_INLINE static inline
-#  endif
+#    ifdef __GNUC__
+#      define FORCE_INLINE static inline __attribute__((always_inline))
+#    else
+#      define FORCE_INLINE static inline
+#    endif
 #  else
 #    define FORCE_INLINE static
 #  endif /* __STDC_VERSION__ */
@@ -99,6 +99,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
     return memcpy(dest,src,size);
 }
 
+
 /**************************************
 *  Basic Types
 ***************************************/
@@ -116,7 +117,6 @@ typedef unsigned int       U32;
 typedef   signed int       S32;
 typedef unsigned long long U64;
 #endif
-
 
 #if defined(__GNUC__)  && !defined(XXH_USE_UNALIGNED_ACCESS)
 #  define _PACKED __attribute__ ((packed))
@@ -190,6 +190,7 @@ static U64 XXH_swap64 (U64 x)
 }
 #endif
 
+
 /**************************************
 *  Constants
 ***************************************/
@@ -252,6 +253,7 @@ FORCE_INLINE U64 XXH_readLE64(const void* ptr, XXH_endianess endian)
 {
     return XXH_readLE64_align(ptr, endian, XXH_unaligned);
 }
+
 
 /****************************
 *  Simple Hash Functions
@@ -916,6 +918,7 @@ XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
 {
     XXH_free(statePtr);
     return XXH_OK;
+}
 
 XXH128_state_t* XXH128_createState(void)
 {

--- a/xxhash.c
+++ b/xxhash.c
@@ -923,6 +923,16 @@ XXH_errorcode XXH128_freeState(XXH128_state_t* statePtr)
     return XXH_OK;
 }
 
+XXH256_state_t* XXH256_createState(void)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH256_state_t) >= sizeof(XXH_istate256_t));   // A compilation error here means XXH256_state_t is not large enough
+    return (XXH256_state_t*)XXH_malloc(sizeof(XXH256_state_t));
+}
+XXH_errorcode XXH256_freeState(XXH256_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
 
 /*** Hash feed ***/
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -83,6 +83,8 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 
 unsigned int       XXH32 (const void* input, size_t length, unsigned seed);
 unsigned long long XXH64 (const void* input, size_t length, unsigned long long seed);
+void 			   XXH128 (const void* input, size_t length, unsigned long long seed, void* out);
+void 			   XXH256 (const void* input, size_t length, unsigned long long seed, void* out);
 
 /*
 XXH32() :
@@ -93,6 +95,12 @@ XXH32() :
     Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark) : 5.4 GB/s
 XXH64() :
     Calculate the 64-bits hash of sequence of length "len" stored at memory address "input".
+XXH128():
+    Calculate the 128-bits hash of sequence of length "len" stored at memory address "input".
+    Output is stored in the 16 byte array "out"
+XXH256():
+    Calculate the 256-bits hash of sequence of length "len" stored at memory address "input".
+    Output is stored in the 32 byte array "out"
 */
 
 
@@ -102,6 +110,8 @@ XXH64() :
 *****************************/
 typedef struct { long long ll[ 6]; } XXH32_state_t;
 typedef struct { long long ll[11]; } XXH64_state_t;
+typedef struct { long long ll[28]; } XXH128_state_t;
+typedef struct { long long ll[28]; } XXH256_state_t;
 
 /*
 These structures allow static allocation of XXH states.
@@ -116,6 +126,12 @@ XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
 XXH64_state_t* XXH64_createState(void);
 XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
 
+XXH128_state_t* XXH128_createState(void);
+XXH_errorcode   XXH128_freeState(XXH128_state_t* statePtr);
+
+XXH256_state_t* XXH256_createState(void);
+XXH_errorcode   XXH256_freeState(XXH256_state_t* statePtr);
+
 /*
 These functions create and release memory for XXH state.
 States must then be initialized using XXHnn_reset() before first use.
@@ -129,6 +145,14 @@ unsigned int  XXH32_digest (const XXH32_state_t* statePtr);
 XXH_errorcode      XXH64_reset  (XXH64_state_t* statePtr, unsigned long long seed);
 XXH_errorcode      XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length);
 unsigned long long XXH64_digest (const XXH64_state_t* statePtr);
+
+XXH_errorcode      XXH128_reset  (XXH128_state_t* statePtr, unsigned long long seed);
+XXH_errorcode      XXH128_update (XXH128_state_t* statePtr, const void* input, size_t length);
+void               XXH128_digest (const XXH128_state_t* statePtr, void* out);
+
+XXH_errorcode      XXH256_reset  (XXH256_state_t* statePtr, unsigned long long seed);
+XXH_errorcode      XXH256_update (XXH256_state_t* statePtr, const void* input, size_t length);
+void               XXH256_digest (const XXH256_state_t* statePtr, void* out);
 
 /*
 These functions calculate the xxHash of an input provided in multiple smaller packets,
@@ -149,7 +173,6 @@ and therefore get some new hashes, by calling again XXHnn_digest().
 
 When you are done, don't forget to free XXH state space, using typically XXHnn_freeState().
 */
-
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
Both XXH128/XXH256 are implemented in the spirit of XXH64, with minor tweaks to constants and the final mixin (to pass smhasher tests). They both pass all smhasher tests. Speedwise, they have the same performance as XXH64 for longer keys, and for shorter keys, they are slightly slower, due to more instructions for the final mix.
