### PR TITLE
Fix minor compile error using XXH_ACCEPT_NULL_INPUT_POINTER

### DIFF
--- a/xxhash.c
+++ b/xxhash.c
@@ -624,7 +624,7 @@ static U64 XXH64_mergeRound(U64 acc, U64 val)
 FORCE_INLINE U64 XXH64_endian_align(const void* input, size_t len, U64 seed, XXH_endianess endian, XXH_alignment align)
 {
     const BYTE* p = (const BYTE*)input;
-    const BYTE* const bEnd = p + len;
+    const BYTE* bEnd = p + len;
     U64 h64;
 #define XXH_get64bits(p) XXH_readLE64_align(p, endian, align)
 


### PR DESCRIPTION
XXH64_endian_align() has a compile issue using XXH_ACCEPT_NULL_INPUT_POINTER, because it declares 

`const BYTE* const bEnd = p + len;`

and then tries to assign to it again with the line `bEnd=p=(const BYTE*)(size_t)32;`

XXH32_endian_align() avoids this issue by declaring `const BYTE* bEnd = p + len;` (notice the pointer itself is non-const here)

I have not looked much into this, just made the most obvious change to get it to work.