### PR TITLE
Add unroll pragma for Clang in XXH3_accumulate.

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -503,6 +503,11 @@ static void XXH3_scrambleAcc(void* acc, const void* key)
 static void XXH3_accumulate(U64* acc, const void* restrict data, const U32* restrict key, size_t nbStripes)
 {
     size_t n;
+
+/* Clang doesn't unroll this loop without the pragma. Unrolling results in code that is about 1.4x faster. */
+#if defined(__clang__) && !defined(__OPTIMIZE_SIZE__)
+#  pragma clang loop unroll(enable)
+#endif
     for (n = 0; n < nbStripes; n++ ) {
         XXH3_accumulate_512(acc, (const BYTE*)data + n*STRIPE_LEN, key);
         key += 2;

--- a/xxh3.h
+++ b/xxh3.h
@@ -197,9 +197,9 @@ XXH3_mul128(U64 ll1, U64 ll2)
     U32 const l2 = (U32)ll2;
 
     U64 const llh  = XXH_mult32to64(h1, h2);
-    U64 const llm1 = XXH_mult32to64(l1, h2;
-    U64 const llm2 = XXH_mult32to64(h1, l2;
-    U64 const lll  = XXH_mult32to64(l1, l2;
+    U64 const llm1 = XXH_mult32to64(l1, h2);
+    U64 const llm2 = XXH_mult32to64(h1, l2);
+    U64 const lll  = XXH_mult32to64(l1, l2);
 
     U64 const t = lll + (llm1 << 32);
     U64 const carry1 = t < lll;


### PR DESCRIPTION
Clang doesn't unroll the XXH3_accumulate loop for some reason. Using `#pragma clang loop unroll(enable)` to hint to Clang that it should unroll results in a huge 1.4-1.5x speedup.

Before: 
```
XXH3_64bits         :     102400 ->   162910 it/s (15909.2 MB/s)
XXH3_64b unaligned  :     102400 ->   140762 it/s (13746.3 MB/s)
```
After:
```
XXH3_64bits         :     102400 ->   215992 it/s (21093.0 MB/s)
XXH3_64b unaligned  :     102400 ->   188791 it/s (18436.6 MB/s)
```