### PR TITLE
changes to increase xxhash' configurability when inlining it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+xxh32sum
+xxh64sum
+xxhsum

--- a/xxhash.c
+++ b/xxhash.c
@@ -72,7 +72,9 @@ You can contact the author at :
  * to improve speed for Big-endian CPU.
  * This option has no impact on Little_Endian CPU.
  */
+#ifndef XXH_FORCE_NATIVE_FORMAT /* can be defined externally */
 #define XXH_FORCE_NATIVE_FORMAT 0
+#endif
 
 /*!XXH_USELESS_ALIGN_BRANCH :
  * This is a minor performance trick, only useful with lots of very small keys.


### PR DESCRIPTION
The first commit is trivial.

The other two would be nice to have; my use case is a portable high-performance application that inlines the hashing calls. With these two changes, it can get top performance on all platforms (e.g. big-endian), and it can save a branch on every hash call (on, say, ARM) since the app is guaranteed to pass aligned input data.

Can you please take a look?

Thanks!