### PR TITLE
v0.6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test-xxhsum-c: xxhsum
 	echo "00000000  test-expects-file-not-found" | ./xxhsum -c -; test $$? -eq 1
 
 clean-xxhsum-c:
-	@rm -f .test.xxh32 .test.xxh64
+	@$(RM) -f .test.xxh32 .test.xxh64
 
 armtest: clean
 	@echo ---- test ARM compilation ----
@@ -125,19 +125,25 @@ staticAnalyze: clean
 	@echo ---- static analyzer - scan-build ----
 	CFLAGS="-g -Werror" scan-build --status-bugs -v $(MAKE) all
 
+namespaceTest:
+	$(CC) -c xxhash.c
+	$(CC) -DXXH_NAMESPACE=TEST_ -c xxhash.c -o xxhash2.o
+	$(CC) xxhash.o xxhash2.o xxhsum.c -o xxhsum2  # will fail if one namespace missing (symbol collision)
+	$(RM) *.o xxhsum2  # clean
+
 xxhsum.1: xxhsum.1.md
 	cat $^ | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
 
 man: xxhsum.1
 
 clean-man:
-	rm xxhsum.1
+	$(RM) xxhsum.1
 
 preview-man: clean-man man
 	man ./xxhsum.1
 
-test-all: clean all test test32 test-xxhsum-c clean-xxhsum-c armtest clangtest gpptest sanitize staticAnalyze
+test-all: clean all namespaceTest test test32 test-xxhsum-c clean-xxhsum-c armtest clangtest gpptest sanitize staticAnalyze
 
 clean: clean-xxhsum-c
-	@rm -f core *.o xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) xxh32sum xxh64sum
+	@$(RM) -f core *.o xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) xxh32sum xxh64sum
 	@echo cleaning completed

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ LIBVER_PATCH:=`sed -n '/define XXH_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\
 LIBVER := $(LIBVER_MAJOR).$(LIBVER_MINOR).$(LIBVER_PATCH)
 
 CFLAGS ?= -O3
-CFLAGS += -std=c99 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -pedantic
+CFLAGS += -std=c99 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
+          -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement \
+		  -Wstrict-prototypes -Wundef -pedantic
 FLAGS  := $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MOREFLAGS)
 XXHSUM_VERSION=$(LIBVER)
-MD2ROFF  =ronn
-MD2ROFF_FLAGS  = --roff --warnings --manual="User Commands" --organization="xxhsum $(XXHSUM_VERSION)"
+MD2ROFF = ronn
+MD2ROFF_FLAGS = --roff --warnings --manual="User Commands" --organization="xxhsum $(XXHSUM_VERSION)"
 
 # Define *.exe as extension for Windows systems
 ifneq (,$(filter Windows%,$(OS)))

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -6,11 +6,14 @@ project(xxhash)
 set(XXHASH_LIB_VERSION "0.42.0")
 set(XXHASH_LIB_SOVERSION "0")
 
-add_library(xxhash SHARED ../xxhash.c)
-set_target_properties(xxhash PROPERTIES COMPILE_DEFINITIONS "XXHASH_EXPORT"
-                       VERSION "${XXHASH_LIB_VERSION}"
-                       SOVERSION "${XXHASH_LIB_SOVERSION}")
-set(install_libs xxhash)
+set(BUILD_SHARED_LIBS ON CACHE BOOL "Set to ON to build shared libraries")
+if(BUILD_SHARED_LIBS)
+  add_library(xxhash SHARED ../xxhash.c)
+  set_target_properties(xxhash PROPERTIES COMPILE_DEFINITIONS "XXHASH_EXPORT"
+                         VERSION "${XXHASH_LIB_VERSION}"
+                         SOVERSION "${XXHASH_LIB_SOVERSION}")
+  LIST(APPEND install_libs xxhash)
+endif(BUILD_SHARED_LIBS)
 
 set(BUILD_STATIC_LIBS ON CACHE BOOL "Set to ON to build static libraries")
 if(BUILD_STATIC_LIBS)
@@ -21,4 +24,9 @@ endif(BUILD_STATIC_LIBS)
 
 
 INSTALL(FILES ../xxhash.h DESTINATION include)
-INSTALL(TARGETS ${install_libs} DESTINATION lib)
+INSTALL(
+    TARGETS ${install_libs}
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)

--- a/xxhash.c
+++ b/xxhash.c
@@ -307,6 +307,20 @@ static const U64 PRIME64_5 =  2870177450012600261ULL;
 XXH_PUBLIC_API unsigned XXH_versionNumber (void) { return XXH_VERSION_NUMBER; }
 
 
+/* **************************
+*  Utils
+****************************/
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* restrict dstState, const XXH32_state_t* restrict srcState)
+{
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* restrict dstState, const XXH64_state_t* restrict srcState)
+{
+    memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+
 /* ***************************
 *  Simple Hash Functions
 *****************************/

--- a/xxhash.c
+++ b/xxhash.c
@@ -560,7 +560,6 @@ XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, unsigned int s
 {
     XXH32_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
     memset(&state, 0, sizeof(state));
-    state.seed = seed;
     state.v1 = seed + PRIME32_1 + PRIME32_2;
     state.v2 = seed + PRIME32_2;
     state.v3 = seed + 0;
@@ -662,7 +661,7 @@ FORCE_INLINE U32 XXH32_digest_endian (const XXH32_state_t* state, XXH_endianess 
     if (state->total_len >= 16) {
         h32 = XXH_rotl32(state->v1, 1) + XXH_rotl32(state->v2, 7) + XXH_rotl32(state->v3, 12) + XXH_rotl32(state->v4, 18);
     } else {
-        h32 = state->seed + PRIME32_5;
+        h32 = state->v3 /* == seed */ + PRIME32_5;
     }
 
     h32 += (U32) state->total_len;

--- a/xxhash.c
+++ b/xxhash.c
@@ -132,7 +132,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
 ***************************************/
 #ifndef MEM_MODULE
 # define MEM_MODULE
-# if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+# if !defined (__VMS) && (defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
 #   include <stdint.h>
     typedef uint8_t  BYTE;
     typedef uint16_t U16;

--- a/xxhash.c
+++ b/xxhash.c
@@ -144,7 +144,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
     typedef unsigned short     U16;
     typedef unsigned int       U32;
     typedef   signed int       S32;
-    typedef unsigned long long U64;
+    typedef unsigned long long U64;   /* if your compiler doesn't support unsigned long long, replace by another 64-bit type here. Note that xxhash.h will also need to be updated. */
 #  endif
 #endif
 

--- a/xxhash.c
+++ b/xxhash.c
@@ -573,7 +573,6 @@ XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long 
 {
     XXH64_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
     memset(&state, 0, sizeof(state));
-    state.seed = seed;
     state.v1 = seed + PRIME64_1 + PRIME64_2;
     state.v2 = seed + PRIME64_2;
     state.v3 = seed + 0;
@@ -787,7 +786,7 @@ FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state, XXH_endianess 
         h64 = XXH64_mergeRound(h64, v3);
         h64 = XXH64_mergeRound(h64, v4);
     } else {
-        h64  = state->seed + PRIME64_5;
+        h64  = state->v3 + PRIME64_5;
     }
 
     h64 += (U64) state->total_len;

--- a/xxhash.h
+++ b/xxhash.h
@@ -280,13 +280,13 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 
    struct XXH64_state_s {
        unsigned long long total_len;
-       unsigned long long seed;
        unsigned long long v1;
        unsigned long long v2;
        unsigned long long v3;
        unsigned long long v4;
        unsigned long long mem64[4];   /* buffer defined as U64 for alignment */
        unsigned memsize;
+       unsigned reserved[2];          /* never read nor write, will be removed in a future version */
    };   /* typedef'd to XXH64_state_t */
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -258,11 +258,14 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 
 /* ================================================================================================
    This section contains definitions which are not guaranteed to remain stable.
-   They could change in a future version, becoming incompatible with a different version of the library.
+   They may change in future versions, becoming incompatible with a different version of the library.
    They shall only be used with static linking.
+   Never use these definitions in association with dynamic linking !
 =================================================================================================== */
 
-/* These definitions allow allocating XXH state statically (on stack) */
+/* These definitions are only meant to allow allocation of XXH state
+   statically, on stack, or in a struct for example.
+   Do not use members directly. */
 
    struct XXH32_state_s {
        unsigned long long total_len;

--- a/xxhash.h
+++ b/xxhash.h
@@ -221,7 +221,12 @@ When done, free XXH state space if it was allocated dynamically.
 /* **************************
 *  Utils
 ****************************/
+#if !(defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))   /* ! C99 */
+#  define restrict   /* disable restrict */
+#endif
 
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* restrict dst_state, const XXH32_state_t* restrict src_state);
+XXH_PUBLIC_API void XXH64_copyState(XXH64_state_t* restrict dst_state, const XXH64_state_t* restrict src_state);
 
 
 /* **************************
@@ -245,11 +250,13 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 
 #ifdef XXH_STATIC_LINKING_ONLY
 
-/* This section contains definitions which are not guaranteed to remain stable.
+/* ================================================================================================
+   This section contains definitions which are not guaranteed to remain stable.
    They could change in a future version, becoming incompatible with a different version of the library.
-   They shall only be used with static linking. */
+   They shall only be used with static linking.
+=================================================================================================== */
 
-/* These definitions allow allocating XXH state statically */
+/* These definitions allow allocating XXH state statically (on stack) */
 
    struct XXH32_state_s {
        unsigned long long total_len;

--- a/xxhash.h
+++ b/xxhash.h
@@ -96,7 +96,7 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 #    define XXH_STATIC_LINKING_ONLY
 #  endif
 #  if defined(__GNUC__)
-#    define XXH_PUBLIC_API static __attribute__((unused))
+#    define XXH_PUBLIC_API static __inline __attribute__((unused))
 #  elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
 #    define XXH_PUBLIC_API static inline
 #  elif defined(_MSC_VER)

--- a/xxhash.h
+++ b/xxhash.h
@@ -88,7 +88,7 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 *   Methodology :
 *     #define XXH_PRIVATE_API
 *     #include "xxhash.h"
-*   `xxhash.c` will also be included, so this file is still needed,
+*   `xxhash.c` is automatically included, so the file is still needed,
 *   but it's not useful to compile and link it anymore.
 */
 #ifdef XXH_PRIVATE_API
@@ -113,10 +113,10 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 If you want to include _and expose_ xxHash functions from within your own library,
 but also want to avoid symbol collisions with another library which also includes xxHash,
 
-you can use XXH_NAMESPACE, to automatically prefix any public symbol from `xxhash.c`
+you can use XXH_NAMESPACE, to automatically prefix any public symbol from xxhash library
 with the value of XXH_NAMESPACE (so avoid to keep it NULL and avoid numeric values).
 
-Note that no change is required within the calling program as long as it also includes `xxhash.h` :
+Note that no change is required within the calling program as long as it includes `xxhash.h` :
 regular symbol name will be automatically translated by this header.
 */
 #ifdef XXH_NAMESPACE
@@ -135,6 +135,8 @@ regular symbol name will be automatically translated by this header.
 #  define XXH64_update XXH_NAME2(XXH_NAMESPACE, XXH64_update)
 #  define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
 #  define XXH64_digest XXH_NAME2(XXH_NAMESPACE, XXH64_digest)
+#  define XXH32_copyState XXH_NAME2(XXH_NAMESPACE, XXH32_copyState)
+#  define XXH64_copyState XXH_NAME2(XXH_NAMESPACE, XXH64_copyState)
 #endif
 
 
@@ -166,7 +168,7 @@ XXH32() :
 XXH64() :
     Calculate the 64-bits hash of sequence of length "len" stored at memory address "input".
     "seed" can be used to alter the result predictably.
-    This function runs faster on 64-bits systems, but slower on 32-bits systems (see benchmark).
+    This function runs 2x faster on 64-bits systems, but slower on 32-bits systems (see benchmark).
 */
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -269,13 +269,13 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 
    struct XXH32_state_s {
        unsigned long long total_len;
-       unsigned seed;
        unsigned v1;
        unsigned v2;
        unsigned v3;
        unsigned v4;
        unsigned mem32[4];   /* buffer defined as U32 for alignment */
        unsigned memsize;
+       unsigned reserved;   /* never read nor write, will be removed in a future version */
    };   /* typedef'd to XXH32_state_t */
 
    struct XXH64_state_s {

--- a/xxhash.h
+++ b/xxhash.h
@@ -88,8 +88,8 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 *   Methodology :
 *     #define XXH_PRIVATE_API
 *     #include "xxhash.h"
-*   `xxhash.c` is automatically included, so the file is still needed,
-*   but it's not useful to compile and link it anymore.
+*   `xxhash.c` is automatically included.
+*   It's not useful to compile and link it as a separate module anymore.
 */
 #ifdef XXH_PRIVATE_API
 #  ifndef XXH_STATIC_LINKING_ONLY
@@ -137,6 +137,10 @@ regular symbol name will be automatically translated by this header.
 #  define XXH64_digest XXH_NAME2(XXH_NAMESPACE, XXH64_digest)
 #  define XXH32_copyState XXH_NAME2(XXH_NAMESPACE, XXH32_copyState)
 #  define XXH64_copyState XXH_NAME2(XXH_NAMESPACE, XXH64_copyState)
+#  define XXH32_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH32_canonicalFromHash)
+#  define XXH64_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH64_canonicalFromHash)
+#  define XXH32_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH32_hashFromCanonical)
+#  define XXH64_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH64_hashFromCanonical)
 #endif
 
 
@@ -145,7 +149,7 @@ regular symbol name will be automatically translated by this header.
 ***************************************/
 #define XXH_VERSION_MAJOR    0
 #define XXH_VERSION_MINOR    6
-#define XXH_VERSION_RELEASE  1
+#define XXH_VERSION_RELEASE  2
 #define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
 XXH_PUBLIC_API unsigned XXH_versionNumber (void);
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -268,7 +268,8 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
    Do not use members directly. */
 
    struct XXH32_state_s {
-       unsigned long long total_len;
+       unsigned total_len_32;
+       unsigned large_len;
        unsigned v1;
        unsigned v2;
        unsigned v3;

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -120,9 +120,8 @@ static const int g_nbBits = (int)(sizeof(void*)*8);
 static const char g_lename[] = "little endian";
 static const char g_bename[] = "big endian";
 #define ENDIAN_NAME (BMK_isLittleEndian() ? g_lename : g_bename)
-#define COMPILED __DATE__
 static const char author[] = "Yann Collet";
-#define WELCOME_MESSAGE(exename) "%s %s (%i-bits %s), by %s (%s) \n", exename, PROGRAM_VERSION,  g_nbBits, ENDIAN_NAME, author, COMPILED
+#define WELCOME_MESSAGE(exename) "%s %s (%i-bits %s), by %s \n", exename, PROGRAM_VERSION,  g_nbBits, ENDIAN_NAME, author
 
 #define NBLOOPS    3                              /* Default number of benchmark iterations */
 #define TIMELOOP_S 1
@@ -1127,7 +1126,7 @@ static int badusage(const char* exename)
 int main(int argc, const char** argv)
 {
     int i, filenamesStart=0;
-    const char* exename = argv[0];
+    const char* const exename = argv[0];
     U32 benchmarkMode = 0;
     U32 fileCheckMode = 0;
     U32 strictMode    = 0;

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -55,11 +55,7 @@
 #include <sys/stat.h>   /* stat64 */
 #include <time.h>       /* clock_t, clock, CLOCKS_PER_SEC */
 
-#ifdef XXHSUM_INCLUDE_XXHC    /* compile xxhsum with xxhash as private (no public symbol) */
-#  define XXH_INCLUDE_BODY
-#else
-#  define XXH_STATIC_LINKING_ONLY   /* *_state_t */
-#endif
+#define XXH_STATIC_LINKING_ONLY   /* *_state_t */
 #include "xxhash.h"
 
 


### PR DESCRIPTION
fix : namespace emulation contains all symbols
removed `seed` from `state`, replaced by `reserved` (#79)