### PR TITLE
Add const to types to fix GCC warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 
 CC     := $(CC)
 CFLAGS ?= -O3
-CFLAGS += -I. -std=c99 -Wall -Wextra -Wundef -Wshadow -Wstrict-prototypes
+CFLAGS += -I. -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-prototypes
 
 
 # Define *.exe as extension for Windows systems

--- a/xxhash.c
+++ b/xxhash.c
@@ -84,11 +84,11 @@ You can contact the author at :
 // Modify the local functions below should you wish to use some other memory routines
 // for malloc(), free()
 #include <stdlib.h>
-FORCE_INLINE void* XXH_malloc(size_t s) { return malloc(s); }
-FORCE_INLINE void  XXH_free  (void* p)  { free(p); }
+static void* XXH_malloc(size_t s) { return malloc(s); }
+static void  XXH_free  (void* p)  { free(p); }
 // for memcpy()
 #include <string.h>
-FORCE_INLINE void* XXH_memcpy(void* dest, const void* src, size_t size)
+static void* XXH_memcpy(void* dest, const void* src, size_t size)
 {
     return memcpy(dest,src,size);
 }
@@ -221,28 +221,28 @@ static const int one = 1;
 //****************************
 typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
 
-FORCE_INLINE U32 XXH_readLE32_align(const U32* ptr, XXH_endianess endian, XXH_alignment align)
+FORCE_INLINE U32 XXH_readLE32_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
 {
     if (align==XXH_unaligned)
         return endian==XXH_littleEndian ? A32(ptr) : XXH_swap32(A32(ptr));
     else
-        return endian==XXH_littleEndian ? *ptr : XXH_swap32(*ptr);
+        return endian==XXH_littleEndian ? *(U32*)ptr : XXH_swap32(*(U32*)ptr);
 }
 
-FORCE_INLINE U32 XXH_readLE32(const U32* ptr, XXH_endianess endian)
+FORCE_INLINE U32 XXH_readLE32(const void* ptr, XXH_endianess endian)
 {
     return XXH_readLE32_align(ptr, endian, XXH_unaligned);
 }
 
-FORCE_INLINE U64 XXH_readLE64_align(const U64* ptr, XXH_endianess endian, XXH_alignment align)
+FORCE_INLINE U64 XXH_readLE64_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
 {
     if (align==XXH_unaligned)
         return endian==XXH_littleEndian ? A64(ptr) : XXH_swap64(A64(ptr));
     else
-        return endian==XXH_littleEndian ? *ptr : XXH_swap64(*ptr);
+        return endian==XXH_littleEndian ? *(U64*)ptr : XXH_swap64(*(U64*)ptr);
 }
 
-FORCE_INLINE U64 XXH_readLE64(const U64* ptr, XXH_endianess endian)
+FORCE_INLINE U64 XXH_readLE64(const void* ptr, XXH_endianess endian)
 {
     return XXH_readLE64_align(ptr, endian, XXH_unaligned);
 }
@@ -256,7 +256,7 @@ FORCE_INLINE U32 XXH32_endian_align(const void* input, size_t len, U32 seed, XXH
     const BYTE* p = (const BYTE*)input;
     const BYTE* bEnd = p + len;
     U32 h32;
-#define XXH_get32bits(p) XXH_readLE32_align((const U32*)p, endian, align)
+#define XXH_get32bits(p) XXH_readLE32_align(p, endian, align)
 
 #ifdef XXH_ACCEPT_NULL_INPUT_POINTER
     if (p==NULL)
@@ -361,7 +361,7 @@ FORCE_INLINE U64 XXH64_endian_align(const void* input, size_t len, U64 seed, XXH
     const BYTE* p = (const BYTE*)input;
     const BYTE* bEnd = p + len;
     U64 h64;
-#define XXH_get64bits(p) XXH_readLE64_align((const U64*)p, endian, align)
+#define XXH_get64bits(p) XXH_readLE64_align(p, endian, align)
 
 #ifdef XXH_ACCEPT_NULL_INPUT_POINTER
     if (p==NULL)
@@ -509,8 +509,8 @@ typedef struct
     U32 v2;
     U32 v3;
     U32 v4;
+    U32 mem32[4];   /* defined as U32 for alignment */
     U32 memsize;
-    char memory[16];
 } XXH_istate32_t;
 
 typedef struct
@@ -521,8 +521,8 @@ typedef struct
     U64 v2;
     U64 v3;
     U64 v4;
+    U64 mem64[4];   /* defined as U64 for alignment */
     U32 memsize;
-    char memory[32];
 } XXH_istate64_t;
 
 
@@ -592,16 +592,16 @@ FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state_in, const v
 
     if (state->memsize + len < 16)   // fill in tmp buffer
     {
-        XXH_memcpy(state->memory + state->memsize, input, len);
+        XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);
         state->memsize += (U32)len;
         return XXH_OK;
     }
 
     if (state->memsize)   // some data left from previous update
     {
-        XXH_memcpy(state->memory + state->memsize, input, 16-state->memsize);
+        XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, 16-state->memsize);
         {
-            const U32* p32 = (const U32*)state->memory;
+            const U32* p32 = state->mem32;
             state->v1 += XXH_readLE32(p32, endian) * PRIME32_2;
             state->v1 = XXH_rotl32(state->v1, 13);
             state->v1 *= PRIME32_1;
@@ -633,19 +633,19 @@ FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state_in, const v
 
         do
         {
-            v1 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v1 += XXH_readLE32(p, endian) * PRIME32_2;
             v1 = XXH_rotl32(v1, 13);
             v1 *= PRIME32_1;
             p+=4;
-            v2 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v2 += XXH_readLE32(p, endian) * PRIME32_2;
             v2 = XXH_rotl32(v2, 13);
             v2 *= PRIME32_1;
             p+=4;
-            v3 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v3 += XXH_readLE32(p, endian) * PRIME32_2;
             v3 = XXH_rotl32(v3, 13);
             v3 *= PRIME32_1;
             p+=4;
-            v4 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v4 += XXH_readLE32(p, endian) * PRIME32_2;
             v4 = XXH_rotl32(v4, 13);
             v4 *= PRIME32_1;
             p+=4;
@@ -660,7 +660,7 @@ FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state_in, const v
 
     if (p < bEnd)
     {
-        XXH_memcpy(state->memory, p, bEnd-p);
+        XXH_memcpy(state->mem32, p, bEnd-p);
         state->memsize = (int)(bEnd-p);
     }
 
@@ -682,8 +682,8 @@ XXH_errorcode XXH32_update (XXH32_state_t* state_in, const void* input, size_t l
 FORCE_INLINE U32 XXH32_digest_endian (const XXH32_state_t* state_in, XXH_endianess endian)
 {
     XXH_istate32_t* state = (XXH_istate32_t*) state_in;
-    const BYTE * p = (const BYTE*)state->memory;
-    BYTE* bEnd = (BYTE*)state->memory + state->memsize;
+    const BYTE * p = (const BYTE*)state->mem32;
+    BYTE* bEnd = (BYTE*)(state->mem32) + state->memsize;
     U32 h32;
 
     if (state->total_len >= 16)
@@ -699,7 +699,7 @@ FORCE_INLINE U32 XXH32_digest_endian (const XXH32_state_t* state_in, XXH_endiane
 
     while (p+4<=bEnd)
     {
-        h32 += XXH_readLE32((const U32*)p, endian) * PRIME32_3;
+        h32 += XXH_readLE32(p, endian) * PRIME32_3;
         h32  = XXH_rotl32(h32, 17) * PRIME32_4;
         p+=4;
     }
@@ -746,16 +746,16 @@ FORCE_INLINE XXH_errorcode XXH64_update_endian (XXH64_state_t* state_in, const v
 
     if (state->memsize + len < 32)   // fill in tmp buffer
     {
-        XXH_memcpy(state->memory + state->memsize, input, len);
+        XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, len);
         state->memsize += (U32)len;
         return XXH_OK;
     }
 
     if (state->memsize)   // some data left from previous update
     {
-        XXH_memcpy(state->memory + state->memsize, input, 32-state->memsize);
+        XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, 32-state->memsize);
         {
-            const U64* p64 = (const U64*)state->memory;
+            const U64* p64 = state->mem64;
             state->v1 += XXH_readLE64(p64, endian) * PRIME64_2;
             state->v1 = XXH_rotl64(state->v1, 31);
             state->v1 *= PRIME64_1;
@@ -787,19 +787,19 @@ FORCE_INLINE XXH_errorcode XXH64_update_endian (XXH64_state_t* state_in, const v
 
         do
         {
-            v1 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v1 += XXH_readLE64(p, endian) * PRIME64_2;
             v1 = XXH_rotl64(v1, 31);
             v1 *= PRIME64_1;
             p+=8;
-            v2 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v2 += XXH_readLE64(p, endian) * PRIME64_2;
             v2 = XXH_rotl64(v2, 31);
             v2 *= PRIME64_1;
             p+=8;
-            v3 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v3 += XXH_readLE64(p, endian) * PRIME64_2;
             v3 = XXH_rotl64(v3, 31);
             v3 *= PRIME64_1;
             p+=8;
-            v4 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v4 += XXH_readLE64(p, endian) * PRIME64_2;
             v4 = XXH_rotl64(v4, 31);
             v4 *= PRIME64_1;
             p+=8;
@@ -814,7 +814,7 @@ FORCE_INLINE XXH_errorcode XXH64_update_endian (XXH64_state_t* state_in, const v
 
     if (p < bEnd)
     {
-        XXH_memcpy(state->memory, p, bEnd-p);
+        XXH_memcpy(state->mem64, p, bEnd-p);
         state->memsize = (int)(bEnd-p);
     }
 
@@ -836,8 +836,8 @@ XXH_errorcode XXH64_update (XXH64_state_t* state_in, const void* input, size_t l
 FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state_in, XXH_endianess endian)
 {
     XXH_istate64_t * state = (XXH_istate64_t *) state_in;
-    const BYTE * p = (const BYTE*)state->memory;
-    BYTE* bEnd = (BYTE*)state->memory + state->memsize;
+    const BYTE * p = (const BYTE*)state->mem64;
+    BYTE* bEnd = (BYTE*)state->mem64 + state->memsize;
     U64 h64;
 
     if (state->total_len >= 32)
@@ -882,7 +882,7 @@ FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state_in, XXH_endiane
 
     while (p+8<=bEnd)
     {
-        U64 k1 = XXH_readLE64((const U64*)p, endian);
+        U64 k1 = XXH_readLE64(p, endian);
         k1 *= PRIME64_2;
         k1 = XXH_rotl64(k1,31);
         k1 *= PRIME64_1;
@@ -893,7 +893,7 @@ FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state_in, XXH_endiane
 
     if (p+4<=bEnd)
     {
-        h64 ^= (U64)(XXH_readLE32((const U32*)p, endian)) * PRIME64_1;
+        h64 ^= (U64)(XXH_readLE32(p, endian)) * PRIME64_1;
         h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
         p+=4;
     }

--- a/xxhash.c
+++ b/xxhash.c
@@ -542,7 +542,7 @@ XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
 {
     XXH_free(statePtr);
     return XXH_OK;
-};
+}
 
 XXH64_state_t* XXH64_createState(void)
 {
@@ -553,7 +553,7 @@ XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
 {
     XXH_free(statePtr);
     return XXH_OK;
-};
+}
 
 
 /*** Hash feed ***/

--- a/xxhash.c
+++ b/xxhash.c
@@ -1,6 +1,7 @@
 /*
 xxHash - Fast Hash algorithm
-Copyright (C) 2012-2015, Yann Collet.
+Copyright (C) 2012-2015, Yann Collet
+
 BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
 Redistribution and use in source and binary forms, with or without
@@ -27,67 +28,71 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 You can contact the author at :
-- xxHash source repository : http://code.google.com/p/xxhash
+- xxHash source repository : http://code.google.com/p/xxhash/
 - xxHash source mirror : https://github.com/Cyan4973/xxHash
 - public discussion board : https://groups.google.com/forum/#!forum/lz4c
 */
 
 
-//**************************************
-// Tuning parameters
-//**************************************
-// Unaligned memory access is automatically enabled for "common" CPU, such as x86.
-// For others CPU, the compiler will be more cautious, and insert extra code to ensure aligned access is respected.
-// If you know your target CPU supports unaligned memory access, you want to force this option manually to improve performance.
-// You can also enable this parameter if you know your input data will always be aligned (boundaries of 4, for U32).
+/**************************************
+*  Tuning parameters
+***************************************/
+/* Unaligned memory access is automatically enabled for "common" CPU, such as x86.
+ * For others CPU, the compiler will be more cautious, and insert extra code to ensure aligned access is respected.
+ * If you know your target CPU supports unaligned memory access, you want to force this option manually to improve performance.
+ * You can also enable this parameter if you know your input data will always be aligned (boundaries of 4, for U32).
+ */
 #if defined(__ARM_FEATURE_UNALIGNED) || defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
 #  define XXH_USE_UNALIGNED_ACCESS 1
 #endif
 
-// XXH_ACCEPT_NULL_INPUT_POINTER :
-// If the input pointer is a null pointer, xxHash default behavior is to trigger a memory access error, since it is a bad pointer.
-// When this option is enabled, xxHash output for null input pointers will be the same as a null-length input.
-// This option has a very small performance cost (only measurable on small inputs).
-// By default, this option is disabled. To enable it, uncomment below define :
-// #define XXH_ACCEPT_NULL_INPUT_POINTER 1
+/* XXH_ACCEPT_NULL_INPUT_POINTER :
+ * If the input pointer is a null pointer, xxHash default behavior is to trigger a memory access error, since it is a bad pointer.
+ * When this option is enabled, xxHash output for null input pointers will be the same as a null-length input.
+ * By default, this option is disabled. To enable it, uncomment below define :
+ */
+/* #define XXH_ACCEPT_NULL_INPUT_POINTER 1 */
 
-// XXH_FORCE_NATIVE_FORMAT :
-// By default, xxHash library provides endian-independant Hash values, based on little-endian convention.
-// Results are therefore identical for little-endian and big-endian CPU.
-// This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
-// Should endian-independance be of no importance for your application, you may set the #define below to 1.
-// It will improve speed for Big-endian CPU.
-// This option has no impact on Little_Endian CPU.
+/* XXH_FORCE_NATIVE_FORMAT :
+ * By default, xxHash library provides endian-independant Hash values, based on little-endian convention.
+ * Results are therefore identical for little-endian and big-endian CPU.
+ * This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
+ * Should endian-independance be of no importance for your application, you may set the #define below to 1.
+ * It will improve speed for Big-endian CPU.
+ * This option has no impact on Little_Endian CPU.
+ */
 #define XXH_FORCE_NATIVE_FORMAT 0
 
-//**************************************
-// Compiler Specific Options
-//**************************************
-// Disable some Visual warning messages
-#ifdef _MSC_VER  // Visual Studio
-#  pragma warning(disable : 4127)      // disable: C4127: conditional expression is constant
-#endif
 
-#ifdef _MSC_VER    // Visual Studio
+/**************************************
+*  Compiler Specific Options
+***************************************/
+#ifdef _MSC_VER    /* Visual Studio */
+#  pragma warning(disable : 4127)      /* disable: C4127: conditional expression is constant */
 #  define FORCE_INLINE static __forceinline
 #else
-#  ifdef __GNUC__
-#    define FORCE_INLINE static inline __attribute__((always_inline))
+#  if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+#    ifdef __GNUC__
+#      define FORCE_INLINE static inline __attribute__((always_inline))
+#    else
+#      define FORCE_INLINE static inline
+#    endif
 #  else
-#    define FORCE_INLINE static inline
-#  endif
+#    define FORCE_INLINE static
+#  endif /* __STDC_VERSION__ */
 #endif
 
-//**************************************
-// Includes & Memory related functions
-//**************************************
+
+/**************************************
+*  Includes & Memory related functions
+***************************************/
 #include "xxhash.h"
-// Modify the local functions below should you wish to use some other memory routines
-// for malloc(), free()
+/* Modify the local functions below should you wish to use some other memory routines */
+/* for malloc(), free() */
 #include <stdlib.h>
 static void* XXH_malloc(size_t s) { return malloc(s); }
 static void  XXH_free  (void* p)  { free(p); }
-// for memcpy()
+/* for memcpy() */
 #include <string.h>
 static void* XXH_memcpy(void* dest, const void* src, size_t size)
 {
@@ -95,10 +100,10 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 }
 
 
-//**************************************
-// Basic Types
-//**************************************
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   // C99
+/**************************************
+*  Basic Types
+***************************************/
+#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
 # include <stdint.h>
 typedef uint8_t  BYTE;
 typedef uint16_t U16;
@@ -144,12 +149,12 @@ typedef struct _U64_S
 #define A64(x) (((U64_S *)(x))->v)
 
 
-//***************************************
-// Compiler-specific Functions and Macros
-//***************************************
+/*****************************************
+*  Compiler-specific Functions and Macros
+******************************************/
 #define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 
-// Note : although _rotl exists for minGW (GCC under windows), performance seems poor
+/* Note : although _rotl exists for minGW (GCC under windows), performance seems poor */
 #if defined(_MSC_VER)
 #  define XXH_rotl32(x,r) _rotl(x,r)
 #  define XXH_rotl64(x,r) _rotl64(x,r)
@@ -158,21 +163,21 @@ typedef struct _U64_S
 #  define XXH_rotl64(x,r) ((x << r) | (x >> (64 - r)))
 #endif
 
-#if defined(_MSC_VER)     // Visual Studio
+#if defined(_MSC_VER)     /* Visual Studio */
 #  define XXH_swap32 _byteswap_ulong
 #  define XXH_swap64 _byteswap_uint64
 #elif GCC_VERSION >= 403
 #  define XXH_swap32 __builtin_bswap32
 #  define XXH_swap64 __builtin_bswap64
 #else
-static inline U32 XXH_swap32 (U32 x)
+static U32 XXH_swap32 (U32 x)
 {
     return  ((x << 24) & 0xff000000 ) |
             ((x <<  8) & 0x00ff0000 ) |
             ((x >>  8) & 0x0000ff00 ) |
             ((x >> 24) & 0x000000ff );
 }
-static inline U64 XXH_swap64 (U64 x)
+static U64 XXH_swap64 (U64 x)
 {
     return  ((x << 56) & 0xff00000000000000ULL) |
             ((x << 40) & 0x00ff000000000000ULL) |
@@ -186,9 +191,9 @@ static inline U64 XXH_swap64 (U64 x)
 #endif
 
 
-//**************************************
-// Constants
-//**************************************
+/**************************************
+*  Constants
+***************************************/
 #define PRIME32_1   2654435761U
 #define PRIME32_2   2246822519U
 #define PRIME32_3   3266489917U
@@ -201,25 +206,26 @@ static inline U64 XXH_swap64 (U64 x)
 #define PRIME64_4  9650029242287828579ULL
 #define PRIME64_5  2870177450012600261ULL
 
-//**************************************
-// Architecture Macros
-//**************************************
+
+/***************************************
+*  Architecture Macros
+****************************************/
 typedef enum { XXH_bigEndian=0, XXH_littleEndian=1 } XXH_endianess;
-#ifndef XXH_CPU_LITTLE_ENDIAN   // It is possible to define XXH_CPU_LITTLE_ENDIAN externally, for example using a compiler switch
+#ifndef XXH_CPU_LITTLE_ENDIAN   /* XXH_CPU_LITTLE_ENDIAN can be defined externally, for example using a compiler switch */
 static const int one = 1;
 #   define XXH_CPU_LITTLE_ENDIAN   (*(char*)(&one))
 #endif
 
 
-//**************************************
-// Macros
-//**************************************
-#define XXH_STATIC_ASSERT(c)   { enum { XXH_static_assert = 1/(!!(c)) }; }    // use only *after* variable declarations
+/**************************************
+*  Macros
+***************************************/
+#define XXH_STATIC_ASSERT(c)   { enum { XXH_static_assert = 1/(!!(c)) }; }    /* use only *after* variable declarations */
 
 
-//****************************
-// Memory reads
-//****************************
+/****************************
+*  Memory reads
+*****************************/
 typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
 
 FORCE_INLINE U32 XXH_readLE32_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
@@ -249,9 +255,9 @@ FORCE_INLINE U64 XXH_readLE64(const void* ptr, XXH_endianess endian)
 }
 
 
-//****************************
-// Simple Hash Functions
-//****************************
+/****************************
+*  Simple Hash Functions
+*****************************/
 FORCE_INLINE U32 XXH32_endian_align(const void* input, size_t len, U32 seed, XXH_endianess endian, XXH_alignment align)
 {
     const BYTE* p = (const BYTE*)input;
@@ -332,7 +338,7 @@ FORCE_INLINE U32 XXH32_endian_align(const void* input, size_t len, U32 seed, XXH
 unsigned int XXH32 (const void* input, size_t len, unsigned seed)
 {
 #if 0
-    // Simple version, good for code maintenance, but unfortunately slow for small inputs
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
     XXH32_state_t state;
     XXH32_reset(&state, seed);
     XXH32_update(&state, input, len);
@@ -341,7 +347,7 @@ unsigned int XXH32 (const void* input, size_t len, unsigned seed)
     XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
 
 #  if !defined(XXH_USE_UNALIGNED_ACCESS)
-    if ((((size_t)input) & 3) == 0)   // Input is aligned, let's leverage the speed advantage
+    if ((((size_t)input) & 3) == 0)   /* Input is aligned, let's leverage the speed advantage */
     {
         if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
             return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
@@ -472,7 +478,7 @@ FORCE_INLINE U64 XXH64_endian_align(const void* input, size_t len, U64 seed, XXH
 unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
 {
 #if 0
-    // Simple version, good for code maintenance, but unfortunately slow for small inputs
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
     XXH64_state_t state;
     XXH64_reset(&state, seed);
     XXH64_update(&state, input, len);
@@ -481,7 +487,7 @@ unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed
     XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
 
 #  if !defined(XXH_USE_UNALIGNED_ACCESS)
-    if ((((size_t)input) & 7)==0)   // Input is aligned, let's leverage the speed advantage
+    if ((((size_t)input) & 7)==0)   /* Input is aligned, let's leverage the speed advantage */
     {
         if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
             return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
@@ -529,7 +535,7 @@ typedef struct
 
 XXH32_state_t* XXH32_createState(void)
 {
-    XXH_STATIC_ASSERT(sizeof(XXH32_state_t) >= sizeof(XXH_istate32_t));   // A compilation error here means XXH32_state_t is not large enough
+    XXH_STATIC_ASSERT(sizeof(XXH32_state_t) >= sizeof(XXH_istate32_t));   /* A compilation error here means XXH32_state_t is not large enough */
     return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
 }
 XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
@@ -540,7 +546,7 @@ XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
 
 XXH64_state_t* XXH64_createState(void)
 {
-    XXH_STATIC_ASSERT(sizeof(XXH64_state_t) >= sizeof(XXH_istate64_t));   // A compilation error here means XXH64_state_t is not large enough
+    XXH_STATIC_ASSERT(sizeof(XXH64_state_t) >= sizeof(XXH_istate64_t));   /* A compilation error here means XXH64_state_t is not large enough */
     return (XXH64_state_t*)XXH_malloc(sizeof(XXH64_state_t));
 }
 XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
@@ -591,14 +597,14 @@ FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state_in, const v
 
     state->total_len += len;
 
-    if (state->memsize + len < 16)   // fill in tmp buffer
+    if (state->memsize + len < 16)   /* fill in tmp buffer */
     {
         XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);
         state->memsize += (U32)len;
         return XXH_OK;
     }
 
-    if (state->memsize)   // some data left from previous update
+    if (state->memsize)   /* some data left from previous update */
     {
         XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, 16-state->memsize);
         {
@@ -745,14 +751,14 @@ FORCE_INLINE XXH_errorcode XXH64_update_endian (XXH64_state_t* state_in, const v
 
     state->total_len += len;
 
-    if (state->memsize + len < 32)   // fill in tmp buffer
+    if (state->memsize + len < 32)   /* fill in tmp buffer */
     {
         XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, len);
         state->memsize += (U32)len;
         return XXH_OK;
     }
 
-    if (state->memsize)   // some data left from previous update
+    if (state->memsize)   /* some data left from previous update */
     {
         XXH_memcpy(((BYTE*)state->mem64) + state->memsize, input, 32-state->memsize);
         {

--- a/xxhash.c
+++ b/xxhash.c
@@ -1,6 +1,6 @@
 /*
 xxHash - Fast Hash algorithm
-Copyright (C) 2012-2014, Yann Collet.
+Copyright (C) 2012-2015, Yann Collet.
 BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
 Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 You can contact the author at :
-- xxHash source repository : http://code.google.com/p/xxhash/
+- xxHash source repository : http://code.google.com/p/xxhash
+- xxHash source mirror : https://github.com/Cyan4973/xxHash
 - public discussion board : https://groups.google.com/forum/#!forum/lz4c
 */
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -1,7 +1,8 @@
 /*
    xxHash - Extremely Fast Hash algorithm
    Header File
-   Copyright (C) 2012-2014, Yann Collet.
+   Copyright (C) 2012-2015, Yann Collet.
+
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
    Redistribution and use in source and binary forms, with or without
@@ -28,7 +29,9 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    You can contact the author at :
-   - xxHash source repository : http://code.google.com/p/xxhash/
+    - xxHash source repository : http://code.google.com/p/xxhash
+    - xxHash source mirror : https://github.com/Cyan4973/xxHash
+    - public discussion board : https://groups.google.com/forum/#!forum/lz4c
 */
 
 /* Notice extracted from xxHash homepage :

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1,5 +1,6 @@
 /*
-bench.c - Demo program to benchmark open-source algorithm
+xxhsum - Command line interface for xxh algorithms
+
 Copyright (C) Yann Collet 2012-2015
 
 This program is free software; you can redistribute it and/or modify
@@ -117,33 +118,32 @@ You can contact the author at :
 static const char stdinName[] = "-";
 
 
-//**************************************
-// Display macros
-//**************************************
+/**************************************
+ * Display macros
+ *************************************/
 #define DISPLAY(...)         fprintf(stderr, __VA_ARGS__)
 #define DISPLAYRESULT(...)   fprintf(stdout, __VA_ARGS__)
 #define DISPLAYLEVEL(l, ...) if (g_displayLevel>=l) DISPLAY(__VA_ARGS__);
 static unsigned g_displayLevel = 1;
 
 
-//**************************************
-// Unit variables
-//**************************************
+/**************************************
+ * Local variables
+ *************************************/
 static int g_nbIterations = NBLOOPS;
-static int g_fn_selection = 1;    // required within main() & usage()
+static int g_fn_selection = 1;    /* required within main() & usage() */
 
 
-//*********************************************************
-// Benchmark Functions
-//*********************************************************
-
+/**************************************
+ * Benchmark Functions
+ *************************************/
 #if defined(BMK_LEGACY_TIMER)
 
 static int BMK_GetMilliStart(void)
 {
-  // Based on Legacy ftime()
-  // Rolls over every ~ 12.1 days (0x100000/24/60/60)
-  // Use GetMilliSpan to correct for rollover
+  /* Based on Legacy ftime()
+   * Rolls over every ~ 12.1 days (0x100000/24/60/60)
+   * Use GetMilliSpan to correct for rollover */
   struct timeb tb;
   int nCount;
   ftime( &tb );
@@ -155,8 +155,8 @@ static int BMK_GetMilliStart(void)
 
 static int BMK_GetMilliStart(void)
 {
-  // Based on newer gettimeofday()
-  // Use GetMilliSpan to correct for rollover
+  /* Based on newer gettimeofday()
+   * Use GetMilliSpan to correct for rollover */
   struct timeval tv;
   int nCount;
   gettimeofday(&tv, NULL);
@@ -207,7 +207,7 @@ static U64 BMK_GetFileSize(char* infilename)
     struct stat statbuf;
     r = stat(infilename, &statbuf);
 #endif
-    if (r || !S_ISREG(statbuf.st_mode)) return 0;   // No good...
+    if (r || !S_ISREG(statbuf.st_mode)) return 0;   /* No good... */
     return (U64)statbuf.st_size;
 }
 
@@ -216,12 +216,9 @@ static int BMK_benchFile(char** fileNamesTable, int nbFiles)
 {
     int fileIdx=0;
     U32 hashResult=0;
-
     U64 totals = 0;
     double totalc = 0.;
 
-
-    // Loop for each file
     while (fileIdx<nbFiles)
     {
         FILE*  inFile;
@@ -232,7 +229,7 @@ static int BMK_benchFile(char** fileNamesTable, int nbFiles)
         char*  buffer;
         char*  alignedBuffer;
 
-        // Check file existence
+        /* Check file existence */
         inFileName = fileNamesTable[fileIdx++];
         inFile = fopen( inFileName, "rb" );
         if (inFile==NULL)
@@ -241,7 +238,7 @@ static int BMK_benchFile(char** fileNamesTable, int nbFiles)
             return 11;
         }
 
-        // Memory allocation & restrictions
+        /* Memory allocation & restrictions */
         inFileSize = BMK_GetFileSize(inFileName);
         benchedSize = (size_t) BMK_findMaxMem(inFileSize);
         if ((U64)benchedSize > inFileSize) benchedSize = (size_t)inFileSize;
@@ -257,9 +254,9 @@ static int BMK_benchFile(char** fileNamesTable, int nbFiles)
             fclose(inFile);
             return 12;
         }
-        alignedBuffer = (buffer+15) - (((size_t)(buffer+15)) & 0xF);   // align on next 16 bytes boundaries
+        alignedBuffer = (buffer+15) - (((size_t)(buffer+15)) & 0xF);   /* align on next 16 bytes boundaries */
 
-        // Fill input buffer
+        /* Fill input buffer */
         DISPLAY("\rLoading %s...        \n", inFileName);
         readSize = fread(alignedBuffer, 1, benchedSize, inFile);
         fclose(inFile);
@@ -272,7 +269,7 @@ static int BMK_benchFile(char** fileNamesTable, int nbFiles)
         }
 
 
-        // Bench XXH32
+        /* XXH32 bench */
         {
             int interationNb;
             double fastestC = 100000000.;

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -38,11 +38,11 @@ You can contact the author at :
 /**************************************
  * Includes
  *************************************/
-#include <stdlib.h>     // malloc
-#include <stdio.h>      // fprintf, fopen, ftello64, fread, stdin, stdout; when present : _fileno
-#include <string.h>     // strcmp
-#include <sys/types.h>  // stat64
-#include <sys/stat.h>   // stat64
+#include <stdlib.h>     /* malloc */
+#include <stdio.h>      /* fprintf, fopen, ftello64, fread, stdin, stdout; when present : _fileno */
+#include <string.h>     /* strcmp */
+#include <sys/types.h>  /* stat64 */
+#include <sys/stat.h>   /* stat64 */
 
 #include "xxhash.h"
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1,6 +1,6 @@
 /*
 bench.c - Demo program to benchmark open-source algorithm
-Copyright (C) Yann Collet 2012-2014
+Copyright (C) Yann Collet 2012-2015
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -17,8 +17,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 You can contact the author at :
-- Blog homepage : http://fastcompression.blogspot.com/
-- Discussion group : https://groups.google.com/forum/?fromgroups#!forum/lz4c
+- xxHash source repository : http://code.google.com/p/xxhash
+- xxHash source mirror : https://github.com/Cyan4973/xxHash
+- public discussion board : https://groups.google.com/forum/#!forum/lz4c
 */
 
 /**************************************

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -492,6 +492,11 @@ static void BMK_sanityCheck(void)
     DISPLAYLEVEL(2, "Sanity check -- all tests ok\n");
 }
 
+static void BMK_display_BigEndian(const void* ptr, size_t length)
+{
+    const BYTE* p = ptr;
+    while (length--) DISPLAYRESULT("%02x", *p++);
+}
 
 static int BMK_hash(const char* fileName, U32 hashNb)
 {
@@ -568,13 +573,15 @@ static int BMK_hash(const char* fileName, U32 hashNb)
     case 0:
         {
             U32 h32 = XXH32_digest((XXH32_state_t*)&state);
-            DISPLAYRESULT("%08x   %s           \n", h32, fileName);
+            BMK_display_BigEndian(&h32, 4);
+            DISPLAYRESULT("   %s           \n", fileName);
             break;
         }
     case 1:
         {
             U64 h64 = XXH64_digest(&state);
-            DISPLAYRESULT("%08x%08x   %s     \n", (U32)(h64>>32), (U32)(h64), fileName);
+            BMK_display_BigEndian(&h64, 8);
+            DISPLAYRESULT("   %s     \n", fileName);
             break;
         }
     default:


### PR DESCRIPTION
GCC gives multiple warnings due to casting a const pointer to a non-const type. Adding in const qualifiers in a few places fixes these warnings. 
