### PR TITLE
 Added export of public symbols on Windows. 

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories("${XXHASH_DIR}")
 
 # libxxhash
 add_library(xxhash "${XXHASH_DIR}/xxhash.c")
+target_compile_definitions(xxhash PUBLIC XXH_EXPORT)
 set_target_properties(xxhash PROPERTIES
   SOVERSION "${XXHASH_VERSION_STRING}"
   VERSION "${XXHASH_VERSION_STRING}")

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -57,7 +57,9 @@ include_directories("${XXHASH_DIR}")
 
 # libxxhash
 add_library(xxhash "${XXHASH_DIR}/xxhash.c")
-target_compile_definitions(xxhash PUBLIC XXH_EXPORT)
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(xxhash PUBLIC XXH_EXPORT)
+endif ()
 set_target_properties(xxhash PROPERTIES
   SOVERSION "${XXHASH_VERSION_STRING}"
   VERSION "${XXHASH_VERSION_STRING}")

--- a/xxhash.h
+++ b/xxhash.h
@@ -107,7 +107,15 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 #    define XXH_PUBLIC_API static
 #  endif
 #else
-#  define XXH_PUBLIC_API   /* do nothing */
+#  ifdef WIN32
+#    ifdef XXH_EXPORT
+#      define XXH_PUBLIC_API __declspec(dllexport)
+#    else
+#      define XXH_PUBLIC_API __declspec(dllimport)
+#    endif
+#  else
+#    define XXH_PUBLIC_API   /* do nothing */
+#  endif
 #endif /* XXH_INLINE_ALL || XXH_PRIVATE_API */
 
 /*! XXH_NAMESPACE, aka Namespace Emulation :

--- a/xxhash.h
+++ b/xxhash.h
@@ -107,7 +107,7 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 #    define XXH_PUBLIC_API static
 #  endif
 #else
-#  ifdef WIN32
+#  if defined(WIN32) && !defined(__GNUC__)
 #    ifdef XXH_EXPORT
 #      define XXH_PUBLIC_API __declspec(dllexport)
 #    else


### PR DESCRIPTION
When I wanted to build xxHash on Windows with MSVC (Visual Studio 15 2017) and CMake, I got some linkage errors about xxhsum could not find the file xxhash.lib.

And it was normal because when MSVC build a shared library, it doesn't set every symbols to public like GCC. So the export/import declaration was missing for MSVC and it couldn't build the file xxhash.lib because for it there wasn't anything to export.

So, I added the missing export/import declaration for MSVC in `XXH_PUBLIC_API` and, for compilation in `shared` mode, the definition of `XXH_EXPORT` to tell xxHash to export the symbols or to import them when using the library.