### PR TITLE
Add Vagrantfile to provide platform independent development environment

### DIFF
--- a/devenv/linux/.gitignore
+++ b/devenv/linux/.gitignore
@@ -1,0 +1,2 @@
+.vagrant/
+xxhash/

--- a/devenv/linux/README-WINDOWS.md
+++ b/devenv/linux/README-WINDOWS.md
@@ -1,0 +1,56 @@
+# How to setup virtual development environment
+
+By the following procedure, you can setup your virtual development environment.
+You can apply the following procedure for Linux, MacOSX and Windows.
+
+
+## Prerequisite
+
+This procedure needs the following softwares:
+
+  - [git](https://git-scm.com/)
+  - [VirtualBox](https://www.virtualbox.org/)
+  - [Vagrant](https://www.vagrantup.com/)
+
+
+## Setup (Windows)
+
+Clone the xxHash repository
+
+```
+cd /d "%USERPROFILE%"
+git clone https://github.com/Cyan4973/xxHash.git xxhash
+```
+
+Setup and test virtual environemnt
+
+```
+cd /d "%USERPROFILE%"
+cd xxhash\devenv\linux
+vagrant up
+vagrant ssh
+
+## If you see passphrase prompt, just press Enter ##
+## If you see password prompt for vagrant, input "vagrant" as password ##
+## here, you'll see GUEST terminal ##
+# note: GUEST's ~/xxhash/ is mapped to HOST's %USERPROFILE%\xxhash\devenv\linux\xxhash\ #
+cd xxhash
+git checkout dev
+make all
+./xxhsum --help
+make test-all
+exit
+## here, you'll back to the HOST ##
+
+vagrant halt     # halt VM #
+vagrant status   # show VM status #
+```
+
+After that, if you don't need virtual environemnt anymore, destory VM image by the following command:
+
+```
+cd /d "%USERPROFILE%"
+cd xxhash\devenv\linux
+vagrant destroy  # delete VM image, if you want #
+rm -rf xxhash    # delete cloned repository #
+```

--- a/devenv/linux/README.md
+++ b/devenv/linux/README.md
@@ -1,0 +1,61 @@
+# How to setup virtual development environment
+
+By the following procedure, you can setup your virtual development environment.
+You can apply the following procedure for Linux, MacOSX and Windows.
+
+
+## Prerequisite
+
+This procedure needs the following softwares:
+
+  - [git](https://git-scm.com/)
+  - [VirtualBox](https://www.virtualbox.org/)
+  - [Vagrant](https://www.vagrantup.com/)
+
+
+## Setup (Windows)
+
+See [README-WINDOWS.md](README-WINDOWS.md)
+
+
+## Setup (Linux and MacOSX)
+
+Clone the xxHash repository
+
+```
+cd
+git clone https://github.com/Cyan4973/xxHash.git xxhash
+```
+
+Setup and test virtual environemnt
+
+```
+cd
+cd xxhash/devenv/linux
+vagrant up
+vagrant ssh
+
+## If you see passphrase prompt, just press Enter ##
+## If you see password prompt for vagrant, input "vagrant" as password ##
+## here, you'll see GUEST terminal ##
+# note: GUEST's ~/xxhash/ is mapped to HOST's xxhash/devenv/linux/xxhash/ #
+cd xxhash
+git checkout dev
+make all
+./xxhsum --help
+make test-all
+exit
+## here, you'll back to the HOST ##
+
+vagrant halt     # halt VM #
+vagrant status   # show VM status #
+```
+
+After that, if you don't need virtual environemnt anymore, destory VM image by the following command:
+
+```
+cd
+cd xxhash/devenv/linux
+vagrant destroy  # delete VM image, if you want #
+rm -rf xxhash    # delete cloned repository #
+```

--- a/devenv/linux/Vagrantfile
+++ b/devenv/linux/Vagrantfile
@@ -1,0 +1,7 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "hashicorp/precise64"
+  config.vm.provision :shell, :path => "setup.sh"
+end

--- a/devenv/linux/setup.sh
+++ b/devenv/linux/setup.sh
@@ -8,6 +8,19 @@ echo "-- begin : xxhash provisioning --"
 # https://www.debian.org/releases/stable/s390x/ch05s02.html.en
 export DEBIAN_FRONTEND=noninteractive
 
+# Add sources.list to select nearest mirror automatically.
+# This mirror selection speeds up apt-get process.
+if [ -f "/etc/apt/sources.list" ]
+then
+    sudo mv /etc/apt/sources.list /etc/apt/sources.list.d/
+fi
+
+sudo echo> /etc/apt/sources.list.d/0.list
+sudo echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt precise main restricted universe multiverse' >> /etc/apt/sources.list.d/0.list
+sudo echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt precise-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/0.list
+sudo echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt precise-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/0.list
+sudo echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt precise-security main restricted universe multiverse' >> /etc/apt/sources.list.d/0.list
+
 # Update package list and install packages
 # note: these commands are same as .travis.yml
 sudo apt-get update -qq

--- a/devenv/linux/setup.sh
+++ b/devenv/linux/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+echo
+echo "-- begin : xxhash provisioning --"
+
+# Minimize interaction with apt-get
+# http://serverfault.com/a/670688
+# https://www.debian.org/releases/stable/s390x/ch05s02.html.en
+export DEBIAN_FRONTEND=noninteractive
+
+# Update package list and install packages
+# note: these commands are same as .travis.yml
+sudo apt-get update -qq
+sudo apt-get install -qq gcc-arm-linux-gnueabi
+sudo apt-get install -qq clang
+sudo apt-get install -qq g++-multilib
+sudo apt-get install -qq gcc-multilib
+sudo apt-get install -qq valgrind
+sudo apt-get install -qq ruby-ronn
+
+# Install packages to minimize difference between VM and Travis-CI
+sudo apt-get install -qq git
+sudo apt-get install -qq make
+
+# note: Entire /vagrant/ directory is mapped to HOST's xxhash/devenv/linux/
+#       See https://www.vagrantup.com/docs/synced-folders/ for details.
+
+# Clone xxhash to /vagrant/xxhash/
+# This directory is mapped to HOST's xxhash/devenv/linux/xxhash/
+rm -rf /vagrant/xxhash
+git clone https://github.com/Cyan4973/xxHash.git /vagrant/xxhash/
+
+# Create symbolic link from ~/xxhash/ to /vagrant/xxhash/
+rm -f xxhash
+ln -s /vagrant/xxhash/ xxhash
+
+echo "-- end : xxhash provisioning --"
+echo


### PR DESCRIPTION
This PR adds Vagrantfile and its provisioning script which provides Linux VM for development of xxhash.  This VM will run on Linux, MacOSX and Windows.

Basic goal of this PR is providing platform independent development environment for major platforms to test/develop xxHash.  Even on Linux, since VM provides clean environment, it would be useful to test environment dependent problems.

You can check this PR by the following procedure
**NOTE : This procedure takes a long time.  Maybe 5 to 30 minutes**
### Prerequisite

This procedure needs the following softwares:
- [git](https://git-scm.com/)
- [VirtualBox](https://www.virtualbox.org/)
- [Vagrant](https://www.vagrantup.com/)
### Setup on Linux

```
cd
git clone https://github.com/t-mat/xxHash.git xxhash-tmat
cd xxhash-tmat
git checkout virtual-devenv
cd devenv/linux

vagrant up
vagrant ssh

## If you see passphrase prompt, just press Enter ##
## If you see password prompt for vagrant, input "vagrant" as password ##
## here, you'll see GUEST terminal ##
# note: GUEST's ~/xxhash/ is mapped to HOST's ~/xxhash-tmat/devenv/linux/xxhash/ #
cd xxhash
git checkout dev
make all
./xxhsum --help
make test-all
exit
## here, you'll back to the HOST ##

vagrant halt     # halt VM #
vagrant status   # show VM status #

# If you don't need VM anymore, destroy VM and delete shared directory #

vagrant destroy  -f # delete VM image, if you want #
rm -rf xxhash       # delete cloned repository #
```
### Possible problems
- It uses old [Ubuntu Precise (12.04LTS, 64bit)](http://releases.ubuntu.com/12.04/).
  - I'm not sure newer version is good for testing/development.
  - Since there are many Vargrant VM images, we can change it easily.
- I'm not sure which is better for cloned repository name in lowercase `xxhash` or camelCase `xxHash`.
