### PR TITLE
Remove trailing whitespace with a check/test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,11 +194,16 @@ preview-man: clean-man man
 	man ./xxhsum.1
 
 test-all: clean all namespaceTest test test32 test-xxhsum-c clean-xxhsum-c \
-	armtest clangtest gpptest c90test test-mem usan staticAnalyze
+	armtest clangtest gpptest c90test test-mem usan staticAnalyze \
+	trailingWhitespace
 
 .PHONY: listL120
 listL120:  # extract lines >= 120 characters in *.{c,h}, by Takayuki Matsuoka (note : $$, for Makefile compatibility)
 	find . -type f -name '*.c' -o -name '*.h' | while read -r filename; do awk 'length > 120 {print FILENAME "(" FNR "): " $$0}' $$filename; done
+
+.PHONY: trailingWhitespace
+trailingWhitespace:
+	! grep -E "`printf '[ \\t]$$'`" *.1 *.c *.h *.md LICENSE Makefile cmake_unofficial/*
 
 .PHONY: clean
 clean: clean-xxhsum-c

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -4,10 +4,10 @@ xxhsum(1) -- print or check xxHash non-cryptographic checksums
 SYNOPSIS
 --------
 
-`xxhsum [<OPTION>] ... [<FILE>] ...`  
+`xxhsum [<OPTION>] ... [<FILE>] ...`
 `xxhsum -b [<OPTION>] ...`
 
-`xxh32sum` is equivalent to `xxhsum -H0`  
+`xxh32sum` is equivalent to `xxhsum -H0`
 `xxh64sum` is equivalent to `xxhsum -H1`
 
 


### PR DESCRIPTION
Their presence caused my tests to fail. I hereby put all my changes
under PD/CC0/Expat licence.