### PR TITLE
Add -w, --version, --help and fix XXHSUM_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ LIBVER := $(LIBVER_MAJOR).$(LIBVER_MINOR).$(LIBVER_PATCH)
 CFLAGS ?= -O3
 CFLAGS += -std=c99 -Wall -Wextra -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -Wstrict-aliasing=1 -Wswitch-enum -Wundef -pedantic 
 FLAGS  := $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MOREFLAGS)
-XXHSUM_VERSION=0.5.1
+XXHSUM_VERSION=$(LIBVER)
 MD2ROFF  =ronn
 MD2ROFF_FLAGS  = --roff --warnings --manual="User Commands" --organization="xxhsum $(XXHSUM_VERSION)"
 

--- a/xxhsum.1
+++ b/xxhsum.1
@@ -1,5 +1,5 @@
 .
-.TH "XXHSUM" "1" "February 2016" "xxhsum 0.5.1" "User Commands"
+.TH "XXHSUM" "1" "February 2016" "xxhsum 0.5.0" "User Commands"
 .
 .SH "NAME"
 \fBxxhsum\fR \- print or check xxHash non\-cryptographic checksums
@@ -11,7 +11,7 @@
 Print or check xxHash (32 or 64bit) checksums\. When \fIFILE\fR is \fB\-\fR, read standard input\.
 .
 .P
-\fBxxhsum\fR supports a command line syntax similar but not indentical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch (\fB\-b\fR, \fB\-t\fR); \fBxxhsum\fR always treats file as binary file; \fBxxhsum\fR doesn\'t have short option switch for warning (\fB\-w\fR)\. \fBxxhsum\fR has hash bit width switch (\fB\-H\fR);
+\fBxxhsum\fR supports a command line syntax similar but not indentical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch (\fB\-b\fR, \fB\-t\fR); \fBxxhsum\fR always treats file as binary file; \fBxxhsum\fR has hash bit width switch (\fB\-H\fR);
 .
 .P
 Since xxHash is non\-cryptographic checksum algorithm, \fBxxhsum\fR should not be used any more for security related purposes\.
@@ -31,7 +31,7 @@ Benchmark mode
 Read xxHash sums from the \fIFILE\fRs and check them
 .
 .TP
-\fB\-h\fR
+\fB\-h\fR, \fB\-\-help\fR
 Display help and exit
 .
 .TP
@@ -43,7 +43,7 @@ Hash selection\. \fIHASHTYPE\fR means \fB0\fR=32bits, \fB1\fR=64bits\. Default v
 Set output hexadecimal checksum value as little endian convention\. By default, value is displayed as big endian
 .
 .TP
-\fB\-V\fR
+\fB\-V\fR, \fB\-\-version\fR
 Display xxhsum version
 .
 .P
@@ -62,7 +62,7 @@ Don\'t print OK for each successfully verified file
 Don\'t output anything, status code shows success
 .
 .TP
-\fB\-\-warn\fR
+\fB\-w\fR, \fB\-\-warn\fR
 Warn about improperly formatted checksum lines
 .
 .SH "EXIT STATUS"

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -4,7 +4,8 @@ xxhsum(1) -- print or check xxHash non-cryptographic checksums
 SYNOPSIS
 --------
 
-`xxhsum` [<OPTION>] ... [<FILE>] ...
+`xxhsum` [<OPTION>] ... [<FILE>] ...<br/>
+`xxhsum -b` [<OPTION>] ...
 
 DESCRIPTION
 -----------
@@ -20,15 +21,10 @@ bit width switch (`-H`);
 Since xxHash is non-cryptographic checksum algorithm, `xxhsum` should not be
 used any more for security related purposes.
 
+`xxhsum -b` invokes benchmark mode. See [OPTIONS](#OPTIONS) and [EXAMPLES](#EXAMPLES) for details.
+
 OPTIONS
 -------
-
-* `-b`:
-  Benchmark mode
-
-* `-B`<BLOCKSIZE>:
-  <BLOCKSIZE> specifies benchmark mode's test data block size in bytes.
-  Default value is 102400
 
 * `-c`, `--check`:
   Read xxHash sums from the <FILE>s and check them
@@ -61,6 +57,21 @@ OPTIONS
 * `-w`, `--warn`:
   Warn about improperly formatted checksum lines
 
+**The following options are useful only benchmark purpose**
+
+* `-b`:
+  Benchmark mode.  See [EXAMPLES](#EXAMPLES) for details.
+
+* `-B`<BLOCKSIZE>:
+  Only useful for benchmark mode (`-b`). See [EXAMPLES](#EXAMPLES) for details.
+  <BLOCKSIZE> specifies benchmark mode's test data block size in bytes.
+  Default value is 102400
+
+* `-i`<ITERATIONS>:
+  Only useful for benchmark mode (`-b`). See [EXAMPLES](#EXAMPLES) for details.
+  <ITERATIONS> specifies number of iterations in benchmark. Single iteration
+  takes at least 2500 milliseconds. Default value is 3
+
 EXIT STATUS
 -----------
 
@@ -84,6 +95,14 @@ Read xxHash sums from specific files and check them
 
     $ xxhsum -c xyz.xxh32 qux.xxh64
 
+Benchmark xxHash algorithm for 16384 bytes data in 10 times. `xxhsum`
+benchmarks xxHash algorithm for 32-bit and 64-bit and output results to
+standard output.  First column means algorithm, second column is source data
+size in bytes, last column means hash generation speed in mega-bytes per
+seconds.
+
+    $ xxhsum -b -i10 -B16384
+
 BUGS
 ----
 
@@ -93,3 +112,8 @@ AUTHOR
 ------
 
 Yann Collet
+
+SEE ALSO
+--------
+
+md5sum(1)

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -14,9 +14,8 @@ standard input.
 
 `xxhsum` supports a command line syntax similar but not indentical to
 md5sum(1).  Differences are: `xxhsum` doesn't have text/binary mode switch
-(`-b`, `-t`);  `xxhsum` always treats file as binary file;  `xxhsum` doesn't
-have short option switch for warning (`-w`).  `xxhsum` has hash bit width
-switch (`-H`);
+(`-b`, `-t`);  `xxhsum` always treats file as binary file;  `xxhsum` has hash
+bit width switch (`-H`);
 
 Since xxHash is non-cryptographic checksum algorithm, `xxhsum` should not be
 used any more for security related purposes.
@@ -59,7 +58,7 @@ OPTIONS
 * `--status`:
   Don't output anything, status code shows success
 
-* `--warn`:
+* `-w`, `--warn`:
   Warn about improperly formatted checksum lines
 
 EXIT STATUS

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -33,7 +33,7 @@ OPTIONS
 * `-c`, `--check`:
   Read xxHash sums from the <FILE>s and check them
 
-* `-h`:
+* `-h`, `--help`:
   Display help and exit
 
 * `-H`<HASHTYPE>:
@@ -44,7 +44,7 @@ OPTIONS
   Set output hexadecimal checksum value as little endian convention.
   By default, value is displayed as big endian
 
-* `-V`:
+* `-V`, `--version`:
   Display xxhsum version
 
 **The following four options are useful only when verifying checksums (`-c`)**

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1297,6 +1297,8 @@ int main(int argc, const char** argv)
         if (!strcmp(argument, "--status")) { statusOnly = 1; continue; }
         if (!strcmp(argument, "--quiet")) { quiet = 1; continue; }
         if (!strcmp(argument, "--warn")) { warn = 1; continue; }
+        if (!strcmp(argument, "--help")) { return usage_advanced(exename); }
+        if (!strcmp(argument, "--version")) { DISPLAY(WELCOME_MESSAGE); return 0; }
 
         if (*argument!='-')
         {

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1249,7 +1249,9 @@ static int usage_advanced(const char* exename)
 {
     usage(exename);
     DISPLAY( "Advanced :\n");
-    DISPLAY( "--little-endian : hash printed using little endian convention (default: big endian)\n");
+    DISPLAY( " --little-endian : hash printed using little endian convention (default: big endian)\n");
+    DISPLAY( " -V, --version   : display version\n");
+    DISPLAY( " -h, --help      : display long help and exit\n");
     DISPLAY( " -b  : benchmark mode \n");
     DISPLAY( " -i# : number of iterations (benchmark mode; default %i)\n", g_nbIterations);
     DISPLAY( "\n");

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1331,6 +1331,12 @@ int main(int argc, const char** argv)
                 argument++;
                 break;
 
+            /* Warning mode (file check mode only, alias of "--warning") */
+            case 'w':
+                warn=1;
+                argument++;
+                break;
+
             /* Trigger benchmark mode */
             case 'b':
                 argument++;


### PR DESCRIPTION
This PR is follow up of PR #55.  All commits are trivial.

 - Fix XXHSUM_VERSION in Makefile
 - Add the following options to mimic `md5sum`
    - `-w` : alias of `--warn`
    - `--version` : alias of `-V`
    - `--help` : alias of `-h`
