### PR TITLE
XXH32a/XXH64a: XXH32, vectorized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ xxhsum_inlinedXXH.exe
 # Mac OS-X artefacts
 *.dSYM
 .DS_Store
+/.vs
+/cmake_unofficial/CMakeSettings.json
+*.obj

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ libxxhash.*
 
 # Executables
 xxh32sum
+xxh32asum
 xxh64sum
 xxhsum
 xxhsum.exe

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,7 @@ LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
 LIBVER_PATCH := $(shell echo $(LIBVER_PATCH_SCRIPT))
 LIBVER := $(LIBVER_MAJOR).$(LIBVER_MINOR).$(LIBVER_PATCH)
 
-# SSE4 detection
-HAVE_SSE4 := $(shell $(CC) -dM -E - < /dev/null | grep "SSE4" > /dev/null && echo 1 || echo 0)
-ifeq ($(HAVE_SSE4), 1)
-NOSSE4 := -mno-sse4
-else
-NOSSE4 :=
-endif
-
-CFLAGS ?= -O2 $(NOSSE4) # disables potential auto-vectorization
+CFLAGS ?= -O2
 DEBUGFLAGS+=-Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
             -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement \
             -Wstrict-prototypes -Wundef -Wpointer-arith -Wformat-security \

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ staticAnalyze: clean
 .PHONY: cppcheck
 cppcheck:
 	@echo ---- static analyzer - cppcheck ----
-	cppcheck . --force --enable=warning,portability,performance,style --inline-suppr --template='{callstack}:{file}:{line},{severity},{id},{message}' --error-exitcode=1 --suppress=knownConditionTrueFalse #> /dev/null
+	cppcheck . --force --enable=warning,portability,performance,style --inline-suppr --error-exitcode=1 --suppress=knownConditionTrueFalse > /dev/null
 
 .PHONY: namespaceTest
 namespaceTest:

--- a/Makefile
+++ b/Makefile
@@ -195,14 +195,14 @@ staticAnalyze: clean
 .PHONY: cppcheck
 cppcheck:
 	@echo ---- static analyzer - cppcheck ----
-	cppcheck . --force --enable=warning,portability,performance,style --error-exitcode=1 > /dev/null
+	cppcheck . --force --enable=warning,portability,performance,style --error-exitcode=1 --suppress=knownConditionTrueFalse > /dev/null
 
 .PHONY: namespaceTest
 namespaceTest:
 	$(CC) -c xxhash.c
 	$(CC) -DXXH_NAMESPACE=TEST_ -c xxhash.c -o xxhash2.o
 	$(CC) xxhash.o xxhash2.o xxhsum.c -o xxhsum2  # will fail if one namespace missing (symbol collision)
-	$(RM) *.o xxhsum2  # clean
+	$(RM) *.o *.obj xxhsum2  # clean
 
 xxhsum.1: xxhsum.1.md
 	cat $^ | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
@@ -233,8 +233,8 @@ trailingWhitespace:
 .PHONY: clean
 clean:
 	@$(RM) -r *.dSYM   # Mac OS-X specific
-	@$(RM) core *.o libxxhash.*
-	@$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) xxh32asum xxh32sum xxh64sum
+	@$(RM) core *.o *.obj libxxhash.*
+	@$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) xxh64asum xxh32asum xxh32sum xxh64sum
 	@echo cleaning completed
 
 
@@ -296,6 +296,7 @@ install: lib xxhsum
 	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh32sum
 	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh32asum
 	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh64sum
+	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh64asum
 	@echo Installing man pages
 	@$(INSTALL_DATA) xxhsum.1 $(DESTDIR)$(MANDIR)/xxhsum.1
 	@ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh32sum.1
@@ -312,6 +313,7 @@ uninstall:
 	@$(RM) $(DESTDIR)$(BINDIR)/xxh32sum
 	@$(RM) $(DESTDIR)$(BINDIR)/xxh32asum
 	@$(RM) $(DESTDIR)$(BINDIR)/xxh64sum
+	@$(RM) $(DESTDIR)$(BINDIR)/xxh64asum
 	@$(RM) $(DESTDIR)$(BINDIR)/xxhsum
 	@$(RM) $(DESTDIR)$(MANDIR)/xxh32sum.1
 	@$(RM) $(DESTDIR)$(MANDIR)/xxh64sum.1

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ staticAnalyze: clean
 .PHONY: cppcheck
 cppcheck:
 	@echo ---- static analyzer - cppcheck ----
-	cppcheck . --force --enable=warning,portability,performance,style --inline-suppr --error-exitcode=1 --suppress=knownConditionTrueFalse > /dev/null
+	cppcheck . --force --enable=warning,portability,performance,style --inline-suppr --error-exitcode=1 --suppress=knownConditionTrueFalse,duplicateBranch > /dev/null
 
 .PHONY: namespaceTest
 namespaceTest:

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ staticAnalyze: clean
 .PHONY: cppcheck
 cppcheck:
 	@echo ---- static analyzer - cppcheck ----
-	cppcheck . --force --enable=warning,portability,performance,style --inline-suppr --error-exitcode=1 --suppress=knownConditionTrueFalse,duplicateBranch > /dev/null
+	cppcheck . --force --enable=warning,portability,performance,style --inline-suppr --error-exitcode=1 --suppress=knownConditionTrueFalse --suppress=duplicateBranch > /dev/null
 
 .PHONY: namespaceTest
 namespaceTest:

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ xxhsum32: xxhash.c xxhsum.c
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 
 .PHONY: xxhsum_and_links
-xxhsum_and_links: xxhsum xxh32sum xxh64sum
+xxhsum_and_links: xxhsum xxh32sum xxh32asum xxh64sum
 
-xxh32sum xxh64sum: xxhsum
+xxh32sum xxh32asum xxh64sum: xxhsum
 	ln -sf $^ $@
 
 xxhsum_inlinedXXH: CPPFLAGS += -DXXH_INLINE_ALL
@@ -232,7 +232,7 @@ trailingWhitespace:
 clean:
 	@$(RM) -r *.dSYM   # Mac OS-X specific
 	@$(RM) core *.o libxxhash.*
-	@$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) xxh32sum xxh64sum
+	@$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) xxh32asum xxh32sum xxh64sum
 	@echo cleaning completed
 
 
@@ -292,6 +292,7 @@ install: lib xxhsum
 	@$(INSTALL) -d -m 755 $(DESTDIR)$(BINDIR)/ $(DESTDIR)$(MANDIR)/
 	@$(INSTALL_PROGRAM) xxhsum $(DESTDIR)$(BINDIR)/xxhsum
 	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh32sum
+	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh32asum
 	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh64sum
 	@echo Installing man pages
 	@$(INSTALL_DATA) xxhsum.1 $(DESTDIR)$(MANDIR)/xxhsum.1
@@ -307,6 +308,7 @@ uninstall:
 	@$(RM) $(DESTDIR)$(LIBDIR)/$(LIBXXH)
 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/xxhash.h
 	@$(RM) $(DESTDIR)$(BINDIR)/xxh32sum
+	@$(RM) $(DESTDIR)$(BINDIR)/xxh32asum
 	@$(RM) $(DESTDIR)$(BINDIR)/xxh64sum
 	@$(RM) $(DESTDIR)$(BINDIR)/xxhsum
 	@$(RM) $(DESTDIR)$(MANDIR)/xxh32sum.1

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ all: lib xxhsum xxhsum_inlinedXXH
 
 xxhsum : xxhash.o xxhsum.o
 
+xxhash.o: %.o: %.c xxhash-vec.h xxhash.h
+xxhsum.o: %.o: %.c xxhash.h
+
 xxhsum32: CFLAGS += -m32
 xxhsum32: xxhash.c xxhsum.c
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
@@ -103,8 +106,8 @@ $(LIBXXH): LDFLAGS += -shared
 ifeq (,$(filter Windows%,$(OS)))
 $(LIBXXH): CFLAGS += -fPIC
 endif
-$(LIBXXH): xxhash.c
-	$(CC) $(FLAGS) $^ $(LDFLAGS) $(SONAME_FLAGS) -o $@
+$(LIBXXH): xxhash.c xxhash-vec.h xxhash.h
+	$(CC) $(FLAGS) $< $(LDFLAGS) $(SONAME_FLAGS) -o $@
 	ln -sf $@ libxxhash.$(SHARED_EXT_MAJOR)
 	ln -sf $@ libxxhash.$(SHARED_EXT)
 

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ staticAnalyze: clean
 .PHONY: cppcheck
 cppcheck:
 	@echo ---- static analyzer - cppcheck ----
-	cppcheck . --force --enable=warning,portability,performance,style --error-exitcode=1 --suppress=knownConditionTrueFalse > /dev/null
+	cppcheck . --force --enable=warning,portability,performance,style --inline-suppr --template='{callstack}:{file}:{line},{severity},{id},{message}' --error-exitcode=1 --suppress=knownConditionTrueFalse #> /dev/null
 
 .PHONY: namespaceTest
 namespaceTest:

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ xxhsum32: xxhash.c xxhsum.c
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 
 .PHONY: xxhsum_and_links
-xxhsum_and_links: xxhsum xxh32sum xxh32asum xxh64sum
+xxhsum_and_links: xxhsum xxh32sum xxh32asum xxh64sum xxh64asum
 
-xxh32sum xxh32asum xxh64sum: xxhsum
+xxh32sum xxh32asum xxh64sum xxh64asum: xxhsum
 	ln -sf $^ $@
 
 xxhsum_inlinedXXH: CPPFLAGS += -DXXH_INLINE_ALL
@@ -174,7 +174,7 @@ cxxtest: clean
 	CC="$(CXX) -Wno-deprecated" $(MAKE) all CFLAGS="-O3 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror -fPIC"
 
 .PHONY: c90test
-c90test: CPPFLAGS += -DXXH_NO_LONG_LONG
+c90test: CPPFLAGS += -DXXH_NO_LONG_LONG -DXXH_NO_ALT_HASHES -DXXH_VECTORIZE=0
 c90test: CFLAGS += -std=c90 -Werror -pedantic
 c90test: xxhash.c
 	@echo ---- test strict C90 compilation [xxh32 only] ----
@@ -216,8 +216,10 @@ clean-man:
 preview-man: clean-man man
 	man ./xxhsum.1
 
+.PHONY: test
 test: all namespaceTest check test-xxhsum-c c90test
 
+.PHONY: test-all
 test-all: test test32 armtest clangtest cxxtest usan listL120 trailingWhitespace staticAnalyze cppcheck
 
 .PHONY: listL120

--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,12 @@ test-xxhsum-c: xxhsum
 	@$(RM) -f .test.xxh32 .test.xxh64
 
 armtest: clean
+ifeq (,$(shell which arm-linux-gnueabi-gcc 2>&1 || true))
+	@echo Skipping ARM compilation, arm-linux-gnueabi-gcc not found
+else
 	@echo ---- test ARM compilation ----
 	CC=arm-linux-gnueabi-gcc MOREFLAGS="-Werror -static" $(MAKE) xxhsum
+endif
 
 clangtest: clean
 	@echo ---- test clang compilation ----
@@ -223,7 +227,13 @@ preview-man: clean-man man
 test: all namespaceTest check test-xxhsum-c c90test
 
 .PHONY: test-all
+
+# macOS disabled 32-bit support in recent Xcode versions.
+ifeq ($(shell uname 2> /dev/null || true),Darwin)
+test-all: test armtest clangtest cxxtest usan listL120 trailingWhitespace staticAnalyze cppcheck
+else
 test-all: test test32 armtest clangtest cxxtest usan listL120 trailingWhitespace staticAnalyze cppcheck
+endif
 
 .PHONY: listL120
 listL120:  # extract lines >= 120 characters in *.{c,h}, by Takayuki Matsuoka (note : $$, for Makefile compatibility)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ benchmark to save power, causing inconsistent results which vary up to 50%.
 Additionally, the alternative hashes have more warmup time than the basic ones, as
 creating and destroying SIMD vectors is expensive.
 
-The performance of the hashes would be graded as follows, assuming aligned data:
+The performance of the hashes would be ranked as follows, assuming aligned data:
 
 Note: Short input is assumed to be shorter than ~256 bytes.
 
@@ -111,15 +111,20 @@ Note: Short input is assumed to be shorter than ~256 bytes.
 
 Note: This assumes that XXH32a/XXH64a uses vectorization.
 XXH32a and XXH64a will not be vectorized if...
-* Not using GCC or Clang and not overridden with XXH_VECTORIZE=1
-* Not targeting either SSE4.1 (or later) or NEON and not overridden with XXH_VECTORIZE=1
-* XXH_VECTORIZE=0
-* On a big endian systems without XXH32
-* When explicitly targeting SSE4.1, not targeting AVX, and not using Clang in 32-bit mode,
+* `XXH_VECTORIZE` is not manually defined and...
+    * not using GCC or Clang
+    * not targeting either SSE4.1 (or later) or ARM NEON
+* `XXH_VECTORIZE` is defined to `0`
+* targeting a big endian systems without `XXH_FORCE_NATIVE_FORMAT`
+* when explicitly targeting SSE4.1, not targeting AVX, and not using Clang in 32-bit mode,
   and using unaligned data. The loops aren't properly vectorized for unaligned access on
-  SSE4.1 this way, and the normal way is slightly faster.
+  SSE4.1 this way, and the standard way is slightly faster.
 
 In addition, on older Core 2 processors, XXH32a and XXH64a will be faster than XXH64.
+Performance is still acceptable, and XXH64 will be significantly faster on newer machines.
+
+XXH64a will almost always be faster than XXH64 on 32-bit targets, even with vectorization
+disabled. This is because it uses native 32-bit arithmetic.
 
 
 For maximum portability, use XXH32. XXH32 is fully C89 conformant, and
@@ -163,18 +168,12 @@ and endianness).
 Some intrinsics are used for when there are faster options that the compiler will
 not recognize, such as forcing the "rotate left" code to produce a `vsliq_n_u32`
 instruction instead of `vshlq_n_u32` followed by `vorrq_u32` on ARM NEON, however, they
-are only to be used when there is a benefit. 
-
-Using XXH32a or XXH64a with `XXH_VECTORIZE` set to zero will be slower than if it is
-enabled, but faster than `XXH_VECTORIZE=1` if the target does not support SIMD.
+are only to be used when there is a significant benefit. 
 
 If you want a consistent 64-bit hash that is fast on 32-bit and 64-bit, use
 XXH64a. XXH64a will not see massive performance gains over XXH32 like XXH64 sees,
 but it is one of the only 64-bit hashes that is actually fast on 32-bit systems, and
 is still going to be faster than XXH32 on longer inputs with supported vectorization.
-
-XXH64a, even without vectorization, will always be faster than XXH64 on a
-32-bit target.
 
 XXH32a is also a good option for longer inputs. 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Note that on macOS, `gcc` is a symlink to `clang` by default.
 These are the results for the xxhsum 100kb benchmark, compiled with both Clang 7.0.0 and GCC 8.1.0 on macOS 10.13.6,
 on an Intel Core 2 Duo P7450 (Penryn, SSE4.1) @2.13 GHz, with `-msse4.1 -O2`:
 
-64-bit:
+**64-bit**
+  
 | Type   | Aligned (GCC) | Unaligned (GCC) | Aligned (Clang) | Unaligned (Clang) |
 |--------|--------------:|----------------:|----------------:|------------------:|
 | XXH32  |     3.91 GB/s |       2.97 GB/s |       3.89 GB/s |         2.98 GB/s |
@@ -65,7 +66,8 @@ on an Intel Core 2 Duo P7450 (Penryn, SSE4.1) @2.13 GHz, with `-msse4.1 -O2`:
 | XXH32a |     4.95 GB/s |       3.14 GB/s |       4.43 GB/s |         2.86 GB/s |
 | XXH64a |     4.94 GB/s |       3.13 GB/s |       4.45 GB/s |         2.89 GB/s |
 
-32-bit:
+**32-bit**
+
 | Type   | Aligned (GCC) | Unaligned (GCC) | Aligned (Clang) | Unaligned (Clang) |
 |--------|--------------:|----------------:|----------------:|------------------:|
 | XXH32  |     3.91 GB/s |       2.97 GB/s |       3.91 GB/s |         2.93 GB/s |
@@ -79,7 +81,8 @@ If you are compiling for iOS or using a recent NDK, you are using Clang.
 On an LG G3 on Android 9.0 (LineageOS 16) with a Qualcomm Snapdragon 801 (Cortex-A15, ARMv7a/ve, quad-core)
 @1.7/1.7/2.45/2.45 GHz, compiled with ARM GCC 8.2.0 and Clang 7.0.0 with `-O2 -march=native`, measured in Termux:
 
-32-bit:
+**32-bit**
+
 | Type   | Aligned (GCC) | Unaligned (GCC) | Aligned (Clang) | Unaligned (Clang) |
 |--------|--------------:|----------------:|----------------:|------------------:|
 | XXH32  |     4.14 GB/s |       4.14 GB/s |       4.14 GB/s |         4.14 GB/s |

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -192,7 +192,7 @@ FORCE_INLINE const BYTE* XXH64_NEON32(const BYTE* p, const BYTE* bEnd,
     const U64 PRIME2[2] = { PRIME64_2, PRIME64_2 };
 
     const U64 STATE1[2] = { PRIME64_1 + PRIME64_2, PRIME64_2 };
-    const U64 STATE2[2] = { 0, -PRIME64_2 };
+    const U64 STATE2[2] = { 0, -PRIME64_1 };
 
     /* Interleave our constants in two ways. */
     const uint64x2_t prime1_base = vld1q_u64(PRIME1);

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -621,14 +621,15 @@ FORCE_INLINE const BYTE* XXH64_SSE2(const BYTE* p, const BYTE* const limit,
         } while (p < limit);
     } else {
         do {
-            __m128i val = _mm_loadu_si128((const __m128i*)p);
+            __m128i val;
+            val = XXH_DISABLE_W_CAST_ALIGN(_mm_loadu_si128((const __m128i*)p));
             val = XXH_U64x2_mult(val, prime2_high, prime2_low);
             v[0] = _mm_add_epi64(v[0], val);
             v[0] = XXH_vec_rotl64(v[0], 31);
             v[0] = XXH_U64x2_mult(v[0], prime1_high, prime1_low);
             p += 16;
 
-            val = _mm_loadu_si128((const __m128i*)p);
+            val = XXH_DISABLE_W_CAST_ALIGN(_mm_loadu_si128((const __m128i*)p));
             val = XXH_U64x2_mult(val, prime2_high, prime2_low);
             v[1] = _mm_add_epi64(v[1], val);
             v[1] = XXH_vec_rotl64(v[1], 31);
@@ -636,8 +637,8 @@ FORCE_INLINE const BYTE* XXH64_SSE2(const BYTE* p, const BYTE* const limit,
             p += 16;
         } while (p < limit);
     }
-    _mm_store_si128((__m128i*)state[0], v[0]);
-    _mm_store_si128((__m128i*)state[1], v[1]);
+    XXH_DISABLE_W_CAST_ALIGN(_mm_store_si128((__m128i*)state[0], v[0]));
+    XXH_DISABLE_W_CAST_ALIGN(_mm_store_si128((__m128i*)state[1], v[1]));
 
     /* SSE2's _mm_sll_epi64 is stupid.
      * In order to have two shift values, you either need to do a lot of shuffling,
@@ -657,13 +658,13 @@ FORCE_INLINE const BYTE* XXH64_SSE2(const BYTE* p, const BYTE* const limit,
     v[0] = XXH_U64x2_mult(v[0], prime1_high, prime1_low);
     v[1] = XXH_U64x2_mult(v[1], prime1_high, prime1_low);
 
-    _mm_store_si128((__m128i*)state[0], v[0]);
+    XXH_DISABLE_W_CAST_ALIGN(_mm_store_si128((__m128i*)state[0], v[0]));
     *h64 ^= state[0][0];
     *h64 = *h64 * PRIME64_1 + PRIME64_4;
     *h64 ^= state[0][1];
     *h64 = *h64 * PRIME64_1 + PRIME64_4;
 
-    _mm_store_si128((__m128i*)state[1], v[1]);
+    XXH_DISABLE_W_CAST_ALIGN(_mm_store_si128((__m128i*)state[1], v[1]));
     *h64 ^= state[1][0];
     *h64 = *h64 * PRIME64_1 + PRIME64_4;
     *h64 ^= state[1][1];

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -35,8 +35,36 @@
 #ifndef XXHASH_VEC_H
 #define XXHASH_VEC_H
 
-#if defined(__ARM_NEON__) || defined(__ARM_NEON)
+/* GCC and Clang warn on -Wcast-align when casting to __m128i. We don't really have many options
+ * but to silence the warning. */
+#ifdef __clang__
+#define XXH_DISABLE_W_CAST_ALIGN(x) __extension__ ({ \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wcast-align\"") \
+    (x); \
+    _Pragma("clang diagnostic pop") \
+})
+#elif defined(__GNUC__)
+#define XXH_DISABLE_W_CAST_ALIGN(x) __extension__ ({ \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wcast-align\"") \
+    (x); \
+    _Pragma("GCC diagnostic pop") \
+})
+#else
+#define XXH_DISABLE_W_CAST_ALIGN(x) (x)
+#endif
+
+#if defined(__GNUC__) && (defined(__ARM_NEON__) || defined(__ARM_NEON))
+
+/* Dumb, dumb, dumb. Clang uses the inline keyword in arm_neon.h,
+ * which causes errors on C89 mode. */
+#if defined(__clang_) && !defined(inline)
+#define inline __inline__
+#endif
 #include <arm_neon.h>
+#undef inline
+
+
 #define XXH_NEON
 #undef XXH_VECTORIZE
 #define XXH_VECTORIZE 1
@@ -50,20 +78,208 @@ typedef uint64x2_t U64x2;
 /* Neither GCC or Clang can properly optimize the generic version
  * for Arm NEON.
  * Instead of the optimal version, which is this:
- *      vshr.u32        q9, q8, #19
- *      vsli.32         q9, q8, #13
+ *      vshl.i32        q9, q8, #13 @ q9 = q8 << 13
+ *      vsra.32         q9, q8, #19 @ q9 += q8 >> 19;
  * GCC and Clang will produce this slower version:
  *      vshr.u32        q9, q8, #19
  *      vshl.i32        q8, q8, #13
  *      vorr            q8, q8, q9
- * This is much faster, and I think a few intrinsics are acceptable. */
-#define XXH_vec_rotl32(x, r) vsliq_n_u32(vshrq_n_u32((x), 32 - (r)), (x), (r))
+ * This is much faster. However, Clang is stupid, and will happily optimize
+ * the top code in intrinsics to the bottom code!
+ *
+ * So, for the best performance, we sadly need inline assembly. */
+/* Clang will convert to Apple syntax for us. */
+#define XXH_vec_rotl32(_x, _r) __extension__ ({ \
+    uint32x4_t _tmp = vshlq_n_u32(_x, _r); \
+    XXH_FORCE_VECTOR_REG(_tmp); \
+    vsraq_n_u32(_tmp, _x, 32 - _r); \
+})
+#define XXH_vec_rotl64(_x, _r) __extension__ ({ \
+    uint32x4_t _tmp = vshlq_n_u64(_x, _r); \
+    XXH_FORCE_VECTOR_REG(_tmp); \
+    vsraq_n_u64(_tmp, _x, 64 - _r); \
+})
 
 #define XXH_vec_load_unaligned(p) vreinterpretq_u32_u8(vld1q_u8((const BYTE*)(p)))
 #define XXH_vec_store_unaligned(p, v) vst1q_u8((BYTE*)(p), vreinterpretq_u8_u32((v)))
 #define XXH_vec_load_aligned(p) vreinterpretq_u32_u8(vld1q_u8((const BYTE*)(p)))
 #define XXH_vec_store_aligned(p, v) vst1q_u8((BYTE*)(p), vreinterpretq_u8_u32((v)))
 
+/**************************************************
+ * 64-bit multiplication in NEON is missing from the instruction set.
+ * There is a way to do it that works like so:
+ *    Truncated grid method
+ *      ___________________________
+ *     |   |    b      |    a      |
+ *     |---|-----------|-----------|
+ *     | d | b*d << 64 | a*d << 32 |
+ *     |---|-----------|-----------|
+ *     | c | b*c << 32 |    a*c    |
+ *     '---'-----------'-----------'
+ *     Add all of them together.
+ *    We can eliminate (b*d << 64) because we truncate to 64 bits.
+ *    Technically only need to do a 32-64-bit multiply on (a*c). However,
+ *    some versions of Clang will scalarize it if we use vmul because of an
+ *    InstCombine bug.
+ *
+ * We can do this two ways, which we use both.
+ *
+ * XXH_U64x2_ssemul uses the same method used by Clang and GCC when multiplying
+ * with vector extensions. We use this when we can interleave the inputs beforehand,
+ * as that puts the elements in a way we can easily perform two multiplies on.
+ * We do this with a vld2_u32 which will put the low bits first, and the high bits last.
+ * This makes it easier to cross multiply.
+ *
+ * XXH_U64x2_twomul uses a different method, which does a U32x4 multiply and a vpaddlq_u32.
+ * We do this when we can only interleave a single multiple. We interleave it with a vrev64q_u32
+ * and a vmovn beforehand, and we don't have to interleave the input that way.
+ */
+
+FORCE_INLINE uint64x2_t XXH_U64x2_ssemul(const uint32x2x2_t top, const uint32x2x2_t bot)
+{
+    /*
+     * product = (U64x2)a * (U64x2)d;
+     * product += (U64x2)b * (U64x2)c;
+     * product <<= 32;
+     * product += (U64x2)a * (U64x2)c;
+     */
+    uint64x2_t product = vmull_u32(top.val[0], bot.val[1]);
+    product = vmlal_u32(product, top.val[1], bot.val[0]);
+    product = vshlq_n_u64(product, 32);
+    product = vmlal_u32(product, top.val[0], bot.val[0]);
+    return product;
+}
+
+FORCE_INLINE uint64x2_t XXH_U64x2_ssemul_add(uint64x2_t acc, const uint32x2x2_t top, const uint32x2x2_t bot)
+{
+    /*
+     * product = (U64x2)a * (U64x2)d;
+     * product += (U64x2)b * (U64x2)c;
+     * product <<= 32;
+     * product += (U64x2)a * (U64x2)c;
+     */
+    uint64x2_t product = vmull_u32(top.val[0], bot.val[1]);
+    acc = vmlal_u32(acc, top.val[0], bot.val[0]);
+    product = vmlal_u32(product, top.val[1], bot.val[0]);
+    product = vshlq_n_u64(product, 32);
+    acc = vaddq_u64(acc, product);
+    return acc;
+}
+/* Expects botRev to be a value preswapped with a vrev64q_u32, and botLo is the low 32 bits. */
+FORCE_INLINE uint64x2_t XXH_U64x2_twomul(const uint64x2_t top,
+                                         const uint32x4_t botRev, const uint32x2_t botLo)
+{
+    /*  U32x2 product[2] = {
+     *      topLo * botHi,
+     *      topHi * botLo
+     *  };
+     *  U64x2 ret = (U64x2)product[0] + (U64x2)product[1];
+     *  ret <<= 32;
+     *  ret += (U64x2)topLo * (U64x2)botLo;
+     */
+    uint32x2_t topLo = vmovn_u64(top);
+    uint32x4_t product = vmulq_u32(vreinterpretq_u32_u64(top), botRev);
+    uint64x2_t ret = vpaddlq_u32(product);
+    ret = vshlq_n_u64(ret, 32);
+    ret = vmlal_u32(ret, topLo, botLo);
+    return ret;
+}
+
+FORCE_INLINE const BYTE* XXH64_NEON32(const BYTE* p, const BYTE* bEnd,
+                                      const U64 seed, U64 *h64)
+{
+    const U64 PRIME1[2] = { PRIME64_1, PRIME64_1 };
+    const U64 PRIME2[2] = { PRIME64_2, PRIME64_2 };
+
+    const U64 STATE1[2] = { PRIME64_1 + PRIME64_2, PRIME64_2 };
+    const U64 STATE2[2] = { 0, -PRIME64_2 };
+
+    /* Interleave our constants in two ways. */
+    const uint64x2_t prime1_base = vld1q_u64(PRIME1);
+    /* prime1_base & 0xFFFFFFFF; */
+    const uint32x2_t prime1_low = vmovn_u64(prime1_base);
+    /* (prime1_base << 32) | (prime1_base >> 32); */
+    const uint32x4_t prime1_swapped = vrev64q_u32(vreinterpretq_u32_u64(prime1_base));
+
+    /* { PRIME64_1 & 0xFFFFFFFF, PRIME64_1 & 0xFFFFFFFF, PRIME64_1 >> 32, PRIME64_1 >> 32 } */
+    const uint32x2x2_t prime2 = vld2_u32((const U32*)PRIME2);
+
+    const uint64x2_t seed_vec = vdupq_n_u64(seed);
+
+    uint64x2_t v[2];
+
+    v[0] = vld1q_u64(STATE1);
+    v[1] = vld1q_u64(STATE2);
+    v[0] = vaddq_u64(v[0], seed_vec);
+    v[1] = vaddq_u64(v[1], seed_vec);
+
+    do {
+        uint32x2x2_t val = vld2_u32((const U32*)p);
+
+        v[0] = XXH_U64x2_ssemul_add(v[0], val, prime2);
+        v[0] = XXH_vec_rotl64(v[0], 31); /* rotl */
+        v[0] = XXH_U64x2_twomul(v[0], prime1_swapped, prime1_low);
+        p += 16;
+
+        val = vld2_u32((const U32*)p);
+        v[1] = XXH_U64x2_ssemul_add(v[1], val, prime2);
+        v[1] = XXH_vec_rotl64(v[1], 31); /* rotl */
+        v[1] = XXH_U64x2_twomul(v[1], prime1_swapped, prime1_low);
+        p += 16;
+    } while (p < bEnd);
+    {
+        /* We need a copy for the rotl. */
+        uint64x2_t v0_cpy = v[0];
+        uint64x2_t v1_cpy = v[1];
+
+        const uint64x2_t prime2_base = vld1q_u64((const U64*)PRIME2);
+        const uint32x4_t prime2_swapped = vrev64q_u32(vreinterpretq_u32_u64(prime2_base));
+
+        /* We perform rounds in XXH64_mergeLane. It is faster to do this now.
+         * If we do this later, we might have to reload the primes. */
+        v[0] = XXH_U64x2_twomul(v[0], prime2_swapped, prime2.val[0]);
+        v[0] = XXH_vec_rotl64(v[0], 31);
+        v[0] = XXH_U64x2_twomul(v[0], prime1_swapped, prime1_low);
+
+        v[1] = XXH_U64x2_twomul(v[1], prime2_swapped, prime2.val[0]);
+        v[1] = XXH_vec_rotl64(v[1], 31);
+        v[1] = XXH_U64x2_twomul(v[1], prime1_swapped, prime1_low);
+
+        /* rotl(v1, 1) + rotl(v2, 7) + rotl(v3, 12) + rotl(v4, 18) */
+        {
+            /* NEON uses negative shifts for right shifts when not shifting by
+             * an immediate value. */
+            const int64_t rotlVals[4][2] = {
+                /* left[0] */ { 1, 7 },
+                /* left[1] */ { 12, 18 },
+                /* right[0] */ { -(64 - 1), -(64 - 7) },
+                /* right[1] */ { -(64 - 12), -(64 - 18) }
+            };
+            int64x2_t left0 = vld1q_s64(rotlVals[0]);
+            int64x2_t left1 = vld1q_s64(rotlVals[1]);
+            int64x2_t right0 = vld1q_s64(rotlVals[2]);
+            int64x2_t right1 = vld1q_s64(rotlVals[3]);
+            uint64x1_t merged; /* for later */
+            v0_cpy = vorrq_u64(vshlq_u64(v0_cpy, left0), vshlq_u64(v0_cpy, right0));
+            v1_cpy = vorrq_u64(vshlq_u64(v1_cpy, left1), vshlq_u64(v1_cpy, right1));
+
+            /* Do some cheap addition while we are here. */
+            v0_cpy = vaddq_u64(v0_cpy, v1_cpy);
+            merged = vadd_u64(vget_low_u64(v0_cpy), vget_high_u64(v0_cpy));
+
+            *h64 = merged[0];
+        }
+        *h64 ^= v[0][0];
+        *h64 = *h64 * PRIME64_1 + PRIME64_4;
+        *h64 ^= v[0][1];
+        *h64 = *h64 * PRIME64_1 + PRIME64_4;
+        *h64 ^= v[1][0];
+        *h64 = *h64 * PRIME64_1 + PRIME64_4;
+        *h64 ^= v[1][1];
+        *h64 = *h64 * PRIME64_1 + PRIME64_4;
+    }
+    return p;
+}
  /* Like XXH_vec_rotl32, but takes a vector as r. No NEON-optimized
   * version for this one. */
 FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
@@ -78,7 +294,7 @@ FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
   && (defined(__SSE4_1__) || defined(__AVX__))
 #undef XXH_VECTORIZE
 #define XXH_VECTORIZE 1
-#include <smmintrin.h>
+#include <immintrin.h>
 #include <stdio.h>
 #include <initializer_list>
 /* A very simple wrapper around __m128i */
@@ -136,6 +352,10 @@ public:
     inline void store(U32 *out) const
     {
         _mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
+    }
+    inline void store_aligned(__m128i *out) const
+    {
+        _mm_store_si128(reinterpret_cast<__m128i*>(XXH_assume_aligned(out, 16)), value);
     }
 };
 #ifndef XXH_NO_LONG_LONG
@@ -212,7 +432,7 @@ public:
     {
         const U64 dup[2] = { rhs, rhs };
         /* we could do (U64[2]) { rhs >> 32, rhs >> 32 }, but it slows down. */
-        const U32 high[4] = { rhs >> 32, 0, rhs >> 32, 0 };
+        const U32 high[4] = { static_cast<const U32>(rhs >> 32), 0, static_cast<const U32>(rhs >> 32), 0 };
 
         U64x2 xmm1(reinterpret_cast<const __m128i*>(dup));
         U64x2 xmm2 = value;
@@ -236,6 +456,11 @@ public:
     {
         _mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
     }
+
+    inline void store_aligned(__m128i *out) const
+    {
+        _mm_store_si128(reinterpret_cast<__m128i*>(XXH_assume_aligned(out, 16)), value);
+    }
 };
 #endif /* !XXH_NO_LONG_LONG */
 FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4 lhs, int bits)
@@ -258,6 +483,17 @@ FORCE_INLINE void XXH_vec_store_unaligned(U32* store, const U32x4 data)
 {
     data.store(store);
 }
+
+FORCE_INLINE U32x4 XXH_vec_load_aligned(const U32x4* data)
+{
+    return U32x4(_mm_load_si128(reinterpret_cast<const __m128i*>(XXH_assume_aligned(data, 16))));
+}
+
+FORCE_INLINE void XXH_vec_store_aligned(U32x4* store, const U32x4 data)
+{
+    data.store_aligned(reinterpret_cast<__m128i*>(store));
+}
+
 #elif (XXH_GCC_VERSION >= 407 || defined(__clang__)) \
     && (defined(__SSE4_1__) || defined(__AVX__))
 #undef XXH_VECTORIZE
@@ -286,11 +522,11 @@ FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4 x, U32 r)
 }
 #if defined(__SSE4_1__) || defined(__AVX__)
 #include <emmintrin.h>
-#define XXH_vec_load_unaligned(p) ((U32x4)_mm_loadu_si128((const __m128i*)(p)))
-#define XXH_vec_store_unaligned(p,v) ((U32x4)_mm_storeu_si128((__m128i*)(p), (__m128i)(v)))
+#define XXH_vec_load_unaligned(p) XXH_DISABLE_W_CAST_ALIGN((U32x4)_mm_loadu_si128((const __m128i*)(p)))
+#define XXH_vec_store_unaligned(p,v) XXH_DISABLE_W_CAST_ALIGN(_mm_storeu_si128((__m128i*)(p), (__m128i)(v)))
 
-#define XXH_vec_load_aligned(p) ((U32x4)_mm_load_si128((const __m128i*)(p)))
-#define XXH_vec_store_aligned(p,v) ((U32x4)_mm_store_si128((__m128i*)(p), (__m128i)(v)))
+#define XXH_vec_load_aligned(p) XXH_DISABLE_W_CAST_ALIGN ( (U32x4)_mm_load_si128((const __m128i*)(p)) )
+#define XXH_vec_store_aligned(p,v) XXH_DISABLE_W_CAST_ALIGN ( _mm_store_si128((__m128i*)(p), (__m128i)(v)) )
 #else
 /* emmintrin.h's _mm_loadu_si128 code. */
 FORCE_INLINE U32x4 XXH_vec_load_unaligned(const void* p)
@@ -316,6 +552,124 @@ FORCE_INLINE void XXH_vec_store_unaligned(void* p, const U32x4 v)
 
 #elif !defined(XXH_VECTORIZE)
 #define XXH_VECTORIZE 0
+#if defined(__SSE2__) && (defined(__i386__) || defined(_M_X86))
+#define XXH_VECTORIZE_XXH64 1
+#endif
 #endif /* C++/SSE4.1 */
+
+/* 32-bit SSE2 always gets this. */
+#if defined(__SSE2__) && (defined(XXH_VECTORIZE_XXH64) || defined(__i386__) || defined(_M_IX86))
+#include <emmintrin.h>
+#define XXH_load_and_swap XXH_load_unaligned
+#define XXH64x2_mult_interleaved XXH_U64x2_mult
+typedef U64 U64x2 __attribute__((vector_size(16)));
+
+FORCE_INLINE __m128i XXH_U64x2_mult(__m128i top, const __m128i botHi, const __m128i botLo)
+{
+    __m128i topHiBotLo, returnval, topLoBotLo, topLoBotHi;
+    /* Prevent a bug in Clang 7.0 which will cause an unwanted sign bit mask. */
+    XXH_FORCE_VECTOR_REG(top);
+
+    topLoBotLo = _mm_mul_epu32(top, botLo);
+    topLoBotHi = _mm_mul_epu32(top, botHi);
+    top = _mm_srli_epi64(top, 32);
+    topHiBotLo = _mm_mul_epu32(top, botLo);
+    returnval = _mm_add_epi64(topHiBotLo, topLoBotHi);
+    returnval = _mm_slli_epi64(returnval, 32);
+    returnval = _mm_add_epi64(returnval, topLoBotLo);
+    return returnval;
+}
+
+#define XXH_vec_rotl64(val,amt) (_mm_or_si128(_mm_slli_epi64(val, amt), _mm_srli_epi64(val, 64 - amt)))
+XXH_ALIGN_16 static const U64 STATE1[2] = { PRIME64_1 + PRIME64_2, PRIME64_2 };
+XXH_ALIGN_16 static const U64 STATE2[2] = { 0, -PRIME64_1 };
+
+
+/* Only intrinsics here! */
+FORCE_INLINE const BYTE* XXH64_SSE2(const BYTE* p, const BYTE* const limit,
+                                    const U64 seed, U64 *h64)
+{
+    /* Interleave our constants. */
+    const __m128i prime1_low = _mm_set1_epi64x(PRIME64_1);
+    const __m128i prime1_high = _mm_set1_epi64x(PRIME64_1 >> 32);
+    const __m128i prime2_low = _mm_set1_epi64x(PRIME64_2);
+    const __m128i prime2_high = _mm_set1_epi64x(PRIME64_2 >> 32);
+    const __m128i seed_vec = _mm_set1_epi64x(seed);
+    XXH_ALIGN_16 U64 state[2][2];
+    XXH_ALIGN_16 __m128i v[2];
+
+    v[0] = _mm_load_si128((const __m128i*)STATE1);
+    v[1] = _mm_load_si128((const __m128i*)STATE2);
+    v[0] = _mm_add_epi64(v[0], seed_vec);
+    v[1] = _mm_add_epi64(v[1], seed_vec);
+
+    if (XXH_FORCE_ALIGN_CHECK && (((size_t)p & 15) == 0)) {
+        do {
+            __m128i val = _mm_load_si128((const __m128i*)XXH_assume_aligned(p, 16));
+            val = XXH_U64x2_mult(val, prime2_high, prime2_low);
+            v[0] = _mm_add_epi64(v[0], val);
+            v[0] = XXH_vec_rotl64(v[0], 31); /* rotl */
+            v[0] = XXH_U64x2_mult(v[0], prime1_high, prime1_low);
+            p += 16;
+
+            val = _mm_load_si128((const __m128i*)XXH_assume_aligned(p, 16));
+            val = XXH_U64x2_mult(val, prime2_high, prime2_low);
+            v[1] = _mm_add_epi64(v[1], val);
+            v[1] = XXH_vec_rotl64(v[1], 31); /* rotl */
+            v[1] = XXH_U64x2_mult(v[1], prime1_high, prime1_low);
+            p += 16;
+        } while (p < limit);
+    } else {
+        do {
+            __m128i val = _mm_loadu_si128((const __m128i*)p);
+            val = XXH_U64x2_mult(val, prime2_high, prime2_low);
+            v[0] = _mm_add_epi64(v[0], val);
+            v[0] = XXH_vec_rotl64(v[0], 31);
+            v[0] = XXH_U64x2_mult(v[0], prime1_high, prime1_low);
+            p += 16;
+
+            val = _mm_loadu_si128((const __m128i*)p);
+            val = XXH_U64x2_mult(val, prime2_high, prime2_low);
+            v[1] = _mm_add_epi64(v[1], val);
+            v[1] = XXH_vec_rotl64(v[1], 31);
+            v[1] = XXH_U64x2_mult(v[1], prime1_high, prime1_low);
+            p += 16;
+        } while (p < limit);
+    }
+    _mm_store_si128((__m128i*)state[0], v[0]);
+    _mm_store_si128((__m128i*)state[1], v[1]);
+
+    /* SSE2's _mm_sll_epi64 is stupid.
+     * In order to have two shift values, you either need to do a lot of shuffling,
+     * or you must use AVX2 for _mm_sllv_epi64. */
+    *h64 = XXH_rotl64(state[0][0],  1) + XXH_rotl64(state[0][1],  7)
+         + XXH_rotl64(state[1][0], 12) + XXH_rotl64(state[1][1], 18);
+
+    /* XXH64_mergeLane */
+    /* We perform rounds in XXH64_mergeLane. It is faster to do this now.
+     * If we do this later, we might have to reload the primes. */
+    v[0] = XXH_U64x2_mult(v[0], prime2_high, prime2_low);
+    v[1] = XXH_U64x2_mult(v[1], prime2_high, prime2_low);
+
+    v[0]  = XXH_vec_rotl64(v[0], 31);
+    v[1]  = XXH_vec_rotl64(v[1], 31);
+
+    v[0] = XXH_U64x2_mult(v[0], prime1_high, prime1_low);
+    v[1] = XXH_U64x2_mult(v[1], prime1_high, prime1_low);
+
+    _mm_store_si128((__m128i*)state[0], v[0]);
+    *h64 ^= state[0][0];
+    *h64 = *h64 * PRIME64_1 + PRIME64_4;
+    *h64 ^= state[0][1];
+    *h64 = *h64 * PRIME64_1 + PRIME64_4;
+
+    _mm_store_si128((__m128i*)state[1], v[1]);
+    *h64 ^= state[1][0];
+    *h64 = *h64 * PRIME64_1 + PRIME64_4;
+    *h64 ^= state[1][1];
+    *h64 = *h64 * PRIME64_1 + PRIME64_4;
+    return p;
+}
+#endif
 
 #endif /* XXHASH_VEC_H */

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -197,7 +197,7 @@ public:
 	 * Thankfully, this is doable with the pmuludq instruction (MultLow), which multiplies
 	 * a 64-bit vector by a 32-bit value.
 	 *
-	 * This is based on Clang's output. 
+	 * This is based on Clang's output.
 	 *
 	 * Unfortunately, there is no such thing for NEON, and this is slower than 64-bit math
 	 * on x86_64. */

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -1,0 +1,194 @@
+/*
+*  xxHash - Fast Hash algorithm
+*  Copyright (C) 2012-2016, Yann Collet
+*
+*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are
+*  met:
+*
+*  * Redistributions of source code must retain the above copyright
+*  notice, this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above
+*  copyright notice, this list of conditions and the following disclaimer
+*  in the documentation and/or other materials provided with the
+*  distribution.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*  You can contact the author at :
+*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+#ifndef XXHASH_VEC_H
+#define XXHASH_VEC_H
+
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
+#  include <arm_neon.h>
+#  define XXH_NEON
+#  define XXH_VECTORIZE 1
+typedef uint32x4_t U32x4;
+typedef uint32x4x2_t U32x4x2;
+
+/* Neither GCC or Clang can properly optimize the generic version
+ * for Arm NEON.
+ * Instead of the optimal version, which is this:
+ *      vshr.u32        q9, q8, #19
+ *      vsli.32         q9, q8, #13
+ * GCC and Clang will produce this slower version:
+ *      vshr.u32        q9, q8, #19
+ *      vshl.i32        q8, q8, #13
+ *      vorr            q8, q8, q9
+ * This is much faster, and I think a few intrinsics are acceptable. */
+#define XXH_vec_rotl32(x, r) vsliq_n_u32(vshrq_n_u32((x), 32 - (r)), (x), (r))
+#define XXH_vec_load_unaligned(p) vld1q_u32((const U32*)p)
+#define XXH_vec_store_unaligned(p, v) vst1q_u32((U32*)p, v)
+#define XXH_vec_load_unaligned(p) vld1q_u32((const U32*)p)
+#define XXH_vec_store_unaligned(p, v) vst1q_u32((U32*)p, v)
+
+ /* Like XXH_vec_rotl32, but takes a vector as r. No NEON-optimized
+  * version for this one. */
+FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
+{
+	const U32x4 v32 = { 32, 32, 32, 32 };
+	return (x << r) | (x >> (v32 - r));
+}
+
+#elif (XXH_GCC_VERSION >= 407 || defined(__clang__)) \
+	&& (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_X64) || defined(_M_IX86_FP))
+
+/* not NEON */
+/* __m128i (SSE) or uint32x4_t (NEON). */
+typedef U32 U32x4 __attribute__((__vector_size__(16)));
+
+/* Two U32x4s. */
+typedef struct { U32x4 val[2]; } U32x4x2;
+
+/* Clang < 5.0 doesn't support int -> vector conversions.
+ * Yuck. */
+FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4 x, U32 r)
+{
+	const U32x4 left = { r, r, r, r };
+	const U32x4 right = {
+		32 - r,
+		32 - r,
+		32 - r,
+		32 - r
+	};
+	return (x << left) | (x >> right);
+}
+
+/* emmintrin.h's _mm_loadu_si128 code. */
+FORCE_INLINE U32x4 XXH_vec_load_unaligned(const void* p)
+{
+	struct loader {
+		U32x4 v;
+	} __attribute__((__packed__, __may_alias__));
+	return ((const struct loader*)p)->v;
+}
+
+/* _mm_storeu_si128 */
+FORCE_INLINE void XXH_vec_store_unaligned(void* p, const U32x4 v)
+{
+	struct loader {
+		U32x4 v;
+	} __attribute__((__packed__, __may_alias__));
+	((struct loader*)p)->v = v;
+}
+
+#define XXH_vec_load_aligned(p) *(U32x4*)(p)
+#define XXH_vec_store_aligned(p, v) (*(U32x4*)(p) = v)
+
+/* This catches MSVC++ if supplied /TP, and hopefully ICC. */
+#elif defined(__cplusplus) && (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_X64) || defined(_M_IX86_FP))
+#define XXH_VECTORIZE 1
+#include <smmintrin.h>
+
+/* A very simple wrapper around __m128i */
+struct U32x4 {
+private:
+	__m128i value;
+public:
+	inline U32x4() {}
+
+	inline U32x4(U32 v1, U32 v2, U32 v3, U32 v4)
+		: value(_mm_set_epi32(v4, v3, v2, v1))
+	{
+	}
+
+	inline U32x4(const void* pointer)
+		: value(_mm_loadu_si128(reinterpret_cast<const __m128i*>(pointer)))
+	{
+	}
+	inline U32x4(const U32 v)
+		: value(_mm_set1_epi32(v))
+	{
+	}
+	inline operator __m128i() const
+	{
+		return value;
+	}
+
+/* Defining the operators is slow and tedious. */
+#define OP(intrinsic, op1, op2, type) \
+    inline U32x4& operator op1(type rhs) \
+    { \
+	    value = intrinsic(value, rhs); \
+	    return *this; \
+    } \
+    inline friend U32x4& operator op2(U32x4 lhs, type rhs) \
+    { \
+	    lhs op1 rhs; \
+	    return lhs; \
+    }
+
+	OP(_mm_add_epi32, +=, +, const U32x4&)
+	OP(_mm_mullo_epi32, *=, *, const U32x4&)
+	OP(_mm_or_si128, |=, |, const U32x4&)
+	OP(_mm_slli_epi32, <<=, <<, int)
+	OP(_mm_srli_epi32, >>=, >>, int)
+
+#undef OP
+	inline void store(U32 *out) const
+	{
+		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
+	}
+};
+FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4& lhs, int bits)
+{
+	return (lhs << bits) | (lhs >> (32 - bits));
+}
+
+FORCE_INLINE U32x4 XXH_vec_load_unaligned(const void* data)
+{
+	return U32x4(data);
+}
+
+FORCE_INLINE void XXH_vec_store_unaligned(U32* store, const U32x4 data)
+{
+	data.store(store);
+}
+
+struct U32x4x2
+{
+	U32x4 val[2];
+
+	U32x4x2() {}
+	U32x4x2(U32x4 v1, U32x4 v2) : val { v1, v2 } {}
+};
+
+#endif /* C++/SSE4.1 */
+
+#endif /* XXHASH_VEC_H */

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -36,9 +36,11 @@
 #define XXHASH_VEC_H
 
 #if defined(__ARM_NEON__) || defined(__ARM_NEON)
-#  include <arm_neon.h>
-#  define XXH_NEON
-#  define XXH_VECTORIZE 1
+#include <arm_neon.h>
+#define XXH_NEON
+#undef XXH_VECTORIZE
+#define XXH_VECTORIZE 1
+
 typedef uint32x4_t U32x4;
 typedef uint32x4x2_t U32x4x2;
 
@@ -68,7 +70,8 @@ FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
 
 #elif (XXH_GCC_VERSION >= 407 || defined(__clang__)) \
 	&& (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_X64) || defined(_M_IX86_FP))
-
+#undef XXH_VECTORIZE
+#define XXH_VECTORIZE 1
 /* not NEON */
 /* __m128i (SSE) or uint32x4_t (NEON). */
 typedef U32 U32x4 __attribute__((__vector_size__(16)));
@@ -113,6 +116,7 @@ FORCE_INLINE void XXH_vec_store_unaligned(void* p, const U32x4 v)
 
 /* This catches MSVC++ if supplied /TP, and hopefully ICC. */
 #elif defined(__cplusplus) && (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_X64) || defined(_M_IX86_FP))
+#undef XXH_VECTORIZE
 #define XXH_VECTORIZE 1
 #include <smmintrin.h>
 

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -68,8 +68,8 @@ typedef uint64x2_t U64x2;
   * version for this one. */
 FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
 {
-	const U32x4 v32 = { 32, 32, 32, 32 };
-	return (x << r) | (x >> (v32 - r));
+    const U32x4 v32 = { 32, 32, 32, 32 };
+    return (x << r) | (x >> (v32 - r));
 }
 
 /* This catches MSVC++ if supplied /TP, and hopefully ICC.
@@ -84,185 +84,185 @@ FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
 /* A very simple wrapper around __m128i */
 struct U32x4 {
 private:
-	__m128i value;
+    __m128i value;
 public:
-	inline U32x4() {}
-	inline U32x4(U32 v1, U32 v2, U32 v3, U32 v4)
-		: value(_mm_set_epi32(v4, v3, v2, v1))
-	{
-	}
-	inline U32x4(__m128i v) : value(v) {}
-	explicit inline U32x4(const __m128i* pointer)
-		: value(_mm_loadu_si128(pointer))
-	{
-	}
-	inline U32x4(const U32 v)
-		: value(_mm_set1_epi32(v))
-	{
-	}
-	inline operator __m128i() const
-	{
-		return value;
-	}
-	inline U32 operator[](size_t pos)
-	{
-		switch (pos & 3) {
-		case 0: return _mm_extract_epi32(value, 0);
-		case 1: return _mm_extract_epi32(value, 1);
-		case 2: return _mm_extract_epi32(value, 2);
-		default: return _mm_extract_epi32(value, 3);
-		}
-	}
-	/* Defining the operators is slow and tedious. */
+    inline U32x4() {}
+    inline U32x4(U32 v1, U32 v2, U32 v3, U32 v4)
+        : value(_mm_set_epi32(v4, v3, v2, v1))
+    {
+    }
+    inline U32x4(__m128i v) : value(v) {}
+    explicit inline U32x4(const __m128i* pointer)
+        : value(_mm_loadu_si128(pointer))
+    {
+    }
+    inline U32x4(const U32 v)
+        : value(_mm_set1_epi32(v))
+    {
+    }
+    inline operator __m128i() const
+    {
+        return value;
+    }
+    inline U32 operator[](size_t pos)
+    {
+        switch (pos & 3) {
+        case 0: return _mm_extract_epi32(value, 0);
+        case 1: return _mm_extract_epi32(value, 1);
+        case 2: return _mm_extract_epi32(value, 2);
+        default: return _mm_extract_epi32(value, 3);
+        }
+    }
+    /* Defining the operators is slow and tedious. */
 #define OP(intrinsic, op1, op2, type) \
     inline U32x4& operator op1(type rhs) \
     { \
-	    this->value = intrinsic(this->value, rhs); \
-	    return *this; \
+        this->value = intrinsic(this->value, rhs); \
+        return *this; \
     } \
     inline friend U32x4 operator op2(U32x4 lhs, type rhs) \
     { \
-	    U32x4 tmp = intrinsic(lhs.value, rhs); \
-	    return tmp; \
+        U32x4 tmp = intrinsic(lhs.value, rhs); \
+        return tmp; \
     }
 
-	OP(_mm_add_epi32, +=, +, const U32x4)
-	OP(_mm_mullo_epi32, *=, *, const U32x4)
-	OP(_mm_or_si128, |=, | , const U32x4)
+    OP(_mm_add_epi32, +=, +, const U32x4)
+    OP(_mm_mullo_epi32, *=, *, const U32x4)
+    OP(_mm_or_si128, |=, | , const U32x4)
 
-	OP(_mm_slli_epi32, <<=, << , int)
-	OP(_mm_srli_epi32, >>=, >> , int)
+    OP(_mm_slli_epi32, <<=, << , int)
+    OP(_mm_srli_epi32, >>=, >> , int)
 #undef OP
-	inline void store(U32 *out) const
-	{
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
-	}
+    inline void store(U32 *out) const
+    {
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
+    }
 };
 #ifndef XXH_NO_LONG_LONG
 struct U64x2 {
 private:
-	__m128i value;
+    __m128i value;
 
 public:
-	inline U64x2() {}
-	inline U64x2(U64 v1, U64 v2)
-		: value(_mm_set_epi64x(v2, v1))
-	{
-	}
-	inline U64x2(__m128i v) : value(v) {}
-	explicit inline U64x2(const __m128i* pointer)
-		: value(_mm_loadu_si128(pointer))
-	{
-	}
-	inline U64x2(const U64 v)
-		: value(_mm_set1_epi64x(v))
-	{
-	}
-	inline operator __m128i() const
-	{
-		return value;
-	}
+    inline U64x2() {}
+    inline U64x2(U64 v1, U64 v2)
+        : value(_mm_set_epi64x(v2, v1))
+    {
+    }
+    inline U64x2(__m128i v) : value(v) {}
+    explicit inline U64x2(const __m128i* pointer)
+        : value(_mm_loadu_si128(pointer))
+    {
+    }
+    inline U64x2(const U64 v)
+        : value(_mm_set1_epi64x(v))
+    {
+    }
+    inline operator __m128i() const
+    {
+        return value;
+    }
 
-	/* Defining the operators is slow and tedious. */
+    /* Defining the operators is slow and tedious. */
 #define OP(intrinsic, op1, op2, type) \
     inline U64x2& operator op1(type rhs) \
     { \
-	    value = intrinsic(value, rhs); \
-	    return *this; \
+        value = intrinsic(value, rhs); \
+        return *this; \
     } \
     inline friend U64x2 operator op2(U64x2 lhs, type rhs) \
     { \
-	    U64x2 tmp = intrinsic(lhs.value, rhs); \
-	    return tmp; \
+        U64x2 tmp = intrinsic(lhs.value, rhs); \
+        return tmp; \
     }
 
-	OP(_mm_add_epi64, +=, +, const U64x2)
-	OP(_mm_or_si128, |=, | , const U64x2)
+    OP(_mm_add_epi64, +=, +, const U64x2)
+    OP(_mm_or_si128, |=, | , const U64x2)
 
-	OP(_mm_slli_epi64, <<=, << , int)
-	OP(_mm_srli_epi64, >>=, >> , int)
+    OP(_mm_slli_epi64, <<=, << , int)
+    OP(_mm_srli_epi64, >>=, >> , int)
 
 #undef OP
-	/* *this *= val & 0xFFFFFFFF */
-	inline U64x2& MultLow(const U64x2 val)
-	{
-		value = _mm_mul_epu32(value, val);
-		return *this;
-	}
-	inline U64x2 MultLow(U64x2 lhs, const U64x2 rhs)
-	{
-		lhs.MultLow(rhs);
-		return lhs;
-	}
-	/* Multiplication is more complex. There isn't a simple U64x2 * U64x2 instruction,
-	 * we have to do this manually.
-	 * Thankfully, this is doable with the pmuludq instruction (MultLow), which multiplies
-	 * a 64-bit vector by a 32-bit value.
-	 *
-	 * This is based on Clang's output.
-	 *
-	 * Unfortunately, there is no such thing for NEON, and this is slower than 64-bit math
-	 * on x86_64. */
-	inline U64x2& operator *=(const U64 rhs)
-	{
-		const U64 dup[2] = { rhs, rhs };
-		/* we could do (U64[2]) { rhs >> 32, rhs >> 32 }, but it slows down. */
-		const U32 high[4] = { rhs >> 32, 0, rhs >> 32, 0 };
+    /* *this *= val & 0xFFFFFFFF */
+    inline U64x2& MultLow(const U64x2 val)
+    {
+        value = _mm_mul_epu32(value, val);
+        return *this;
+    }
+    inline U64x2 MultLow(U64x2 lhs, const U64x2 rhs)
+    {
+        lhs.MultLow(rhs);
+        return lhs;
+    }
+    /* Multiplication is more complex. There isn't a simple U64x2 * U64x2 instruction,
+     * we have to do this manually.
+     * Thankfully, this is doable with the pmuludq instruction (MultLow), which multiplies
+     * a 64-bit vector by a 32-bit value.
+     *
+     * This is based on Clang's output.
+     *
+     * Unfortunately, there is no such thing for NEON, and this is slower than 64-bit math
+     * on x86_64. */
+    inline U64x2& operator *=(const U64 rhs)
+    {
+        const U64 dup[2] = { rhs, rhs };
+        /* we could do (U64[2]) { rhs >> 32, rhs >> 32 }, but it slows down. */
+        const U32 high[4] = { rhs >> 32, 0, rhs >> 32, 0 };
 
-		U64x2 xmm1(reinterpret_cast<const __m128i*>(dup));
-		U64x2 xmm2 = value;
-		U64x2 xmm3 = value;
-		U64x2 xmm0 = MultLow(*this, U64x2(reinterpret_cast<const __m128i*>(high)));
-		xmm3 >>= 32;
-		xmm3.MultLow(xmm1);
-		xmm2.MultLow(xmm1);
-		xmm0 += xmm3;
-		xmm0 <<= 32;
-		value = xmm0 + xmm2;
-		return *this;
-	}
-	inline friend U64x2 operator *(U64x2 lhs, const U64 rhs)
-	{
-		lhs *= rhs;
-		return lhs;
-	}
+        U64x2 xmm1(reinterpret_cast<const __m128i*>(dup));
+        U64x2 xmm2 = value;
+        U64x2 xmm3 = value;
+        U64x2 xmm0 = MultLow(*this, U64x2(reinterpret_cast<const __m128i*>(high)));
+        xmm3 >>= 32;
+        xmm3.MultLow(xmm1);
+        xmm2.MultLow(xmm1);
+        xmm0 += xmm3;
+        xmm0 <<= 32;
+        value = xmm0 + xmm2;
+        return *this;
+    }
+    inline friend U64x2 operator *(U64x2 lhs, const U64 rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
 
-	inline void store(U64 *out) const
-	{
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
-	}
+    inline void store(U64 *out) const
+    {
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
+    }
 };
 #endif /* !XXH_NO_LONG_LONG */
 FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4 lhs, int bits)
 {
-	return (lhs << bits) | (lhs >> (32 - bits));
+    return (lhs << bits) | (lhs >> (32 - bits));
 }
 
 FORCE_INLINE U32x4 XXH_vec_load_unaligned(const BYTE* data)
 {
-	U32x4 val(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data)));
-	return val;
+    U32x4 val(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data)));
+    return val;
 }
 
 FORCE_INLINE U32x4 XXH_vec_load_unaligned(const U32* data)
 {
-	return U32x4(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data)));
+    return U32x4(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data)));
 }
 
 FORCE_INLINE void XXH_vec_store_unaligned(U32* store, const U32x4 data)
 {
-	data.store(store);
+    data.store(store);
 }
 
 struct U32x4x2
 {
-	U32x4 val[2];
+    U32x4 val[2];
 
-	U32x4x2() {}
-	U32x4x2(U32x4 v1, U32x4 v2) : val{ v1, v2 } {}
+    U32x4x2() {}
+    U32x4x2(U32x4 v1, U32x4 v2) : val{ v1, v2 } {}
 };
 #elif (XXH_GCC_VERSION >= 407 || defined(__clang__)) \
-	&& (defined(__SSE4_1__) || defined(__AVX__))
+    && (defined(__SSE4_1__) || defined(__AVX__))
 #undef XXH_VECTORIZE
 #define XXH_VECTORIZE 1
 /* not NEON */
@@ -281,32 +281,32 @@ typedef U64 U64x2 __attribute__((__vector_size__(16)));
  * Yuck. */
 FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4 x, U32 r)
 {
-	const U32x4 left = { r, r, r, r };
-	const U32x4 right = {
-		32 - r,
-		32 - r,
-		32 - r,
-		32 - r
-	};
-	return (x << left) | (x >> right);
+    const U32x4 left = { r, r, r, r };
+    const U32x4 right = {
+        32 - r,
+        32 - r,
+        32 - r,
+        32 - r
+    };
+    return (x << left) | (x >> right);
 }
 
 /* emmintrin.h's _mm_loadu_si128 code. */
 FORCE_INLINE U32x4 XXH_vec_load_unaligned(const void* p)
 {
-	struct loader {
-		U32x4 v;
-	} __attribute__((__packed__, __may_alias__));
-	return ((const struct loader*)p)->v;
+    struct loader {
+        U32x4 v;
+    } __attribute__((__packed__, __may_alias__));
+    return ((const struct loader*)p)->v;
 }
 
 /* _mm_storeu_si128 */
 FORCE_INLINE void XXH_vec_store_unaligned(void* p, const U32x4 v)
 {
-	struct loader {
-		U32x4 v;
-	} __attribute__((__packed__, __may_alias__));
-	((struct loader*)p)->v = v;
+    struct loader {
+        U32x4 v;
+    } __attribute__((__packed__, __may_alias__));
+    ((struct loader*)p)->v = v;
 }
 
 #define XXH_vec_load_aligned(p) *(U32x4*)(p)

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -282,7 +282,7 @@ FORCE_INLINE const BYTE* XXH64_NEON32(const BYTE* p, const BYTE* limit,
     return p;
 }
 
-FORCE_INLNE const BYTE* XXH64_update_NEON32(const BYTE* p, const BYTE* limit, U64 state[2][2])
+FORCE_INLINE const BYTE* XXH64_update_NEON32(const BYTE* p, const BYTE* limit, U64 state[2][2])
 {
     const U64 PRIME1[2] = { PRIME64_1, PRIME64_1 };
     const U64 PRIME2[2] = { PRIME64_2, PRIME64_2 };

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -69,7 +69,7 @@ FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
 }
 
 #elif (XXH_GCC_VERSION >= 407 || defined(__clang__)) \
-	&& (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_IX86_FP))
+	&& (defined(__SSE4_1__) || defined(__AVX__))
 #undef XXH_VECTORIZE
 #define XXH_VECTORIZE 1
 /* not NEON */
@@ -115,7 +115,7 @@ FORCE_INLINE void XXH_vec_store_unaligned(void* p, const U32x4 v)
 #define XXH_vec_store_aligned(p, v) (*(U32x4*)(p) = v)
 
 /* This catches MSVC++ if supplied /TP, and hopefully ICC. */
-#elif defined(__cplusplus) && (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_X64) || defined(_M_IX86_FP))
+#elif defined(__cplusplus) && (defined(__SSE4_1__) || defined(__AVX__))
 #undef XXH_VECTORIZE
 #define XXH_VECTORIZE 1
 #include <smmintrin.h>

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -69,7 +69,7 @@ FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
 }
 
 #elif (XXH_GCC_VERSION >= 407 || defined(__clang__)) \
-	&& (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_X64) || defined(_M_IX86_FP))
+	&& (defined(__SSE4_1__) || defined(__AVX__) || defined(_M_IX86_FP))
 #undef XXH_VECTORIZE
 #define XXH_VECTORIZE 1
 /* not NEON */

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -43,8 +43,10 @@
 
 typedef uint32x4_t U32x4;
 typedef uint32x4x2_t U32x4x2;
-typedef uint64x2_t U64x2;
 
+#ifndef XXH_NO_LONG_LONG
+typedef uint64x2_t U64x2;
+#endif
 
 /* Neither GCC or Clang can properly optimize the generic version
  * for Arm NEON.
@@ -136,10 +138,10 @@ public:
 		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
 	}
 };
+#ifndef XXH_NO_LONG_LONG
 struct U64x2 {
 private:
 	__m128i value;
-	typedef uint64_t U64;
 
 public:
 	inline U64x2() {}
@@ -230,6 +232,7 @@ public:
 		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
 	}
 };
+#endif /* !XXH_NO_LONG_LONG */
 FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4 lhs, int bits)
 {
 	return (lhs << bits) | (lhs >> (32 - bits));
@@ -269,8 +272,10 @@ typedef U32 U32x4 __attribute__((__vector_size__(16)));
 /* Two U32x4s. */
 typedef struct { U32x4 val[2]; } U32x4x2;
 
+#ifndef XXH_NO_LONG_LONG
 /* Two U64s. */
 typedef U64 U64x2 __attribute__((__vector_size__(16)));
+#endif
 
 /* Clang < 5.0 doesn't support int -> vector conversions.
  * Yuck. */

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -192,7 +192,8 @@ struct U32x4x2
 	U32x4x2() {}
 	U32x4x2(U32x4 v1, U32x4 v2) : val { v1, v2 } {}
 };
-
+#elif !defined(XXH_VECTORIZE)
+#define XXH_VECTORIZE 0
 #endif /* C++/SSE4.1 */
 
 #endif /* XXHASH_VEC_H */

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -303,6 +303,7 @@ FORCE_INLNE const BYTE* XXH64_update_NEON32(const BYTE* p, const BYTE* limit, U6
     XXH64_VEC_LOOP
     return p;
 }
+#undef XXH64_VEC_LOOP
 
  /* Like XXH_vec_rotl32, but takes a vector as r. No NEON-optimized
   * version for this one. */

--- a/xxhash-vec.h
+++ b/xxhash-vec.h
@@ -43,6 +43,8 @@
 
 typedef uint32x4_t U32x4;
 typedef uint32x4x2_t U32x4x2;
+typedef uint64x2_t U64x2;
+
 
 /* Neither GCC or Clang can properly optimize the generic version
  * for Arm NEON.
@@ -68,6 +70,194 @@ FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
 	return (x << r) | (x >> (v32 - r));
 }
 
+/* This catches MSVC++ if supplied /TP, and hopefully ICC.
+ * g++ benefits here on 32-bit because it does not vectorize XXH64 properly. */
+#elif defined(__cplusplus) && !defined(__clang__) \
+  && (defined(__SSE4_1__) || defined(__AVX__))
+#undef XXH_VECTORIZE
+#define XXH_VECTORIZE 1
+#include <smmintrin.h>
+#include <stdio.h>
+#include <initializer_list>
+/* A very simple wrapper around __m128i */
+struct U32x4 {
+private:
+	__m128i value;
+public:
+	inline U32x4() {}
+	inline U32x4(U32 v1, U32 v2, U32 v3, U32 v4)
+		: value(_mm_set_epi32(v4, v3, v2, v1))
+	{
+	}
+	inline U32x4(__m128i v) : value(v) {}
+	explicit inline U32x4(const __m128i* pointer)
+		: value(_mm_loadu_si128(pointer))
+	{
+	}
+	inline U32x4(const U32 v)
+		: value(_mm_set1_epi32(v))
+	{
+	}
+	inline operator __m128i() const
+	{
+		return value;
+	}
+	inline U32 operator[](size_t pos)
+	{
+		switch (pos & 3) {
+		case 0: return _mm_extract_epi32(value, 0);
+		case 1: return _mm_extract_epi32(value, 1);
+		case 2: return _mm_extract_epi32(value, 2);
+		default: return _mm_extract_epi32(value, 3);
+		}
+	}
+	/* Defining the operators is slow and tedious. */
+#define OP(intrinsic, op1, op2, type) \
+    inline U32x4& operator op1(type rhs) \
+    { \
+	    this->value = intrinsic(this->value, rhs); \
+	    return *this; \
+    } \
+    inline friend U32x4 operator op2(U32x4 lhs, type rhs) \
+    { \
+	    U32x4 tmp = intrinsic(lhs.value, rhs); \
+	    return tmp; \
+    }
+
+	OP(_mm_add_epi32, +=, +, const U32x4)
+	OP(_mm_mullo_epi32, *=, *, const U32x4)
+	OP(_mm_or_si128, |=, | , const U32x4)
+
+	OP(_mm_slli_epi32, <<=, << , int)
+	OP(_mm_srli_epi32, >>=, >> , int)
+#undef OP
+	inline void store(U32 *out) const
+	{
+		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
+	}
+};
+struct U64x2 {
+private:
+	__m128i value;
+	typedef uint64_t U64;
+
+public:
+	inline U64x2() {}
+	inline U64x2(U64 v1, U64 v2)
+		: value(_mm_set_epi64x(v2, v1))
+	{
+	}
+	inline U64x2(__m128i v) : value(v) {}
+	explicit inline U64x2(const __m128i* pointer)
+		: value(_mm_loadu_si128(pointer))
+	{
+	}
+	inline U64x2(const U64 v)
+		: value(_mm_set1_epi64x(v))
+	{
+	}
+	inline operator __m128i() const
+	{
+		return value;
+	}
+
+	/* Defining the operators is slow and tedious. */
+#define OP(intrinsic, op1, op2, type) \
+    inline U64x2& operator op1(type rhs) \
+    { \
+	    value = intrinsic(value, rhs); \
+	    return *this; \
+    } \
+    inline friend U64x2 operator op2(U64x2 lhs, type rhs) \
+    { \
+	    U64x2 tmp = intrinsic(lhs.value, rhs); \
+	    return tmp; \
+    }
+
+	OP(_mm_add_epi64, +=, +, const U64x2)
+	OP(_mm_or_si128, |=, | , const U64x2)
+
+	OP(_mm_slli_epi64, <<=, << , int)
+	OP(_mm_srli_epi64, >>=, >> , int)
+
+#undef OP
+	/* *this *= val & 0xFFFFFFFF */
+	inline U64x2& MultLow(const U64x2 val)
+	{
+		value = _mm_mul_epu32(value, val);
+		return *this;
+	}
+	inline U64x2 MultLow(U64x2 lhs, const U64x2 rhs)
+	{
+		lhs.MultLow(rhs);
+		return lhs;
+	}
+	/* Multiplication is more complex. There isn't a simple U64x2 * U64x2 instruction,
+	 * we have to do this manually.
+	 * Thankfully, this is doable with the pmuludq instruction (MultLow), which multiplies
+	 * a 64-bit vector by a 32-bit value.
+	 *
+	 * This is based on Clang's output. 
+	 *
+	 * Unfortunately, there is no such thing for NEON, and this is slower than 64-bit math
+	 * on x86_64. */
+	inline U64x2& operator *=(const U64 rhs)
+	{
+		const U64 dup[2] = { rhs, rhs };
+		/* we could do (U64[2]) { rhs >> 32, rhs >> 32 }, but it slows down. */
+		const U32 high[4] = { rhs >> 32, 0, rhs >> 32, 0 };
+
+		U64x2 xmm1(reinterpret_cast<const __m128i*>(dup));
+		U64x2 xmm2 = value;
+		U64x2 xmm3 = value;
+		U64x2 xmm0 = MultLow(*this, U64x2(reinterpret_cast<const __m128i*>(high)));
+		xmm3 >>= 32;
+		xmm3.MultLow(xmm1);
+		xmm2.MultLow(xmm1);
+		xmm0 += xmm3;
+		xmm0 <<= 32;
+		value = xmm0 + xmm2;
+		return *this;
+	}
+	inline friend U64x2 operator *(U64x2 lhs, const U64 rhs)
+	{
+		lhs *= rhs;
+		return lhs;
+	}
+
+	inline void store(U64 *out) const
+	{
+		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
+	}
+};
+FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4 lhs, int bits)
+{
+	return (lhs << bits) | (lhs >> (32 - bits));
+}
+
+FORCE_INLINE U32x4 XXH_vec_load_unaligned(const BYTE* data)
+{
+	U32x4 val(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data)));
+	return val;
+}
+
+FORCE_INLINE U32x4 XXH_vec_load_unaligned(const U32* data)
+{
+	return U32x4(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data)));
+}
+
+FORCE_INLINE void XXH_vec_store_unaligned(U32* store, const U32x4 data)
+{
+	data.store(store);
+}
+
+struct U32x4x2
+{
+	U32x4 val[2];
+
+	U32x4x2() {}
+	U32x4x2(U32x4 v1, U32x4 v2) : val{ v1, v2 } {}
+};
 #elif (XXH_GCC_VERSION >= 407 || defined(__clang__)) \
 	&& (defined(__SSE4_1__) || defined(__AVX__))
 #undef XXH_VECTORIZE
@@ -78,6 +268,9 @@ typedef U32 U32x4 __attribute__((__vector_size__(16)));
 
 /* Two U32x4s. */
 typedef struct { U32x4 val[2]; } U32x4x2;
+
+/* Two U64s. */
+typedef U64 U64x2 __attribute__((__vector_size__(16)));
 
 /* Clang < 5.0 doesn't support int -> vector conversions.
  * Yuck. */
@@ -114,84 +307,6 @@ FORCE_INLINE void XXH_vec_store_unaligned(void* p, const U32x4 v)
 #define XXH_vec_load_aligned(p) *(U32x4*)(p)
 #define XXH_vec_store_aligned(p, v) (*(U32x4*)(p) = v)
 
-/* This catches MSVC++ if supplied /TP, and hopefully ICC. */
-#elif defined(__cplusplus) && (defined(__SSE4_1__) || defined(__AVX__))
-#undef XXH_VECTORIZE
-#define XXH_VECTORIZE 1
-#include <smmintrin.h>
-
-/* A very simple wrapper around __m128i */
-struct U32x4 {
-private:
-	__m128i value;
-public:
-	inline U32x4() {}
-
-	inline U32x4(U32 v1, U32 v2, U32 v3, U32 v4)
-		: value(_mm_set_epi32(v4, v3, v2, v1))
-	{
-	}
-
-	inline U32x4(const void* pointer)
-		: value(_mm_loadu_si128(reinterpret_cast<const __m128i*>(pointer)))
-	{
-	}
-	inline U32x4(const U32 v)
-		: value(_mm_set1_epi32(v))
-	{
-	}
-	inline operator __m128i() const
-	{
-		return value;
-	}
-
-/* Defining the operators is slow and tedious. */
-#define OP(intrinsic, op1, op2, type) \
-    inline U32x4& operator op1(type rhs) \
-    { \
-	    value = intrinsic(value, rhs); \
-	    return *this; \
-    } \
-    inline friend U32x4& operator op2(U32x4 lhs, type rhs) \
-    { \
-	    lhs op1 rhs; \
-	    return lhs; \
-    }
-
-	OP(_mm_add_epi32, +=, +, const U32x4&)
-	OP(_mm_mullo_epi32, *=, *, const U32x4&)
-	OP(_mm_or_si128, |=, |, const U32x4&)
-	OP(_mm_slli_epi32, <<=, <<, int)
-	OP(_mm_srli_epi32, >>=, >>, int)
-
-#undef OP
-	inline void store(U32 *out) const
-	{
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), value);
-	}
-};
-FORCE_INLINE U32x4 XXH_vec_rotl32(U32x4& lhs, int bits)
-{
-	return (lhs << bits) | (lhs >> (32 - bits));
-}
-
-FORCE_INLINE U32x4 XXH_vec_load_unaligned(const void* data)
-{
-	return U32x4(data);
-}
-
-FORCE_INLINE void XXH_vec_store_unaligned(U32* store, const U32x4 data)
-{
-	data.store(store);
-}
-
-struct U32x4x2
-{
-	U32x4 val[2];
-
-	U32x4x2() {}
-	U32x4x2(U32x4 v1, U32x4 v2) : val { v1, v2 } {}
-};
 #elif !defined(XXH_VECTORIZE)
 #define XXH_VECTORIZE 0
 #endif /* C++/SSE4.1 */

--- a/xxhash.c
+++ b/xxhash.c
@@ -135,6 +135,11 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
 #  endif /* __STDC_VERSION__ */
 #endif
 
+/* Clang's __has_builtin because checking clang versions is impossible,
+ * thank you Apple. */
+#ifndef __has_builtin
+#  define __has_builtin(x) 0
+#endif
 
 /* *************************************
 *  Basic Types
@@ -380,10 +385,6 @@ XXH32_finalize(U32 h32, const void* ptr, size_t len,
     return h32;   /* reaching this point is deemed impossible */
 }
 
-#ifndef __has_builtin
-#  define __has_builtin(x) 0
-#endif
-
 #ifndef XXH_VECTORIZE
 /* Clang and GCC 4.6+ can use vectorization properly.
  * Most importantly, shifting vectors. */
@@ -398,7 +399,7 @@ XXH32_finalize(U32 h32, const void* ptr, size_t len,
 
 #if XXH_VECTORIZE
 /* __m128i (SSE) or uint32x4_t (NEON). */
-typedef U32 U32x4 __attribute__((vector_size(16)));
+typedef U32 U32x4 __attribute__((__vector_size__(16)));
 /* Two U32x4s. */
 typedef struct { const U32x4 i[2]; } U32x4x2;
 
@@ -407,7 +408,7 @@ FORCE_INLINE U32x4 XXH32_load_unaligned(const U32x4* p)
 {
     struct loader {
         U32x4 v;
-    } __attribute__((packed, may_alias));
+    } __attribute__((__packed__, __may_alias__));
     return ((struct loader*)p)->v;
 }
 /* Same, but loads two vectors. */
@@ -415,7 +416,7 @@ FORCE_INLINE U32x4x2 XXH32_load_double_unaligned(const U32x4* p)
 {
     struct loader {
         U32x4x2 v;
-    } __attribute__((packed, may_alias));
+    } __attribute__((__packed__, __may_alias__));
     return ((struct loader*)p)->v;
 }
 
@@ -424,14 +425,26 @@ FORCE_INLINE void XXH32_store_unaligned(U32x4* p, const U32x4 v)
 {
     struct loader {
         U32x4 v;
-     } __attribute__((packed, may_alias));
+     } __attribute__((__packed__, __may_alias__));
     ((struct loader*)p)->v = v;
 }
 
-/*
- * Clang < 5.0 doesn't support int -> vector conversions.
- * Yuck.
- */
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
+#include <arm_neon.h>
+/* Neither GCC or Clang can properly optimize the generic version
+ * for Arm NEON.
+ * Instead of the optimal version, which is this:
+ *      vshr.u32        q9, q8, #19
+ *      vsli.32         q9, q8, #13
+ * GCC and Clang will produce this slower version:
+ *      vshr.u32        q9, q8, #19
+ *      vshl.i32        q8, q8, #13
+ *      vorr            q8, q8, q9
+ * This is much faster, and I think one intrinsic is acceptable. */
+#define XXH_rotlvec32(x, r) vsliq_n_u32(vshr_n_u32((x), 32 - (r)), (x), (r))
+#else /* not NEON */
+/* Clang < 5.0 doesn't support int -> vector conversions.
+ * Yuck. */
 FORCE_INLINE U32x4 XXH_rotlvec32(U32x4 x, U32 r)
 {
     const U32x4 left = { r, r, r, r };
@@ -441,7 +454,15 @@ FORCE_INLINE U32x4 XXH_rotlvec32(U32x4 x, U32 r)
         32 - r,
         32 - r
     };
-    return (x << right) | (x >> left);
+    return (x << left) | (x >> right);
+}
+#endif /* not NEON */
+/* Like XXH_rotlvec32, but takes a vector as r. No NEON-optimized
+ * version for this one. */
+FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
+{
+    const U32x4 v32 = { 32, 32, 32, 32 };
+    return (x << r) | (x >> (v32 - r));
 }
 #endif
 
@@ -462,7 +483,14 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
 
 /* SIMD-optimized code */
 #if XXH_VECTORIZE
+/* x86 slows down significantly on unaligned reads with SSE4.1 instructions.
+ * On x86, we want to only do SIMD on aligned pointers.
+ * NEON prefers unaligned reads, so we always use SIMD. */
+#ifdef __SSE4_1__
+    if (len>=32 && align == XXH_aligned) {
+#else
     if (len>=32) {
+#endif
         const BYTE* const limit = bEnd - 31;
         U32 vx1[4] = {
             seed + PRIME32_1 + PRIME32_2,
@@ -474,7 +502,7 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
             XXH32_load_unaligned((const U32x4*)vx1),
             XXH32_load_unaligned((const U32x4*)vx1)
         };
-        const U32x4 prime1 = { PRIME32_2, PRIME32_1, PRIME32_1, PRIME32_1 };
+        const U32x4 prime1 = { PRIME32_1, PRIME32_1, PRIME32_1, PRIME32_1 };
         const U32x4 prime2 = { PRIME32_2, PRIME32_2, PRIME32_2, PRIME32_2 };
 
         /* https://moinakg.wordpress.com/2013/01/19/vectorizing-xxhash-for-fun-and-profit/
@@ -482,7 +510,7 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
          * performance. It produces a different hash, though. */
 
         /* Aligned reads are faster. We want a 16-byte align. */
-        if (((size_t)p & 15) == 0) {
+        if (((size_t)p&15) == 0) {
 
 #if XXH_GCC_VERSION >= 407 || __has_builtin(__builtin_assume_aligned)
             /* GCC/Clang builtin that tells the compiler that this will be aligned. */
@@ -528,11 +556,18 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
         v[0] += v[1] * prime2;
         v[0]  = XXH_rotlvec32(v[0], 13);
         v[0] *= prime1;
+
+        {
+            const U32x4 r = { 1, 7, 12, 18 };
+            v[0] = XXH_rotlvec_vec32(v[0], r);
+        }
+
         XXH32_store_unaligned((U32x4 *)vx1, v[0]);
 
-        h32 = XXH_rotl32(vx1[0], 1) + XXH_rotl32(vx1[1], 7) + XXH_rotl32(vx1[2], 12) + XXH_rotl32(vx1[3], 18);
-    }
-#else /* no SIMD */
+        h32 = vx1[0] + vx1[1] + vx1[2] + vx1[3];
+    } else
+#endif
+#if !XXH_VECTORIZE || defined(__SSE4_1__) /* no SIMD or x86 */
     if (len>=32) {
         const BYTE* const limit = bEnd - 31;
         U32 v1 = seed + PRIME32_1 + PRIME32_2;
@@ -563,15 +598,15 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
         v4 = XXH32_round(v4, v4A);
         h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
             + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
-    }
+    } else
 #endif
-    else {
+    {
         h32  = seed + PRIME32_5;
     }
 
     h32 += (U32)len;
 
-    return XXH32_finalize(h32, p, len&15, endian, align);
+    return XXH32_finalize(h32, p, len&31, endian, align);
 }
 
 
@@ -992,23 +1027,7 @@ XXH64_finalize(U64 h64, const void* ptr, size_t len,
     assert(0);
     return 0;  /* unreachable, but some compilers complain without it */
 }
-#if XXH_VECTORIZE
-typedef U64 U64x2 __attribute__((vector_size(16)));
-FORCE_INLINE U64x2 XXH64_load_unaligned(const U64x2 *p)
-{
-    struct loader {
-        U64x2 v;
-    } __attribute__((__packed__, __may_alias__));
-    return ((struct loader*)p)->v;
-}
-FORCE_INLINE void XXH64_store_unaligned(U64x2 *p, const U64x2 v)
-{
-    struct loader {
-        U64x2 v;
-    } __attribute__((__packed__, __may_alias__));
-    ((struct loader*)p)->v = v;
-}
-#endif
+
 FORCE_INLINE U64
 XXH64_endian_align(const void* input, size_t len, U64 seed,
                 XXH_endianess endian, XXH_alignment align)
@@ -1023,7 +1042,6 @@ XXH64_endian_align(const void* input, size_t len, U64 seed,
         bEnd=p=(const BYTE*)(size_t)32;
     }
 #endif
-#if 1
     if (len>=32) {
         const BYTE* const limit = bEnd - 32;
         U64 v1 = seed + PRIME64_1 + PRIME64_2;
@@ -1044,66 +1062,7 @@ XXH64_endian_align(const void* input, size_t len, U64 seed,
         h64 = XXH64_mergeRound(h64, v2);
         h64 = XXH64_mergeRound(h64, v3);
         h64 = XXH64_mergeRound(h64, v4);
-    }
-#else
-    /* Not complete yet. Needs a lot of work. */
-    if (len>=32) {
-        const BYTE* const limit = bEnd - 63;
-        /* We use two individual vectors because most computers only
-         * have 128 bits. */
-        U64 vx1[2] = {
-            PRIME64_1 + PRIME64_2,
-            PRIME64_2
-        };
-        U64 vx2[2] = {
-            0,
-            -PRIME64_1
-        };
-        U64x2 v1 = XXH64_load_unaligned((const U64x2 *)vx1);
-        U64x2 v2 = XXH64_load_unaligned((const U64x2 *)vx2);
-
-        v1 += seed;
-        v2 += seed;
-        if ((size_t)p & 31) {
-            do {
-                U64x2 inp1 = XXH64_load_unaligned((const U64x2 *)p);
-                U64x2 inp2 = XXH64_load_unaligned((const U64x2 *)(p + 16));
-                v1 += inp1 * PRIME64_2;
-                v2 += inp2 * PRIME64_2;
-                v1  = XXH_rotl64(v1, 31);
-                v2  = XXH_rotl64(v2, 31);
-                v1 *= PRIME64_1;
-                v2 *= PRIME64_1;
-
-                p += 32;
-            } while (p < limit);
-        } else {
-            const U64x2 *p_quad = __builtin_assume_aligned(p, 32);
-            do {
-                U64x2 inp1 = *p_quad;
-                U64x2 inp2 = *(p_quad + 1);
-                v1 += inp1 * PRIME64_2;
-                v2 += inp2 * PRIME64_2;
-                v1  = XXH_rotl64(v1, 31);
-                v2  = XXH_rotl64(v2, 31);
-                v1 *= PRIME64_1;
-                v2 *= PRIME64_1;
-                p_quad += 2;
-            } while ((const BYTE *)p_quad < limit);
-            p = (const BYTE *) p_quad;
-        }
-
-        XXH64_store_unaligned((U64x2 *)vx1, v1);
-        XXH64_store_unaligned((U64x2 *)vx2, v2);
-        /* Add them all together */
-        h64 = XXH_rotl64(vx1[0], 1) + XXH_rotl64(vx1[1], 7) + XXH_rotl64(vx2[0], 12) + XXH_rotl64(vx2[1], 18);
-        h64 = XXH64_mergeRound(h64, vx1[0]);
-        h64 = XXH64_mergeRound(h64, vx1[1]);
-        h64 = XXH64_mergeRound(h64, vx2[0]);
-        h64 = XXH64_mergeRound(h64, vx2[1]);
-    }
-#endif
-    else {
+    } else {
         h64  = seed + PRIME64_5;
     }
 

--- a/xxhash.c
+++ b/xxhash.c
@@ -891,7 +891,7 @@ static U64 XXH64_round(U64 acc, U64 input)
     acc += input * PRIME64_2;
     acc  = XXH_rotl64(acc, 31);
     acc *= PRIME64_1;
-    
+
 #if !defined(XXH_FORCE_VECTOR) && defined(__x86_64__) && defined(__GNUC__)
     /* Again, see XXH32_round. This mostly affects Clang,
      * but it also has slight improvement for GCC. */
@@ -1207,7 +1207,6 @@ XXH64_update_endian (XXH64_state_t* state, const void* input, size_t len, XXH_en
             U64 v3 = state->v3;
             U64 v4 = state->v4;
 
-            
             do {
                 v1 = XXH64_round(v1, XXH_readLE64(p, endian)); p+=8;
                 v2 = XXH64_round(v2, XXH_readLE64(p, endian)); p+=8;

--- a/xxhash.c
+++ b/xxhash.c
@@ -387,7 +387,7 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
         U32 v2 = seed + PRIME32_2;
         U32 v3 = seed + 0;
         U32 v4 = seed - PRIME32_1;
-#if 0
+
         /* Avoid branching when we don't have to. This helps out ARM Thumb a lot. */
         if (align==XXH_aligned && endian==XXH_littleEndian) {
 #if XXH_GCC_VERSION >= 407 || __has_builtin(__builtin_assume_aligned)
@@ -404,7 +404,6 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
             } while ((const BYTE*)p_align < limit);
             p = (const BYTE*)p_align;
         } else
-#endif
             do {
                 v1 = XXH32_round(v1, XXH_get32bits(p)); p+=4;
                 v2 = XXH32_round(v2, XXH_get32bits(p)); p+=4;
@@ -523,7 +522,6 @@ XXH32_update_endian(XXH32_state_t* state, const void* input, size_t len, XXH_end
             U32 v2 = state->v2;
             U32 v3 = state->v3;
             U32 v4 = state->v4;
-#if 0
             /* Aligned pointers and fewer branches are very helpful and worth the
              * duplication on ARM. */
             if (((size_t)p&3)==0 && endian==XXH_littleEndian) {
@@ -541,8 +539,6 @@ XXH32_update_endian(XXH32_state_t* state, const void* input, size_t len, XXH_end
                 } while ((const BYTE*)p_align <= limit);
                 p = (const BYTE*)p_align;
             } else
-#endif
-
                 do {
                     v1 = XXH32_round(v1, XXH_readLE32(p, endian)); p+=4;
                     v2 = XXH32_round(v2, XXH_readLE32(p, endian)); p+=4;
@@ -921,7 +917,7 @@ XXH32a_endian_align(const void* input, size_t len, U32 seed,
         U32 v7 = seed + 0;
         U32 v8 = seed - PRIME32_1;
 
-#if 0 && !XXH_VECTORIZE /* would never happen because it would be caught above */
+#if !XXH_VECTORIZE /* would never happen because it would be caught above */
         if (align==XXH_aligned && endian==XXH_littleEndian) {
 #if XXH_GCC_VERSION >= 407 || __has_builtin(__builtin_assume_aligned)
             const U32* p_align = (const U32*)__builtin_assume_aligned(p, 4);
@@ -1146,7 +1142,7 @@ XXH32a_update_endian(XXH32a_state_t* state, const void* input, size_t len, XXH_e
             U32 v7 = state->v7;
             U32 v8 = state->v8;
 
-#if 0 && !XXH_VECTORIZE
+#if !XXH_VECTORIZE
             if (((size_t)p&3)==0 && endian==XXH_littleEndian) {
 #if XXH_GCC_VERSION >= 407 || __has_builtin(__builtin_assume_aligned)
                 const U32* p_align = (const U32*)__builtin_assume_aligned(p, 4);

--- a/xxhash.c
+++ b/xxhash.c
@@ -464,7 +464,7 @@ FORCE_INLINE U32x4 XXH_rotlvec_vec32(U32x4 x, const U32x4 r)
     const U32x4 v32 = { 32, 32, 32, 32 };
     return (x << r) | (x >> (v32 - r));
 }
-#endif
+#endif /* XXH_VECTORIZE */
 
 FORCE_INLINE U32
 XXH32_endian_align(const void* input, size_t len, U32 seed,
@@ -566,7 +566,8 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
 
         h32 = vx1[0] + vx1[1] + vx1[2] + vx1[3];
     } else
-#endif
+#endif /* XXH_VECTORIZE */
+
 #if !XXH_VECTORIZE || defined(__SSE4_1__) /* no SIMD or x86 */
     if (len>=32) {
         const BYTE* const limit = bEnd - 31;
@@ -599,7 +600,7 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
         h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
             + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
     } else
-#endif
+#endif /* !XXH_VECTORIZE || __SSE4_1__ */
     {
         h32  = seed + PRIME32_5;
     }

--- a/xxhash.c
+++ b/xxhash.c
@@ -2240,8 +2240,10 @@ XXH_PUBLIC_API unsigned XXH32_auto (const void* input, size_t len, unsigned seed
     /* With slower inputs, it is usually better to use XXH32. XXH64 and XXH32a/XXH64a
      * have slower setup times, and SSE/NEON registers are slower to move back and forth
      * between normal registers. */
+
+    /* cppcheck-suppress duplicateBranch */
     if (len <= 128) {
-        return  XXH32_endian_align(input, len, seed, XXH_littleEndian, align);
+        return XXH32_endian_align(input, len, seed, XXH_littleEndian, align);
     } else
 #if (defined(__x86_64__) || defined(_M_IX86)) && !defined(XXH_NO_LONG_LONG)
         if (!XXH_CPU_IS_PRE_NEHALEM) {

--- a/xxhash.c
+++ b/xxhash.c
@@ -373,10 +373,10 @@ typedef uint32x4x2_t U32x4x2;
  *      vorr            q8, q8, q9
  * This is much faster, and I think a few intrinsics are acceptable. */
 #define XXH_vec_rotl32(x, r) vsliq_n_u32(vshrq_n_u32((x), 32 - (r)), (x), (r))
-#define XXH_vec_load_unaligned vld1q_u32
-#define XXH_vec_store_unaligned vst1q_u32
-#define XXH_vec_load_aligned vld1q_u32
-#define XXH_vec_store_aligned vst1q_u32
+#define XXH_vec_load_unaligned(p) vld1q_u32((const U32*)p)
+#define XXH_vec_store_unaligned(p, v) vst1q_u32((const U32*)p, v)
+#define XXH_vec_load_unaligned(p) vld1q_u32((const U32*)p)
+#define XXH_vec_store_unaligned(p, v) vst1q_u32((const U32*)p, v)
 
 /* Like XXH_vec_rotl32, but takes a vector as r. No NEON-optimized
  * version for this one. */
@@ -521,12 +521,11 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
             -PRIME32_1
         };
         U32x4 v = XXH_vec_load_unaligned(vx1);
-        const BYTE* limit = bEnd - 15;
+        const BYTE* const limit = bEnd - 15;
 
         const U32x4 prime1 = vdupq_n_u32(PRIME32_1);
         const U32x4 prime2 = vdupq_n_u32(PRIME32_2);
 
-        const BYTE* const limit = bEnd - 15;
         v += vdupq_n_u32(seed);
         do {
             const U32x4 inp = XXH_vec_load_unaligned((const U32 *)p);

--- a/xxhash.c
+++ b/xxhash.c
@@ -2049,7 +2049,7 @@ XXH64a_endian_align(const void* input, size_t len, U64 seed,
 
         p = XXH32a_XXH64a_endian_align(v, p, len, endian, align);
 
-        /* Join the 8 32-bit lanes into 4 64-bit lanes. 
+        /* Join the 8 32-bit lanes into 4 64-bit lanes.
          * Gotta love the ugly C casting rules. */
         v64[0] = XXH64a_join_lane((const U32(*)[4])v, 0);
         v64[1] = XXH64a_join_lane((const U32(*)[4])v, 1);

--- a/xxhash.c
+++ b/xxhash.c
@@ -998,19 +998,23 @@ XXH64_endian_align(const void* input, size_t len, U64 seed,
 #endif
 
 /* Decent performance (2 GB/s on Core 2 Duo @2.13GHz) is possible on x86_32 with two vectors.
- * It slows down x64 and ARMv7, though. */
-#if XXH_VECTORIZE && (defined(__i386__) || defined(XXH_VECTORIZE_XXH64))
+ * It slows down x64 (native math is faster) and ARMv7 (no 64-bit vector multiply), though.
+ * Clang vectorizes this nicely, but on GCC, it is necessary to use the C++ wrappers for
+ * proper performance. */
+#if XXH_VECTORIZE && (defined(__i386__) || defined(_M_IX86) || defined(XXH_VECTORIZE_XXH64))
     if (len>=32 && endian==XXH_littleEndian) {
         const BYTE* const limit = bEnd - 32;
-        typedef U64 U64x2 __attribute__((__vector_size__(16)));
-        U64x2 v[2] = {{
-            seed + PRIME64_1 + PRIME64_2,
-            seed + PRIME64_2
-        },{
-            seed + 0,
-            seed - PRIME64_1
-        }};
-        if (XXH_FORCE_ALIGN_CHECK && ((size_t)p & 15) == 0) {
+		U64 vx1[2][2];
+		U64x2 v[2];
+		vx1[0][0] = seed + PRIME64_1 + PRIME64_2;
+		vx1[0][1] = seed + PRIME64_2;
+
+		vx1[1][0] = seed + 0;
+		vx1[1][1] = seed - PRIME64_1;
+
+		v[0] = (U64x2)XXH_vec_load_unaligned((const U32*)vx1[0]);
+		v[1] = (U64x2)XXH_vec_load_unaligned((const U32*)vx1[1]);
+		if (XXH_FORCE_ALIGN_CHECK && ((size_t)p & 15) == 0) {
             do {
                 U64x2 inp = *(const U64x2*)XXH_assume_aligned(p, 16);
                 v[0] += inp * PRIME64_2;
@@ -1025,29 +1029,29 @@ XXH64_endian_align(const void* input, size_t len, U64 seed,
                 p += 16;
             } while (p < limit);
         } else {
-            struct loader {
-                U64x2 v;
-            } __attribute__((__packed__, __may_alias__));
             do {
-                U64x2 inp = ((const struct loader *)p)->v;
+                U64x2 inp = (U64x2)XXH_vec_load_unaligned(p);
                 v[0] += inp * PRIME64_2;
                 v[0]  = (v[0] << 31) | (v[0] >> 33);
                 v[0] *= PRIME64_1;
                 p += 16;
 
-                inp = ((const struct loader *)p)->v;
+                inp = (U64x2)XXH_vec_load_unaligned(p);
                 v[1] += inp * PRIME64_2;
                 v[1]  = (v[1] << 31) | (v[1] >> 33);
                 v[1] *= PRIME64_1;
                 p += 16;
             } while (p < limit);
         }
-        h64 = XXH_rotl64(v[0][0], 1) + XXH_rotl64(v[0][1], 7) + XXH_rotl64(v[1][0], 12) + XXH_rotl64(v[1][1], 18);
 
-        h64 = XXH64_mergeRound(h64, v[0][0]);
-        h64 = XXH64_mergeRound(h64, v[0][1]);
-        h64 = XXH64_mergeRound(h64, v[1][0]);
-        h64 = XXH64_mergeRound(h64, v[1][1]);
+		XXH_vec_store_unaligned((U32*)vx1[0], (U32x4)v[0]);
+		XXH_vec_store_unaligned((U32*)vx1[1], (U32x4)v[1]);
+        h64 = XXH_rotl64(vx1[0][0], 1) + XXH_rotl64(vx1[0][1], 7) + XXH_rotl64(vx1[1][0], 12) + XXH_rotl64(vx1[1][1], 18);
+
+        h64 = XXH64_mergeRound(h64, vx1[0][0]);
+        h64 = XXH64_mergeRound(h64, vx1[0][1]);
+        h64 = XXH64_mergeRound(h64, vx1[1][0]);
+        h64 = XXH64_mergeRound(h64, vx1[1][1]);
     } else
 #endif /* XXH_VECTORIZE && (i386 || XXH_VECTORIZE_XXH64) */
     if (len>=32) {

--- a/xxhash.c
+++ b/xxhash.c
@@ -2241,7 +2241,6 @@ XXH_PUBLIC_API unsigned XXH32_auto (const void* input, size_t len, unsigned seed
      * have slower setup times, and SSE/NEON registers are slower to move back and forth
      * between normal registers. */
 
-    /* cppcheck-suppress duplicateBranch */
     if (len <= 128) {
         return XXH32_endian_align(input, len, seed, XXH_littleEndian, align);
     } else

--- a/xxhash.c
+++ b/xxhash.c
@@ -374,9 +374,9 @@ typedef uint32x4x2_t U32x4x2;
  * This is much faster, and I think a few intrinsics are acceptable. */
 #define XXH_vec_rotl32(x, r) vsliq_n_u32(vshrq_n_u32((x), 32 - (r)), (x), (r))
 #define XXH_vec_load_unaligned(p) vld1q_u32((const U32*)p)
-#define XXH_vec_store_unaligned(p, v) vst1q_u32((const U32*)p, v)
+#define XXH_vec_store_unaligned(p, v) vst1q_u32((U32*)p, v)
 #define XXH_vec_load_unaligned(p) vld1q_u32((const U32*)p)
-#define XXH_vec_store_unaligned(p, v) vst1q_u32((const U32*)p, v)
+#define XXH_vec_store_unaligned(p, v) vst1q_u32((U32*)p, v)
 
 /* Like XXH_vec_rotl32, but takes a vector as r. No NEON-optimized
  * version for this one. */

--- a/xxhash.c
+++ b/xxhash.c
@@ -136,19 +136,6 @@
 #  endif /* __STDC_VERSION__ */
 #endif
 
-/* Unrolling loops, especially on ARM, is beneficial for most cases. We aim for
- * 4 unrolls. Doing this with a pragma is much easier and less prone to copy-paste
- * errors, as the compiler will put a runtime trip inside to do this.
- * We don't unroll with -Os/-Oz, or when XXH_INLINE_ALL. The first is to reduce
- * size (obviously), and the second is to avoid cache miss hell. */
-#if defined(__OPTIMIZE_SIZE__) || defined(XXH_INLINE_ALL) || !defined(__GNUC__)
-#  define UNROLL
-#elif defined(__clang__)
-#  define UNROLL _Pragma("clang loop unroll_count(4)")
-#else
-#  define UNROLL _Pragma("GCC unroll 4")
-#endif
-
 /* Inline assembly guards. These are used to disable unwanted vectorization or
  * instruction combining. */
 #if defined(__GNUC__) && !defined(XXH_FORCE_VECTOR)
@@ -381,6 +368,22 @@ FORCE_INLINE void XXH_cpuID(void)
 #  define XXH_assume_aligned(p, align) __builtin_assume_aligned((p), (align))
 #else
 #  define XXH_assume_aligned(p, align) (p)
+#endif
+
+
+/* Unrolling loops, especially on ARM, is beneficial for most cases. We aim for
+ * 4 unrolls. Doing this with a pragma is much easier and less prone to copy-paste
+ * errors, as the compiler will put a runtime trip inside to do this.
+ * We don't unroll with -Os/-Oz, or when XXH_INLINE_ALL. The first is to reduce
+ * size (obviously), and the second is to avoid cache miss hell. */
+#if defined(__OPTIMIZE_SIZE__) || defined(XXH_INLINE_ALL)
+#  define UNROLL
+#elif defined(__clang__)
+#  define UNROLL _Pragma("clang loop unroll_count(4)")
+#elif XXH_GCC_VERSION >= 800
+#  define UNROLL _Pragma("GCC unroll 4")
+#else
+#  define UNROLL
 #endif
 
 /* Note : although _rotl exists for minGW (GCC under windows), performance seems poor */

--- a/xxhash.c
+++ b/xxhash.c
@@ -303,8 +303,16 @@ XXH32_finalize(U32 h32, const void* ptr, size_t len,
     p+=4;                                \
     h32  = XXH_rotl32(h32, 17) * PRIME32_4 ;
 
-    switch(len&15)  /* or switch(bEnd - p) */
+    switch(len&31)  /* or switch(bEnd - p) */
     {
+      case 28:      PROCESS4;
+                    /* fallthrough */
+      case 24:      PROCESS4;
+                    /* fallthrough */
+      case 20:      PROCESS4;
+                    /* fallthrough */
+      case 16:      PROCESS4;
+                    /* fallthrough */
       case 12:      PROCESS4;
                     /* fallthrough */
       case 8:       PROCESS4;
@@ -312,6 +320,14 @@ XXH32_finalize(U32 h32, const void* ptr, size_t len,
       case 4:       PROCESS4;
                     return XXH32_avalanche(h32);
 
+      case 29:      PROCESS4;
+                    /* fallthrough */
+      case 25:       PROCESS4;
+                    /* fallthrough */
+      case 21:      PROCESS4;
+                    /* fallthrough */
+      case 17:       PROCESS4;
+                    /* fallthrough */
       case 13:      PROCESS4;
                     /* fallthrough */
       case 9:       PROCESS4;
@@ -320,6 +336,15 @@ XXH32_finalize(U32 h32, const void* ptr, size_t len,
                     PROCESS1;
                     return XXH32_avalanche(h32);
 
+
+      case 30:      PROCESS4;
+                    /* fallthrough */
+      case 26:      PROCESS4;
+                    /* fallthrough */
+      case 22:      PROCESS4;
+                    /* fallthrough */
+      case 18:      PROCESS4;
+                    /* fallthrough */
       case 14:      PROCESS4;
                     /* fallthrough */
       case 10:      PROCESS4;
@@ -329,6 +354,14 @@ XXH32_finalize(U32 h32, const void* ptr, size_t len,
                     PROCESS1;
                     return XXH32_avalanche(h32);
 
+      case 31:      PROCESS4;
+                    /* fallthrough */
+      case 27:      PROCESS4;
+                    /* fallthrough */
+      case 23:      PROCESS4;
+                    /* fallthrough */
+      case 19:      PROCESS4;
+                    /* fallthrough */
       case 15:      PROCESS4;
                     /* fallthrough */
       case 11:      PROCESS4;
@@ -438,8 +471,8 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
             seed - PRIME32_1
         };
         U32x4 v[2] = {
-            XXH32_load_unaligned((const U32x4 *)vx1),
-            XXH32_load_unaligned((const U32x4 *)vx1)
+            XXH32_load_unaligned((const U32x4*)vx1),
+            XXH32_load_unaligned((const U32x4*)vx1)
         };
         const U32x4 prime1 = { PRIME32_2, PRIME32_1, PRIME32_1, PRIME32_1 };
         const U32x4 prime2 = { PRIME32_2, PRIME32_2, PRIME32_2, PRIME32_2 };
@@ -453,9 +486,9 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
 
 #if XXH_GCC_VERSION >= 407 || __has_builtin(__builtin_assume_aligned)
             /* GCC/Clang builtin that tells the compiler that this will be aligned. */
-            const U32x4x2 *p_quad = (const U32x4x2 *)__builtin_assume_aligned(p, 16);
+            const U32x4x2* p_quad = (const U32x4x2*)__builtin_assume_aligned(p, 16);
 #else
-            const U32x4x2 *p_quad = (const U32x4x2 *)p;
+            const U32x4x2* p_quad = (const U32x4x2*)p;
 #endif
 
             do {
@@ -471,11 +504,12 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
                 v[0] *= prime1;
                 v[1] *= prime1;
             } while ((const BYTE*)p_quad < limit);
-            p = (const BYTE *)p_quad;
+            p = (const BYTE*)p_quad;
 
         } else {
             do {
-                U32x4x2 inp = XXH32_load_double_unaligned((const U32x4 *)p);
+                /* Load 32 bytes at a time. */
+                U32x4x2 inp = XXH32_load_double_unaligned((const U32x4*)p);
 
                 /* XXH32_round */
                 v[0] += inp.i[0] * prime2;
@@ -523,10 +557,10 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
             v4A = XXH32_round(v4A, XXH_get32bits(p)); p+=4;
         } while (p < limit);
 
-        v1 += v1A * PRIME32_2; v1 = XXH_rotl32(v1, 13); v1 *= PRIME32_1;
-        v2 += v2A * PRIME32_2; v2 = XXH_rotl32(v2, 13); v2 *= PRIME32_1;
-        v3 += v3A * PRIME32_2; v3 = XXH_rotl32(v3, 13); v3 *= PRIME32_1;
-        v4 += v4A * PRIME32_2; v4 = XXH_rotl32(v4, 13); v4 *= PRIME32_1;
+        v1 = XXH32_round(v1, v1A);
+        v2 = XXH32_round(v2, v2A);
+        v3 = XXH32_round(v3, v3A);
+        v4 = XXH32_round(v4, v4A);
         h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
             + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
     }

--- a/xxhash.c
+++ b/xxhash.c
@@ -654,7 +654,7 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
 {
     const BYTE* p = (const BYTE*)input;
     const BYTE* bEnd = p + len;
-    /* cppcheck flags this as unused for some reason... */
+    /* cppcheck flags this as unused because it doesn't know how to parse _Pragma. */
     /* cppcheck-suppress unusedVariable */
     U32 h32;
 
@@ -1196,7 +1196,7 @@ XXH64_endian_align(const void* input, size_t len, U64 seed,
 {
     const BYTE* p = (const BYTE*)input;
     const BYTE* bEnd = p + len;
-    /* cppcheck flags this as unused for some reason... */
+    /* cppcheck flags this as unused because it doesn't understand _Pragma. */
     /* cppcheck-suppress unusedVariable */
     U64 h64;
 

--- a/xxhash.c
+++ b/xxhash.c
@@ -57,7 +57,8 @@
 #  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
   (defined(__GNUC__) && ( defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) \
                     || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) \
-                    || defined(__ARM_ARCH_7S__) || defined(__ARM_ARCH_V7VE__) ))
+                    || defined(__ARM_ARCH_7S__) || defined(__ARM_ARCH_V7VE__) \
+                    || defined(__aarch64__)))
 #    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif

--- a/xxhash.c
+++ b/xxhash.c
@@ -93,7 +93,7 @@
  * set it to 0 when the input is guaranteed to be aligned,
  * or when alignment doesn't matter for performance.
  *
- * For example, Sandy Bridge (AVX) and ARMv7 have no unaligned
+ * For example, Nehalem (SSE4.2) and ARMv7 have no unaligned
  * access penalty. Disabling this check can increase performance.
  *
  * However, on a Core 2, which has an unaligned access penalty, enabling
@@ -101,7 +101,7 @@
  * on GCC 8.1.
  */
 #ifndef XXH_FORCE_ALIGN_CHECK /* can be defined externally */
-#  if defined(__AVX__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
+#  if defined(__SSE4_2__) || defined(__ARM_NEON__) || defined(__ARM_NEON)
 #    define XXH_FORCE_ALIGN_CHECK 0
 #  else
 #    define XXH_FORCE_ALIGN_CHECK 1
@@ -1626,8 +1626,8 @@ XXH32a_XXH64a_update_endian(XXH32a_state_t* state, const void* input, size_t len
 /* SIMD-optimized code */
 #if XXH_VECTORIZE
 /* Older x86_64 processors slow down significantly on unaligned reads with
- * SSE4.1 instructions. Sandy Bridge (AVX) is unaffected, so we don't check
- * if you target AVX.
+ * SSE4.1 instructions. Nehalem is unaffected, so we don't check
+ * if you target SSE4.2
  * NEON is just as fast with unaligned reads, so we always use SIMD. */
 #if XXH_FORCE_ALIGN_CHECK && !(defined(__clang__) && defined(__i386__))
     if (len >= 32 && endian==XXH_littleEndian && ((size_t)p&3)==0) {

--- a/xxhash.c
+++ b/xxhash.c
@@ -1536,7 +1536,7 @@ XXH32a_XXH64a_update_endian(XXH32a_state_t* state, const void* input, size_t len
                 state->v[1][0] = XXH32_round(state->v[1][0], XXH_readLE32(p32, endian)); p32++;
                 state->v[1][1] = XXH32_round(state->v[1][1], XXH_readLE32(p32, endian)); p32++;
                 state->v[1][2] = XXH32_round(state->v[1][2], XXH_readLE32(p32, endian)); p32++;
-                state->v[1][3] = XXH32_round(state->v[1][3], XXH_readLE32(p32, endian)); p32++;
+                state->v[1][3] = XXH32_round(state->v[1][3], XXH_readLE32(p32, endian));
             }
             p += 32-state->memsize;
             state->memsize = 0;

--- a/xxhash.c
+++ b/xxhash.c
@@ -521,10 +521,10 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
             -PRIME32_1
         };
         U32x4 v = XXH_vec_load_unaligned(vx1);
-        const BYTE* const limit = bEnd - 15;
-
         const U32x4 prime1 = vdupq_n_u32(PRIME32_1);
         const U32x4 prime2 = vdupq_n_u32(PRIME32_2);
+
+        const BYTE* const limit = bEnd - 15;
 
         v += vdupq_n_u32(seed);
         do {

--- a/xxhash.c
+++ b/xxhash.c
@@ -2049,11 +2049,12 @@ XXH64a_endian_align(const void* input, size_t len, U64 seed,
 
         p = XXH32a_XXH64a_endian_align(v, p, len, endian, align);
 
-        /* Join the 8 32-bit lanes into 4 64-bit lanes. */
-        v64[0] = XXH64a_join_lane(v, 0);
-        v64[1] = XXH64a_join_lane(v, 1);
-        v64[2] = XXH64a_join_lane(v, 2);
-        v64[3] = XXH64a_join_lane(v, 3);
+        /* Join the 8 32-bit lanes into 4 64-bit lanes. 
+         * Gotta love the ugly C casting rules. */
+        v64[0] = XXH64a_join_lane((const U32(*)[4])v, 0);
+        v64[1] = XXH64a_join_lane((const U32(*)[4])v, 1);
+        v64[2] = XXH64a_join_lane((const U32(*)[4])v, 2);
+        v64[3] = XXH64a_join_lane((const U32(*)[4])v, 3);
 
         /* The usual XXH64 ending routine */
         h64 = XXH_rotl64(v64[0], 1) + XXH_rotl64(v64[1], 7)

--- a/xxhash.c
+++ b/xxhash.c
@@ -165,6 +165,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
 #define CONSTANT static const
 #endif
 
+
 /* *************************************
 *  Basic Types
 ***************************************/
@@ -176,10 +177,16 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
     typedef uint8_t  BYTE;
     typedef uint16_t U16;
     typedef uint32_t U32;
+#ifndef XXH_NO_LONG_LONG
+	typedef uint64_t U64;
+#endif
 # else
     typedef unsigned char      BYTE;
     typedef unsigned short     U16;
     typedef unsigned int       U32;
+#ifndef XXH_NO_LONG_LONG
+	typedef unsigned long long U64;
+#endif
 # endif
 #endif
 
@@ -754,20 +761,6 @@ XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src
 
 /*======   Memory access   ======*/
 
-#ifndef MEM_MODULE
-# define MEM_MODULE
-# if !defined (__VMS) \
-  && (defined (__cplusplus) \
-  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
-#   include <stdint.h>
-    typedef uint64_t U64;
-# else
-    /* if compiler doesn't support unsigned long long, replace by another 64-bit type */
-    typedef unsigned long long U64;
-# endif
-#endif
-
-
 #if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
 
 /* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
@@ -1280,6 +1273,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
     return XXH_readBE64(src);
 }
 
+#endif /* !XXH_NO_LONG_LONG */
 #ifndef XXH_NO_ALT_HASHES
 /* *******************************************************************
 *  32-bit hash functions (alternative)
@@ -1703,6 +1697,8 @@ XXH_PUBLIC_API unsigned int XXH32a_digest (const XXH32a_state_t* state_in)
     else
         return XXH32a_digest_endian(state_in, XXH_bigEndian);
 }
+
+#ifndef XXH_NO_LONG_LONG
 /* Synopsis:
  * U32 v[2][4];
  * U64 seed;

--- a/xxhash.c
+++ b/xxhash.c
@@ -178,14 +178,14 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
     typedef uint16_t U16;
     typedef uint32_t U32;
 #ifndef XXH_NO_LONG_LONG
-	typedef uint64_t U64;
+    typedef uint64_t U64;
 #endif
 # else
     typedef unsigned char      BYTE;
     typedef unsigned short     U16;
     typedef unsigned int       U32;
 #ifndef XXH_NO_LONG_LONG
-	typedef unsigned long long U64;
+    typedef unsigned long long U64;
 #endif
 # endif
 #endif
@@ -997,17 +997,17 @@ XXH64_endian_align(const void* input, size_t len, U64 seed,
 #if XXH_VECTORIZE && (defined(__i386__) || defined(_M_IX86) || defined(XXH_VECTORIZE_XXH64))
     if (len>=32 && endian==XXH_littleEndian) {
         const BYTE* const limit = bEnd - 32;
-		U64 vx1[2][2];
-		U64x2 v[2];
-		vx1[0][0] = seed + PRIME64_1 + PRIME64_2;
-		vx1[0][1] = seed + PRIME64_2;
+        U64 vx1[2][2];
+        U64x2 v[2];
+        vx1[0][0] = seed + PRIME64_1 + PRIME64_2;
+        vx1[0][1] = seed + PRIME64_2;
 
-		vx1[1][0] = seed + 0;
-		vx1[1][1] = seed - PRIME64_1;
+        vx1[1][0] = seed + 0;
+        vx1[1][1] = seed - PRIME64_1;
 
-		v[0] = (U64x2)XXH_vec_load_unaligned((const U32*)vx1[0]);
-		v[1] = (U64x2)XXH_vec_load_unaligned((const U32*)vx1[1]);
-		if (XXH_FORCE_ALIGN_CHECK && ((size_t)p & 15) == 0) {
+        v[0] = (U64x2)XXH_vec_load_unaligned((const U32*)vx1[0]);
+        v[1] = (U64x2)XXH_vec_load_unaligned((const U32*)vx1[1]);
+        if (XXH_FORCE_ALIGN_CHECK && ((size_t)p & 15) == 0) {
             do {
                 U64x2 inp = *(const U64x2*)XXH_assume_aligned(p, 16);
                 v[0] += inp * PRIME64_2;
@@ -1037,8 +1037,8 @@ XXH64_endian_align(const void* input, size_t len, U64 seed,
             } while (p < limit);
         }
 
-		XXH_vec_store_unaligned((U32*)vx1[0], (U32x4)v[0]);
-		XXH_vec_store_unaligned((U32*)vx1[1], (U32x4)v[1]);
+        XXH_vec_store_unaligned((U32*)vx1[0], (U32x4)v[0]);
+        XXH_vec_store_unaligned((U32*)vx1[1], (U32x4)v[1]);
         h64 = XXH_rotl64(vx1[0][0], 1) + XXH_rotl64(vx1[0][1], 7) + XXH_rotl64(vx1[1][0], 12) + XXH_rotl64(vx1[1][1], 18);
 
         h64 = XXH64_mergeRound(h64, vx1[0][0]);

--- a/xxhash.h
+++ b/xxhash.h
@@ -157,6 +157,9 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 #  define XXH64a_update XXH_NAME2(XXH_NAMESPACE, XXH64a_update)
 #  define XXH64a_digest XXH_NAME2(XXH_NAMESPACE, XXH64a_digest)
 #  define XXH64a_copyState XXH_NAME2(XXH_NAMESPACE, XXH64a_copyState)
+#  define XXH_auto XXH_NAME2(XXH_NAMESPACE, XXH_auto)
+#  define XXH32_auto XXH_NAME2(XXH_NAMESPACE, XXH32_auto)
+#  define XXH64_auto XXH_NAME2(XXH_NAMESPACE, XXH64_auto)
 #endif
 
 
@@ -317,6 +320,68 @@ XXH_PUBLIC_API XXH64_hash_t  XXH64a_digest (const XXH64a_state_t* statePtr);
 #endif /* !XXH_NO_LONG_LONG */
 #endif /* !XXH_NO_ALT_HASHES */
 
+/*! XXH32_auto() :
+    Calculates *A* 32-bit hash. This will choose either of the xxHash hashes, attempting to choose
+    the fastest one based on the architecture and the length. Endianness is ignored.
+
+   ************************************** WARNING **************************************
+   *                  DO NOT RELY ON THE EXACT VALUE OF THIS HASH!!!!                  *
+   *                  -----------------------------------------------                  *
+   * Unlike XXH64 and XXH64a, this does not guarantee a stable, cross-platform result. *
+   * The only reliable promise for this hash is that it will generate the same value   *
+   * on the same CPU and xxHash version. And since CPUs are sometimes interchangable,  *
+   * do not store this value. This should be used for identity hashes e.g. hashtables. *
+   *************************************************************************************
+
+    For the reference, this uses the following logic:
+      if   length <= 128: XXH32
+      elif x86_64: XXH64
+      elif XXH_VECTORIZE: XXH32a
+      else: XXH32
+
+    If a hash is unavailable, it will choose the next best hash.
+*/
+XXH_PUBLIC_API XXH32_hash_t XXH32_auto (const void* input, size_t length, unsigned seed);
+#ifndef XXH_NO_LONG_LONG
+/*! XXH_auto() :
+    Calculates *A* 32 or 64-bit hash, depending on size_t's width. This will choose either of
+    the xxHash hashes, attempting to choose the fastest one based on the architecture and
+    the length.
+
+   ************************************** WARNING **************************************
+   *                  DO NOT RELY ON THE EXACT VALUE OF THIS HASH!!!!                  *
+   *                  -----------------------------------------------                  *
+   * Unlike XXH64 and XXH64a, this does not guarantee a stable, cross-platform result. *
+   * The only reliable promise for this hash is that it will generate the same value   *
+   * on the same CPU and xxHash version. And since CPUs are sometimes interchangable,  *
+   * do not store this value. This should be used for identity hashes e.g. hashtables. *
+   *************************************************************************************
+
+    This will call either XXH32_auto or XXH64_auto depending on the native word size. */
+XXH_PUBLIC_API size_t XXH_auto (const void* input, size_t length, size_t seed);
+/*! XXH64_auto() :
+    Calculates *A* 64-bit hash. This will choose either of the xxHash hashes,
+    attempting to choose the fastest one based on the architecture and the length.
+
+   ************************************** WARNING **************************************
+   *                  DO NOT RELY ON THE EXACT VALUE OF THIS HASH!!!!                  *
+   *                  -----------------------------------------------                  *
+   * Unlike XXH64 and XXH64a, this does not guarantee a stable, cross-platform result. *
+   * The only reliable promise for this hash is that it will generate the same value   *
+   * on the same CPU and xxHash version. And since CPUs are sometimes interchangable,  *
+   * do not store this value. This should be used for identity hashes e.g. hashtables. *
+   *************************************************************************************
+
+    For the reference, this chooses the following logic:
+      if   length <= 128: XXH64
+      elif x86_64 && SSE4.2: XXH64
+      elif 32-bit || NEON: XXH64a
+      else: XXH64
+
+      If a hash is unavailable, it will choose the next best hash.
+*/
+XXH_PUBLIC_API XXH64_hash_t XXH64_auto (const void* input, size_t length, unsigned long long seed);
+#endif /* !XXH_NO_LONG_LONG */
 #ifdef XXH_STATIC_LINKING_ONLY
 
 /* We want XXH32a_state_t to be aligned. That way we can reinterpret it as a pointer

--- a/xxhash.h
+++ b/xxhash.h
@@ -376,6 +376,7 @@ struct XXH32a_state_s {
    uint32_t reserved;       /*     76 - never read nor write, might be removed in a future version */
 };   /* typedef'd to XXH32a_state_t */
 
+#   ifndef XXH_NO_LONG_LONG
 struct XXH64_state_s {
    uint64_t total_len;
    uint64_t v1;
@@ -386,7 +387,7 @@ struct XXH64_state_s {
    uint32_t memsize;
    uint32_t reserved[2];          /* never read nor write, might be removed in a future version */
 };   /* typedef'd to XXH64_state_t */
-
+#   endif
 # else
 
 struct XXH32_state_s {

--- a/xxhash.h
+++ b/xxhash.h
@@ -367,7 +367,7 @@ struct XXH32_state_s {
  * unaligned reads, or worse. */
 struct XXH32a_state_s {
    XXH_ALIGN_16             /* Offset */
-   uint32_t v[8];           /*      0 */
+   uint32_t v[2][4];        /*      0 */
    XXH_ALIGN_16
    uint32_t mem32[8];       /*     32 */
    uint32_t total_len_32;   /*     64 */
@@ -405,7 +405,7 @@ struct XXH32_state_s {
  * unaligned reads, or worse. */
 struct XXH32a_state_s {
    XXH_ALIGN_16             /* Offset */
-   unsigned v[8];           /*      0 */
+   unsigned v[2][4];        /*      0 */
    XXH_ALIGN_16
    unsigned mem32[8];       /*     32 */
    unsigned total_len_32;   /*     64 */

--- a/xxhash.h
+++ b/xxhash.h
@@ -220,7 +220,7 @@ XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src
  * This way, hash values can be written into a file / memory, and remain comparable on different systems and programs.
  */
 
-
+#ifndef XXH_NO_32A
 /*-**********************************************************************
 *  32-bit hash (alternative)
 ************************************************************************/
@@ -294,6 +294,7 @@ XXH_PUBLIC_API XXH32_hash_t XXH32a_hashFromCanonical(const XXH32a_canonical_t* s
  * This way, hash values can be written into a file / memory, and remain comparable on different systems and programs.
  */
 
+#endif /* !XXH_NO_32a */
 
 #ifndef XXH_NO_LONG_LONG
 /*-**********************************************************************

--- a/xxhash.h
+++ b/xxhash.h
@@ -308,7 +308,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64a (const void* input, size_t length, unsigned l
 /*======   Streaming   ======*/
 typedef struct XXH32a_state_s XXH64a_state_t;   /* They use the same state type. */
 XXH_PUBLIC_API XXH64a_state_t* XXH64a_createState(void);
-XXH_PUBLIC_API XXH_errorcode  XXH32a_freeState(XXH64a_state_t* statePtr);
+XXH_PUBLIC_API XXH_errorcode  XXH64a_freeState(XXH64a_state_t* statePtr);
 XXH_PUBLIC_API void XXH64a_copyState(XXH64a_state_t* dst_state, const XXH64a_state_t* src_state);
 
 XXH_PUBLIC_API XXH_errorcode XXH64a_reset  (XXH64a_state_t* statePtr, unsigned long long seed);

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -134,7 +134,9 @@ static __inline int IS_CONSOLE(FILE* stdStream) {
 **************************************/
 #ifndef MEM_MODULE
 # define MEM_MODULE
-# if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+# if !defined (__VMS) \
+  && (defined(__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
 #   include <stdint.h>
     typedef uint8_t  BYTE;
     typedef uint16_t U16;

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -158,7 +158,8 @@ static __inline int IS_CONSOLE(FILE* stdStream) {
 
 static unsigned BMK_isLittleEndian(void)
 {
-    const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental  */
+    union { U32 u; BYTE c[4]; } one;   /* don't use static : performance detrimental  */
+    one.u = 1;
     return one.c[0];
 }
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -198,7 +198,7 @@ static const algoType g_defaultAlgo = algo_xxh64;    /* required within main() &
 
 /* <16 hex char> <SPC> <SPC> <filename> <'\0'>
  * '4096' is typical Linux PATH_MAX configuration. */
-#define DEFAULT_LINE_LENGTH (sizeof(XXH64_hash_t) * 2 + 2 + 4096 + 1)
+#define DEFAULT_LINE_LENGTH (sizeof(XXH64_hash_t) * 2 + 2 + 4096 + 3)
 
 /* Maximum acceptable line length. */
 #define MAX_LINE_LENGTH (32 KB)
@@ -939,7 +939,7 @@ static GetLineResult getLine(char** lineBuf, int* lineMax, FILE* inFile)
     if ((*lineBuf == NULL) || (*lineMax<1)) {
         free(*lineBuf);  /* in case it's != NULL */
         *lineMax = 0;
-        *lineBuf = (char*)malloc(DEFAULT_LINE_LENGTH);
+        *lineBuf = (char*)calloc(1, DEFAULT_LINE_LENGTH);
         if(*lineBuf == NULL) return GetLine_outOfMemory;
         *lineMax = DEFAULT_LINE_LENGTH;
     }

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -527,7 +527,7 @@ static void BMK_testSequence64(const char* testName, const void* sentence,
 
     (void)XXH64_reset(&state, seed);
     for (pos=0; pos<len; pos++)
-        (void)XXH64_update(&state, ((char*)sentence)+pos, 1);
+        (void)XXH64_update(&state, ((const char*)sentence)+pos, 1);
     Dresult = XXH64_digest(&state);
     BMK_checkResult64(Dresult, Nresult, "XXH64 Partial Update", testName);
 }
@@ -548,7 +548,7 @@ static void BMK_testSequence64a(const char* testName, const void* sentence,
 
     (void)XXH64a_reset(&state, seed);
     for (pos=0; pos<len; pos++)
-        (void)XXH64a_update(&state, ((char*)sentence)+pos, 1);
+        (void)XXH64a_update(&state, ((const char*)sentence)+pos, 1);
     Dresult = XXH64a_digest(&state);
     BMK_checkResult64(Dresult, Nresult, "XXH64a Partial Update", testName);
 }

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -271,6 +271,13 @@ static U32 localXXH64(const void* buffer, size_t bufferSize, U32 seed) { return 
 
 static U32 localXXH64a(const void* buffer, size_t bufferSize, U32 seed) { return (U32)XXH64a(buffer, bufferSize, seed); }
 
+static U32 localXXH_auto(const void* buffer, size_t bufferSize, U32 seed) { return (U32)XXH_auto(buffer, bufferSize, seed); }
+
+static U32 localXXH32_auto(const void* buffer, size_t bufferSize, U32 seed) { return XXH32_auto(buffer, bufferSize, seed); }
+
+static U32 localXXH64_auto(const void* buffer, size_t bufferSize, U32 seed) { return (U32)XXH64_auto(buffer, bufferSize, seed); }
+
+
 static void BMK_benchHash(hashFunction h, const char* hName, const void* buffer, size_t bufferSize)
 {
     U32 nbh_perIteration = (U32)((300 MB) / (bufferSize+1)) + 1;  /* first loop conservatively aims for 300 MB/s */
@@ -351,6 +358,32 @@ static int BMK_benchMem(const void* buffer, size_t bufferSize, U32 specificTest)
     /* Bench XXH64a on Unaligned input */
     if ((specificTest==0) | (specificTest==8))
         BMK_benchHash(localXXH64a, "XXH64a unaligned", ((const char*)buffer)+1, bufferSize);
+
+    /* XXH64a bench */
+    if ((specificTest==0) | (specificTest==9))
+        BMK_benchHash(localXXH_auto, "XXH auto", buffer, bufferSize);
+
+    /* Bench XXH64a on Unaligned input */
+    if ((specificTest==0) | (specificTest==10))
+        BMK_benchHash(localXXH_auto, "XXH auto unaligned", ((const char*)buffer)+1, bufferSize);
+
+    /* XXH64a bench */
+    if ((specificTest==0) | (specificTest==9))
+        BMK_benchHash(localXXH32_auto, "XXH32 auto", buffer, bufferSize);
+
+    /* Bench XXH64a on Unaligned input */
+    if ((specificTest==0) | (specificTest==10))
+        BMK_benchHash(localXXH32_auto, "XXH32 auto unaligned", ((const char*)buffer)+1, bufferSize);
+
+
+    /* XXH64a bench */
+    if ((specificTest==0) | (specificTest==9))
+        BMK_benchHash(localXXH64_auto, "XXH64 auto", buffer, bufferSize);
+
+    /* Bench XXH64a on Unaligned input */
+    if ((specificTest==0) | (specificTest==10))
+        BMK_benchHash(localXXH64_auto, "XXH64 auto unaligned", ((const char*)buffer)+1, bufferSize);
+
 
     if (specificTest > 4) {
         DISPLAY("benchmark mode invalid \n");
@@ -451,7 +484,7 @@ static void BMK_checkResult(U32 r1, U32 r2)
     if (r1==r2) {
         DISPLAYLEVEL(3, "\rTest%3i : %08X == %08X   ok   ", nbTests, r1, r2);
     } else {
-        DISPLAY("\rERROR : Test%3i : %08X <> %08X   !!!!!   \n", nbTests, r1, r2);
+        DISPLAY("\rERROR : Test%3i : Got 0x%08X, expected 0x%08X   !!!!!   \n", nbTests, r1, r2);
         exit(1);
     }
     nbTests++;
@@ -463,7 +496,7 @@ static void BMK_checkResult64(U64 r1, U64 r2)
     static int nbTests = 1;
     if (r1!=r2) {
         DISPLAY("\rERROR : Test%3i : 64-bit values non equals   !!!!!   \n", nbTests);
-        DISPLAY("\r %08X%08X != %08X%08X \n", (U32)(r1>>32), (U32)r1, (U32)(r2>>32), (U32)r2);
+        DISPLAY("\r Got 0x%08X%08X, expected 0x%08X%08X \n", (U32)(r1>>32), (U32)r1, (U32)(r2>>32), (U32)r2);
         exit(1);
     }
     nbTests++;
@@ -545,9 +578,11 @@ static void BMK_testSequence32a(const void* sequence, size_t len, U32 seed, U32 
     (void)XXH32a_reset(&state, seed);
     (void)XXH32a_update(&state, sequence, len);
     Dresult = XXH32a_digest(&state);
+
     BMK_checkResult(Dresult, Nresult);
 
     (void)XXH32a_reset(&state, seed);
+
     for (pos=0; pos<len; pos++)
         (void)XXH32a_update(&state, ((const char*)sequence)+pos, 1);
     Dresult = XXH32a_digest(&state);
@@ -577,13 +612,13 @@ static void BMK_sanityCheck(void)
     BMK_testSequence(sanityBuffer, SANITY_BUFFER_SIZE, prime, 0x498EC8E2);
 
     BMK_testSequence32a(NULL,          0, 0,     0x02CC5D05);
-    BMK_testSequence32a(NULL,          0, prime, 0x36B78AE7);
+    BMK_testSequence32a(NULL,          0, prime, 0xC85F5E5E);
     BMK_testSequence32a(sanityBuffer,  1, 0,     0xB85CBEE5);
-    BMK_testSequence32a(sanityBuffer,  1, prime, 0xD5845D64);
+    BMK_testSequence32a(sanityBuffer,  1, prime, 0x6B1E2996);
     BMK_testSequence32a(sanityBuffer, 14, 0,     0xE5AA0AB4);
-    BMK_testSequence32a(sanityBuffer, 14, prime, 0x4481951D);
-    BMK_testSequence32a(sanityBuffer, SANITY_BUFFER_SIZE, 0,     0x7BDCA81E);
-    BMK_testSequence32a(sanityBuffer, SANITY_BUFFER_SIZE, prime, 0x267C4625);
+    BMK_testSequence32a(sanityBuffer, 14, prime, 0xA5119F89);
+    BMK_testSequence32a(sanityBuffer, SANITY_BUFFER_SIZE, 0,     0x7F88514A);
+    BMK_testSequence32a(sanityBuffer, SANITY_BUFFER_SIZE, prime, 0x420A8F14);
 
     BMK_testSequence64(NULL        ,  0, 0,     0xEF46DB3751D8E999ULL);
     BMK_testSequence64(NULL        ,  0, prime, 0xAC75FDA2929B17EFULL);


### PR DESCRIPTION
This uses the tips to vectorize xxHash32 from https://moinakg.wordpress.com/2013/01/19/vectorizing-xxhash-for-fun-and-profit/ but without the x86 intrinsics. Instead, it uses GCC vector extensions to implement the same behavior naturally.

It supports (presumably) all versions of Clang, and GCC 4.7+, as long as they target SSE4.1 (`-march=core2`, `-march=penryn`, `-msse4.1`), or ARMv7-a with NEON.

It changes the hash which sucks a lot, but the performance seems very promising once it gets tweaked a bit.

Aligned 32-bit hashes on my MacBook (2.13 GHz Core 2 Duo/P7450/Penryn) have a 1.1-1.16x speedup, but a yucky 0.8-0.9x slowdown for unaligned hashes.

Before (`gcc-8 -mno-sse4`):
```
XXH32               :     102400 ->    40398 it/s ( 3945.1 MB/s)
XXH32 unaligned     :     102400 ->    31806 it/s ( 3106.1 MB/s)
XXH64               :     102400 ->    41097 it/s ( 4013.3 MB/s)
XXH64 unaligned     :     102400 ->    29493 it/s ( 2880.2 MB/s)
```

After (`gcc-8 -ftree-vectorize -ftree-slp-vectorize -msse4.1`):
```
XXH32               :     102400 ->    47076 it/s ( 4597.3 MB/s)
XXH32 unaligned     :     102400 ->    29567 it/s ( 2887.4 MB/s)
XXH64               :     102400 ->    41151 it/s ( 4018.7 MB/s)
XXH64 unaligned     :     102400 ->    29494 it/s ( 2880.3 MB/s)
```
This actually makes 32-bit hashes __faster__ than 64-bit on my machine.

~~I still need to fix update_endian and make unaligned and 64-bit faster, and I want to know how this performs on AVX (Sandy Bridge/2nd Gen Core i-series, use `-mavx`).~~ AVX performs fine here and endianness is taken care of.

In addition, I just added XXH64a.  

The difference between XXH32a and XXH64a are minimal. They use the exact same inner loops and state type (they are treated separately, but typedef'd to each other) but the beginning and end are handled differently.

XXH32a will copy the seed and merge the lanes in the digest, while XXH64a will split the seed between the 8 lanes and join them together.

The result of XXH64a is a 64-bit hash that has good performance on both 32-bit and 64-bit systems.

XXH64 will (usually) be much faster on 64-bit (excluding pre-2010 Intel chips), but you will not see the drastic slowdown from software arithmetic if your code is run on 32-bit.