### PR TITLE
Fix reversed links for NVBIO and Factor

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,12 +221,12 @@ The following versions produce xxHash-compatible results in different languages.
 <li><a href="https://wiki.freebsd.org/pkgng"			><img src="images/logo50/freebsd.png"		/><span> PKG</span></a></li>
 <li><a href="https://www.qemu.org/"				><img src="images/logo50/qemu.png"		/><span> Qemu</span></a></li>
 <li><a href="http://www.teamviewer.com/"			><img src="images/logo50/teamviewer.png"	/><span> TeamViewer</span></a></li>
-<li><a href="http://nvlabs.github.io/nvbio/index.html"		><img src="images/logo50/factor.png"		/><span> Factor</span></a></li>
-<li><a href="http://factorcode.org/"                ><img src="images/logo50/nvbio.png"         /><span> nVBio</span></a></li>
-<li><a href="http://dvisvgm.bplaced.net/">          <img src="images/logo50/placeholder.png"    /><span> dvisvgm</span></a></li>
-<li><a href="http://www.fastbuild.org/">            <img src="images/logo50/fastbuild.png"      /><span> FastBuild</span></a></li>
-<li><a href="http://keypirinha.com/">               <img src="images/logo50/keypirinha.png"     /><span> Keypirinha</span></a></li>
-<li><a href="http://quickhash-gui.org/">            <img src="images/logo50/quickhash.png"      /><span> QuickHash</span></a></li>
+<li><a href="http://factorcode.org/"                            ><img src="images/logo50/factor.png"		/><span> Factor</span></a></li>
+<li><a href="http://nvlabs.github.io/nvbio/index.html"          ><img src="images/logo50/nvbio.png"             /><span> nVBio</span></a></li>
+<li><a href="http://dvisvgm.bplaced.net/"                       ><img src="images/logo50/placeholder.png"       /><span> dvisvgm</span></a></li>
+<li><a href="http://www.fastbuild.org/"                         ><img src="images/logo50/fastbuild.png"         /><span> FastBuild</span></a></li>
+<li><a href="http://keypirinha.com/"                            ><img src="images/logo50/keypirinha.png"        /><span> Keypirinha</span></a></li>
+<li><a href="http://quickhash-gui.org/"                         ><img src="images/logo50/quickhash.png"         /><span> QuickHash</span></a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
Previously the links for factorcode and NVBIO were switched around. This fixes that and neatens up the indentation.