### PR TITLE
Add manpage and its markdown source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@
 # xxhsum : provides 32/64 bits hash of one or multiple files, or stdin
 # ################################################################
 
+# Version numbers
+LIBVER_MAJOR:=`sed -n '/define XXH_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
+LIBVER_MINOR:=`sed -n '/define XXH_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
+LIBVER_PATCH:=`sed -n '/define XXH_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
+LIBVER := $(LIBVER_MAJOR).$(LIBVER_MINOR).$(LIBVER_PATCH)
+
 CFLAGS ?= -O3
 CFLAGS += -std=c99 -Wall -Wextra -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -Wstrict-aliasing=1 -Wswitch-enum -Wundef -pedantic 
 FLAGS  := $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MOREFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@
 CFLAGS ?= -O3
 CFLAGS += -std=c99 -Wall -Wextra -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -Wstrict-aliasing=1 -Wswitch-enum -Wundef -pedantic 
 FLAGS  := $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MOREFLAGS)
-
+XXHSUM_VERSION=0.5.1
 MD2ROFF  =ronn
-MD2ROFF_FLAGS  = --roff --warnings
+MD2ROFF_FLAGS  = --roff --warnings --manual="User Commands" --organization="xxhsum $(XXHSUM_VERSION)"
 
 # Define *.exe as extension for Windows systems
 ifneq (,$(filter Windows%,$(OS)))

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ CFLAGS ?= -O3
 CFLAGS += -std=c99 -Wall -Wextra -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -Wstrict-aliasing=1 -Wswitch-enum -Wundef -pedantic 
 FLAGS  := $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MOREFLAGS)
 
+MD2ROFF  =ronn
+MD2ROFF_FLAGS  = --roff --warnings
 
 # Define *.exe as extension for Windows systems
 ifneq (,$(filter Windows%,$(OS)))
@@ -114,6 +116,17 @@ sanitize: clean
 staticAnalyze: clean
 	@echo ---- static analyzer - scan-build ----
 	CFLAGS="-g -Werror" scan-build --status-bugs -v $(MAKE) all
+
+xxhsum.1: xxhsum.1.md
+	cat $^ | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
+
+man: xxhsum.1
+
+clean-man:
+	rm xxhsum.1
+
+preview-man: clean-man man
+	man ./xxhsum.1
 
 test-all: clean all test test32 test-xxhsum-c clean-xxhsum-c armtest clangtest gpptest sanitize staticAnalyze
 

--- a/xxhsum.1
+++ b/xxhsum.1
@@ -2,7 +2,7 @@
 .TH "XXHSUM" "1" "February 2016" "xxhsum 0.5.1" "User Commands"
 .
 .SH "NAME"
-\fBxxhsum\fR \- print or check xxHash checksums
+\fBxxhsum\fR \- print or check xxHash non\-cryptographic checksums
 .
 .SH "SYNOPSIS"
 \fBxxhsum\fR [\fIOPTION\fR] \.\.\. [\fIFILE\fR] \.\.\.
@@ -13,15 +13,38 @@ Print or check xxHash (32 or 64bit) checksums\. When \fIFILE\fR is \fB\-\fR, rea
 .P
 \fBxxhsum\fR supports a command line syntax similar but not indentical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch (\fB\-b\fR, \fB\-t\fR); \fBxxhsum\fR always treats file as binary file; \fBxxhsum\fR doesn\'t have short option switch for warning (\fB\-w\fR)\. \fBxxhsum\fR has hash bit width switch (\fB\-H\fR);
 .
+.P
+Since xxHash is non\-cryptographic checksum algorithm, \fBxxhsum\fR should not be used any more for security related purposes\.
+.
 .SH "OPTIONS"
+.
+.TP
+\fB\-b\fR
+Benchmark mode
+.
+.TP
+\fB\-B\fR\fIBLOCKSIZE\fR
+\fIBLOCKSIZE\fR specifies benchmark mode\'s test data block size in bytes\. Default value is 102400
 .
 .TP
 \fB\-c\fR, \fB\-\-check\fR
 Read xxHash sums from the \fIFILE\fRs and check them
 .
 .TP
+\fB\-h\fR
+Display help and exit
+.
+.TP
 \fB\-H\fR\fIHASHTYPE\fR
 Hash selection\. \fIHASHTYPE\fR means \fB0\fR=32bits, \fB1\fR=64bits\. Default value is \fB1\fR (64bits)
+.
+.TP
+\fB\-\-little\-endian\fR
+Set output hexadecimal checksum value as little endian convention\. By default, value is displayed as big endian
+.
+.TP
+\fB\-V\fR
+Display xxhsum version
 .
 .P
 \fBThe following four options are useful only when verifying checksums (\fB\-c\fR)\fR
@@ -59,26 +82,27 @@ $ xxhsum \-H1 foo bar baz
 .IP "" 0
 .
 .P
-Output xxHash (32bit) checksum values of specific files to standard output, and redirect it to \fBxyz\.xxhash\fR
+Output xxHash (32bit and 64bit) checksum values of specific files to standard output, and redirect it to \fBxyz\.xxh32\fR and \fBqux\.xxh64\fR
 .
 .IP "" 4
 .
 .nf
 
-$ xxhsum \-H0 foo bar baz > xyz\.xxhash
+$ xxhsum \-H0 foo bar baz > xyz\.xxh32
+$ xxhsum \-H1 foo bar baz > qux\.xxh64
 .
 .fi
 .
 .IP "" 0
 .
 .P
-Read xxHash sums from specific file and check them
+Read xxHash sums from specific files and check them
 .
 .IP "" 4
 .
 .nf
 
-$ xxhsum \-c xyz\.xxhash
+$ xxhsum \-c xyz\.xxh32 qux\.xxh64
 .
 .fi
 .

--- a/xxhsum.1
+++ b/xxhsum.1
@@ -1,5 +1,5 @@
 .
-.TH "XXHSUM" "1" "February 2016" "" ""
+.TH "XXHSUM" "1" "February 2016" "xxhsum 0.5.1" "User Commands"
 .
 .SH "NAME"
 \fBxxhsum\fR \- print or check xxHash checksums
@@ -11,7 +11,7 @@
 Print or check xxHash (32 or 64bit) checksums\. When \fIFILE\fR is \fB\-\fR, read standard input\.
 .
 .P
-\fBxxhsum\fR supports a command line syntax similar but not indentical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch; \fBxxhsum\fR always treats file as binary file; \fBxxhsum\fR have hash bit width switch (\fB\-H\fR)\.
+\fBxxhsum\fR supports a command line syntax similar but not indentical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch (\fB\-b\fR, \fB\-t\fR); \fBxxhsum\fR always treats file as binary file; \fBxxhsum\fR doesn\'t have short option switch for warning (\fB\-w\fR)\. \fBxxhsum\fR has hash bit width switch (\fB\-H\fR);
 .
 .SH "OPTIONS"
 .
@@ -24,7 +24,11 @@ Read xxHash sums from the \fIFILE\fRs and check them
 Hash selection\. \fIHASHTYPE\fR means \fB0\fR=32bits, \fB1\fR=64bits\. Default value is \fB1\fR (64bits)
 .
 .P
-The following four options are useful only when verifying checksums (\fB\-c\fR)
+\fBThe following four options are useful only when verifying checksums (\fB\-c\fR)\fR
+.
+.TP
+\fB\-\-quiet\fR
+Exit non\-zero for improperly formatted checksum lines
 .
 .TP
 \fB\-\-strict\fR
@@ -35,12 +39,50 @@ Don\'t print OK for each successfully verified file
 Don\'t output anything, status code shows success
 .
 .TP
-\fB\-\-quiet\fR
-Exit non\-zero for improperly formatted checksum lines
-.
-.TP
 \fB\-\-warn\fR
 Warn about improperly formatted checksum lines
+.
+.SH "EXIT STATUS"
+\fBxxhsum\fR exit \fB0\fR on success, \fB1\fR if at least one file couldn\'t be read or doesn\'t have the same checksum as the \fB\-c\fR option\.
+.
+.SH "EXAMPLES"
+Output xxHash (64bit) checksum values of specific files to standard output
+.
+.IP "" 4
+.
+.nf
+
+$ xxhsum \-H1 foo bar baz
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Output xxHash (32bit) checksum values of specific files to standard output, and redirect it to \fBxyz\.xxhash\fR
+.
+.IP "" 4
+.
+.nf
+
+$ xxhsum \-H0 foo bar baz > xyz\.xxhash
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Read xxHash sums from specific file and check them
+.
+.IP "" 4
+.
+.nf
+
+$ xxhsum \-c xyz\.xxhash
+.
+.fi
+.
+.IP "" 0
 .
 .SH "BUGS"
 Report bugs at: https://github\.com/Cyan4973/xxHash/issues/

--- a/xxhsum.1
+++ b/xxhsum.1
@@ -1,0 +1,49 @@
+.
+.TH "XXHSUM" "1" "February 2016" "" ""
+.
+.SH "NAME"
+\fBxxhsum\fR \- print or check xxHash checksums
+.
+.SH "SYNOPSIS"
+\fBxxhsum\fR [\fIOPTION\fR] \.\.\. [\fIFILE\fR] \.\.\.
+.
+.SH "DESCRIPTION"
+Print or check xxHash (32 or 64bit) checksums\. When \fIFILE\fR is \fB\-\fR, read standard input\.
+.
+.P
+\fBxxhsum\fR supports a command line syntax similar but not indentical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch; \fBxxhsum\fR always treats file as binary file; \fBxxhsum\fR have hash bit width switch (\fB\-H\fR)\.
+.
+.SH "OPTIONS"
+.
+.TP
+\fB\-c\fR, \fB\-\-check\fR
+Read xxHash sums from the \fIFILE\fRs and check them
+.
+.TP
+\fB\-H\fR\fIHASHTYPE\fR
+Hash selection\. \fIHASHTYPE\fR means \fB0\fR=32bits, \fB1\fR=64bits\. Default value is \fB1\fR (64bits)
+.
+.P
+The following four options are useful only when verifying checksums (\fB\-c\fR)
+.
+.TP
+\fB\-\-strict\fR
+Don\'t print OK for each successfully verified file
+.
+.TP
+\fB\-\-status\fR
+Don\'t output anything, status code shows success
+.
+.TP
+\fB\-\-quiet\fR
+Exit non\-zero for improperly formatted checksum lines
+.
+.TP
+\fB\-\-warn\fR
+Warn about improperly formatted checksum lines
+.
+.SH "BUGS"
+Report bugs at: https://github\.com/Cyan4973/xxHash/issues/
+.
+.SH "AUTHOR"
+Yann Collet

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -13,9 +13,10 @@ Print or check xxHash (32 or 64bit) checksums.  When <FILE> is `-`, read
 standard input.
 
 `xxhsum` supports a command line syntax similar but not indentical to
-md5sum(1).  Differences are: `xxhsum` doesn't have text/binary mode switch;
-`xxhsum` always treats file as binary file;  `xxhsum` have hash bit width
-switch (`-H`).
+md5sum(1).  Differences are: `xxhsum` doesn't have text/binary mode switch
+(`-b`, `-t`);  `xxhsum` always treats file as binary file;  `xxhsum` doesn't
+have short option switch for warning (`-w`).  `xxhsum` has hash bit width
+switch (`-H`);
 
 OPTIONS
 -------
@@ -27,7 +28,10 @@ OPTIONS
   Hash selection.  <HASHTYPE> means `0`=32bits, `1`=64bits.
   Default value is `1` (64bits)
 
-The following four options are useful only when verifying checksums (`-c`)
+**The following four options are useful only when verifying checksums (`-c`)**
+
+* `--quiet`:
+  Exit non-zero for improperly formatted checksum lines
 
 * `--strict`:
   Don't print OK for each successfully verified file
@@ -35,11 +39,30 @@ The following four options are useful only when verifying checksums (`-c`)
 * `--status`:
   Don't output anything, status code shows success
 
-* `--quiet`:
-  Exit non-zero for improperly formatted checksum lines
-
 * `--warn`:
   Warn about improperly formatted checksum lines
+
+EXIT STATUS
+-----------
+
+`xxhsum` exit `0` on success, `1` if at least one file couldn't be read or
+doesn't have the same checksum as the `-c` option.
+
+EXAMPLES
+--------
+
+Output xxHash (64bit) checksum values of specific files to standard output
+
+    $ xxhsum -H1 foo bar baz
+
+Output xxHash (32bit) checksum values of specific files to standard output,
+and redirect it to `xyz.xxhash`
+
+    $ xxhsum -H0 foo bar baz > xyz.xxhash
+
+Read xxHash sums from specific file and check them
+
+    $ xxhsum -c xyz.xxhash
 
 BUGS
 ----

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -1,5 +1,5 @@
-xxhsum(1) -- print or check xxHash checksums
-============================================
+xxhsum(1) -- print or check xxHash non-cryptographic checksums
+==============================================================
 
 SYNOPSIS
 --------
@@ -17,6 +17,9 @@ md5sum(1).  Differences are: `xxhsum` doesn't have text/binary mode switch
 (`-b`, `-t`);  `xxhsum` always treats file as binary file;  `xxhsum` doesn't
 have short option switch for warning (`-w`).  `xxhsum` has hash bit width
 switch (`-H`);
+
+Since xxHash is non-cryptographic checksum algorithm, `xxhsum` should not be
+used any more for security related purposes.
 
 OPTIONS
 -------

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -1,0 +1,52 @@
+xxhsum(1) -- print or check xxHash checksums
+============================================
+
+SYNOPSIS
+--------
+
+`xxhsum` [<OPTION>] ... [<FILE>] ...
+
+DESCRIPTION
+-----------
+
+Print or check xxHash (32 or 64bit) checksums.  When <FILE> is `-`, read
+standard input.
+
+`xxhsum` supports a command line syntax similar but not indentical to
+md5sum(1).  Differences are: `xxhsum` doesn't have text/binary mode switch;
+`xxhsum` always treats file as binary file;  `xxhsum` have hash bit width
+switch (`-H`).
+
+OPTIONS
+-------
+
+* `-c`, `--check`:
+  Read xxHash sums from the <FILE>s and check them
+
+* `-H`<HASHTYPE>:
+  Hash selection.  <HASHTYPE> means `0`=32bits, `1`=64bits.
+  Default value is `1` (64bits)
+
+The following four options are useful only when verifying checksums (`-c`)
+
+* `--strict`:
+  Don't print OK for each successfully verified file
+
+* `--status`:
+  Don't output anything, status code shows success
+
+* `--quiet`:
+  Exit non-zero for improperly formatted checksum lines
+
+* `--warn`:
+  Warn about improperly formatted checksum lines
+
+BUGS
+----
+
+Report bugs at: https://github.com/Cyan4973/xxHash/issues/
+
+AUTHOR
+------
+
+Yann Collet

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -21,12 +21,29 @@ switch (`-H`);
 OPTIONS
 -------
 
+* `-b`:
+  Benchmark mode
+
+* `-B`<BLOCKSIZE>:
+  <BLOCKSIZE> specifies benchmark mode's test data block size in bytes.
+  Default value is 102400
+
 * `-c`, `--check`:
   Read xxHash sums from the <FILE>s and check them
+
+* `-h`:
+  Display help and exit
 
 * `-H`<HASHTYPE>:
   Hash selection.  <HASHTYPE> means `0`=32bits, `1`=64bits.
   Default value is `1` (64bits)
+
+* `--little-endian`:
+  Set output hexadecimal checksum value as little endian convention.
+  By default, value is displayed as big endian
+
+* `-V`:
+  Display xxhsum version
 
 **The following four options are useful only when verifying checksums (`-c`)**
 

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -75,14 +75,15 @@ Output xxHash (64bit) checksum values of specific files to standard output
 
     $ xxhsum -H1 foo bar baz
 
-Output xxHash (32bit) checksum values of specific files to standard output,
-and redirect it to `xyz.xxhash`
+Output xxHash (32bit and 64bit) checksum values of specific files to standard
+output, and redirect it to `xyz.xxh32` and `qux.xxh64`
 
-    $ xxhsum -H0 foo bar baz > xyz.xxhash
+    $ xxhsum -H0 foo bar baz > xyz.xxh32
+    $ xxhsum -H1 foo bar baz > qux.xxh64
 
-Read xxHash sums from specific file and check them
+Read xxHash sums from specific files and check them
 
-    $ xxhsum -c xyz.xxhash
+    $ xxhsum -c xyz.xxh32 qux.xxh64
 
 BUGS
 ----


### PR DESCRIPTION
This PR adds ROFF format manpage `xxhsum.1`.  Also `xxhsum.1` will be genareted from Markdown file `xxhsum.1.md` by [ronn](https://github.com/rtomayko/ronn).
You can generate `xxhsum.1` by the following procedure

```
sudo apt-get install -y ruby-ronn
# make man generates xxhsum.1 from xxhsum.1.md #
make man

# edit xxhsum.1.md here #
# auto preview for development
make preview-man
```

To keep it simple, all `Makefile` targets are written in explicit fashion.


## Removal of `ronn`'s version

`Makefile` has the following tricky part:

```
xxhsum.1: xxhsum.1.md
        cat $^ | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
```

Last `sed` command removes `ronn`'s comment lines (`ronn`'s version, author, URL).  It doesn't mean disrespect for `ronn`.  We need this removal because we must keep independent `xxhsum.1` from `ronn`'s version.

## Possible problems

 - This PR adds external dependency for `ronn`.
    - Here is a tradeoff.
    - It requires ruby and rubygems environment.  So I don't say it's lightweight dependency.
 - Should we contain `xxhsum.1` in the repository?
    - Since we can generate it from `xxhsum.1.md`, we can remove it from repository.
    - But some users who can't run `ronn` can't generate `xxhsum.1`.
 - I should verify `sed` syntax for BSD families.
    - If we remove `xxhsum.1` from repository, we can also remove this `sed` filter.
    - Since `ronn` requires ruby, there is possibility to replace `sed` with `ruby` one-liner.

I think this is an experimental PR, please feel free to comment anything.

update:
I've checked `sed` syntax on Mac OSX 10.11.3 and FreeBSD 10.2-RELEASE-p12.  It works fine.
