### PR TITLE
better uint128_t multiply for 32-bit, MSVC multiply intrinsics, and fix XXH32 SSE4 bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,7 @@ LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
 LIBVER_PATCH := $(shell echo $(LIBVER_PATCH_SCRIPT))
 LIBVER := $(LIBVER_MAJOR).$(LIBVER_MINOR).$(LIBVER_PATCH)
 
-# SSE4 detection
-HAVE_SSE4 := $(shell $(CC) -dM -E - < /dev/null | grep "SSE4" > /dev/null && echo 1 || echo 0)
-ifeq ($(HAVE_SSE4), 1)
-NOSSE4 := -mno-sse4
-else
-NOSSE4 :=
-endif
-
-CFLAGS ?= -O3 $(NOSSE4) # disables potential auto-vectorization
+CFLAGS ?= -O3
 DEBUGFLAGS+=-Wall -Wextra -Wconversion -Wcast-qual -Wcast-align -Wshadow \
             -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement \
             -Wstrict-prototypes -Wundef -Wpointer-arith -Wformat-security \

--- a/xxh3.h
+++ b/xxh3.h
@@ -99,7 +99,7 @@ __attribute__((__target__("no-sse")))
 static U64
 XXH3_mul128(U64 ll1, U64 ll2)
 {
-#if 0 && defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
 
     __uint128_t lll = (__uint128_t)ll1 * ll2;
     return (U64)lll + (U64)(lll >> 64);

--- a/xxhash.c
+++ b/xxhash.c
@@ -414,17 +414,6 @@ XXH32_endian_align(const void* input, size_t len, U32 seed,
         U32 v3 = seed + 0;
         U32 v4 = seed - PRIME32_1;
 
-        /* note : clang will try to vectorize this loop, using pmulld instruction.
-         * This is a bad idea, and will result in substantial performance reduction.
-         * To prevent clang from "optimizing" this loop,
-         * it's necessary to disable SSE4 on command line (-mno-sse4).
-         * However, this is a build instruction, so it's outside of source code.
-         * Whenever xxhash.c is used in a different code base, build flags don't follow.
-         * It would be better to ensure vectorization is disabled from within the source code.
-         * Alas, so far, I've not found a working method.
-         * I tried both `#pragma` and `__attribute__`, but clang still vectorizes.
-         * Help welcomed.
-         * In the meantime, vectorization is prevented by the `Makefile` */
         do {
             v1 = XXH32_round(v1, XXH_get32bits(p)); p+=4;
             v2 = XXH32_round(v2, XXH_get32bits(p)); p+=4;


### PR DESCRIPTION
Inline assembly is the only thing that works on Clang to stop it from vectorizing XXH32 because it is literally impossible to do so. This lets us (well, not me…) use the AVX2 version of XXH3 without worrying about XXH32, and lets us remove the Makefile hack.