### PR TITLE
intel: do not use __attribute__((packed)) on Windows

### DIFF
--- a/xxhash.c
+++ b/xxhash.c
@@ -54,7 +54,7 @@
                         || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) \
                         || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
 #    define XXH_FORCE_MEMORY_ACCESS 2
-#  elif defined(__INTEL_COMPILER) || \
+#  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
   (defined(__GNUC__) && ( defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) \
                     || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) \
                     || defined(__ARM_ARCH_7S__) ))


### PR DESCRIPTION
On Windows, the Intel compiler is closer to MSVC rather than GCC and
does not support the GCC attribute syntax.

---
See lz4/lz4#468.