### PR TITLE
Improve aarch64 performance

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -49,6 +49,11 @@
 #    define XXH_VECTOR XXH_AVX2
 #  elif defined(__SSE2__)
 #    define XXH_VECTOR XXH_SSE2
+/* GCC < 7 for aarch64 generates unreasonably slow code for the NEON
+ * implementation. We fall back to the scalar version and emit a warning. */
+#  elif defined(__aarch64__) && !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 7
+#    warning Your GCC version has broken NEON support. Please use GCC 7+ or Clang.
+#    define XXH_VECTOR XXH_SCALAR
 /* msvc support maybe later */
 #  elif defined(__GNUC__) && (defined(__ARM_NEON__) || defined(__ARM_NEON))
 #    define XXH_VECTOR XXH_NEON

--- a/xxh3.h
+++ b/xxh3.h
@@ -49,11 +49,6 @@
 #    define XXH_VECTOR XXH_AVX2
 #  elif defined(__SSE2__)
 #    define XXH_VECTOR XXH_SSE2
-/* GCC < 7 for aarch64 generates unreasonably slow code for the NEON
- * implementation. We fall back to the scalar version and emit a warning. */
-#  elif defined(__aarch64__) && !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 7
-#    warning Your GCC version has broken NEON support. Please use GCC 7+ or Clang.
-#    define XXH_VECTOR XXH_SCALAR
 /* msvc support maybe later */
 #  elif defined(__GNUC__) && (defined(__ARM_NEON__) || defined(__ARM_NEON))
 #    define XXH_VECTOR XXH_NEON
@@ -320,23 +315,26 @@ XXH3_accumulate_512(void* acc, const void *restrict data, const void *restrict k
              *  | v8.2s (.val[0]) |     <zero>     | v9.2s (.val[1]) |      <zero>     |
              *  '-----------------'----------------'-----------------'-----------------'
              * On aarch64, ld2 will put it into v8.2s and v9.2s. Reinterpreting
-             * is not going to help us here, as half of it will end up being zero. */
+             * is not going to help us here, as half of it will end up being zero.
+             *
+             * Even if it did, aarch64 apparently does really bad with shuffling, so
+             * we use a different method. */
 
             uint32x2x2_t d = vld2_u32(xdata + i * 4);     /* load and swap */
             uint32x2x2_t k = vld2_u32(xkey + i * 4);
             /* Not sorry about breaking the strict aliasing rule.
              * Using a union causes GCC to spit out nonsense, but an alias cast
              * does not. */
-            uint32x4_t const dk = vaddq_u32(*(uint32x4_t*)&d, *(uint32x4_t*)&k);
-            xacc[i] = vmlal_u32(xacc[i], vget_low_u32(dk), vget_high_u32(dk));
+            uint32x4_t const dk = vaddq_u32(*(uint32x4_t*)&d, *(uint32x4_t*)&k);  /* dk = d + k */
+            xacc[i] = vmlal_u32(xacc[i], vget_low_u32(dk), vget_high_u32(dk));    /* xacc[i] += (U64)dkLo * (U64)dkHi; */
 #else
-            /* Portable, but slightly slower version */
-            uint32x2x2_t const d = vld2_u32(xdata + i * 4);
-            uint32x2x2_t const k = vld2_u32(xkey + i * 4);
-            uint32x2_t const dkL = vadd_u32(d.val[0], k.val[0]);
-            uint32x2_t const dkH = vadd_u32(d.val[1], k.val[1]);   /* uint32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
-            /* xacc must be aligned on 16 bytes boundaries */
-            xacc[i] = vmlal_u32(xacc[i], dkL, dkH);                /* uint64 res[2] = {dk0*dk1,dk2*dk3} */
+            /* A portable and aarch64-friendly version. It is slower on ARMv7a, though. */
+            uint32x4_t d = vld1q_u32(xdata + i * 4);
+            uint32x4_t k = vld1q_u32(xkey + i * 4);
+            /* Add d and k, then reinterpret to a uint64x2_t. This is not a long add. */
+            uint64x2_t dk = vreinterpretq_u64_u32(vaddq_u32(d, k));           /* dk = (U64)(d[1] + k[1]) << 32) | (d[0] + k[0]); */
+            /* Long multiply high and low bits. */
+            xacc[i] = vmlal_u32(xacc[i], vmovn_u64(dk), vshrn_n_u64(dk, 32)); /* xacc[i] += (dk & 0xFFFFFFFF) * (dk >> 32); */
 #endif
         }
     }
@@ -424,6 +422,12 @@ static void XXH3_scrambleAcc(void* acc, const void* key)
             data = veorq_u64(data, xor_p5);
 
             {
+#ifdef __aarch64__
+                /* aarch64 prefers this method, ARMv7a prefers the other. */
+                uint64x2_t k = *(uint64x2_t *)(xkey + i * 4);
+                uint64x2_t const dk = vmull_u32(vmovn_u64(data), vmovn_u64(k));
+                uint64x2_t const dk2 = vmull_u32(vshrn_n_u64(data, 32), vshrn_n_u64(k, 32));
+#else
                 /* shuffle: 0, 1, 2, 3 -> 0, 2, 1, 3 */
                 uint32x2x2_t const d =
                     vzip_u32(
@@ -433,6 +437,7 @@ static void XXH3_scrambleAcc(void* acc, const void* key)
                 uint32x2x2_t const k = vld2_u32 (xkey+i*4);              /* load and swap */
                 uint64x2_t const dk  = vmull_u32(d.val[0],k.val[0]);     /* U64 dk[2]  = {d0 * k0, d2 * k2} */
                 uint64x2_t const dk2 = vmull_u32(d.val[1],k.val[1]);     /* U64 dk2[2] = {d1 * k1, d3 * k3} */
+#endif
                 xacc[i] = veorq_u64(dk, dk2);                            /* xacc[i] = dk ^ dk2;             */
         }   }
     }


### PR DESCRIPTION
Decided to move to a new PR.

OK, huge performance improvements found for aarch64.

Apparently, aarch64 **hates** shuffling with a passion and a pride. Even more than armv7a which wasn't so fond of it in the first place.

Using `vshrn`/`vmovn` is almost always faster than `vzip`/`vld2`. It also doesn't freak out GCC 6 so I can remove the warning.

```
./xxhsum 0.6.6 (64-bits little endian), by Yann Collet
Sample of 100 KB...
XXH32               :     102400 ->    38082 it/s ( 3718.9 MB/s)
XXH32 unaligned     :     102400 ->    37847 it/s ( 3696.0 MB/s)
XXH64               :     102400 ->    25979 it/s ( 2537.0 MB/s)
XXH64 unaligned     :     102400 ->    25971 it/s ( 2536.2 MB/s)
XXH3_64bits         :     102400 ->    66295 it/s ( 6474.2 MB/s)
XXH3_64b unaligned  :     102400 ->    65166 it/s ( 6363.8 MB/s)
```

Also, by the way, scalar isn't matching.
xxhash.c:
fe41ec4075ea7be1 -> vectorized
293cfafd94b5ab94 -> scalar

scalar does this for scramble:
```c
    for (i=0; i < (int)ACC_NB; i++) {
        int const left = 2*i;
        int const right= 2*i + 1;
        xacc[i] ^= xacc[i] >> 47;
        xacc[i] ^= PRIME64_5;

        {   U64 p1 = (xacc[i] >> 32) * xkey[left];
            U64 p2 = (xacc[i] & 0xFFFFFFFF) * xkey[right];
            xacc[i] = p1 ^ p2;
    }   }
```
while vector effectively does this
```c
    for (i=0; i < (int)ACC_NB; i++) {
        int const left = 2*i;
        int const right= 2*i + 1;
        xacc[i] ^= xacc[i] >> 47;
        xacc[i] ^= PRIME64_5;

        {   U64 p1 = (xacc[i] & 0xFFFFFFFF) * xkey[left];
            U64 p2 = (xacc[i] >> 32) * xkey[right];
            xacc[i] = p1 ^ p2;
    }   }
```

Which did you intend?