### PR TITLE
xxhash-bench: fix U64/PTime confusion.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
         - CPPFLAGS=-DXXH_VECTOR=1 make check   # SSE2 code path
         - make clean
         - CPPFLAGS="-mavx2 -DXXH_VECTOR=2" make check   # AVX2 code path
+        - make -C tests/bench
 
     - name: ARM + aarch64 compilation and consistency checks
       dist: xenial

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,8 @@ build_script:
         make -B clean test MOREFLAGS=-Werror
       ) ELSE (
         make -B clean test CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion"
-      )
+      ) &&
+      make -C tests/bench
     )
   - if "%PLATFORM%"=="visual_x64" (
       cd cmake_unofficial &&

--- a/tests/bench/Makefile
+++ b/tests/bench/Makefile
@@ -2,7 +2,7 @@
 
 CPPFLAGS += -I../..
 CFLAGS   ?= -O3
-CFLAGS   += -Wall -Wextra -Wstrict-aliasing=1
+CFLAGS   += -std=c99 -Wall -Wextra -Wstrict-aliasing=1
 CXXFLAGS ?= -O3
 
 

--- a/tests/bench/timefn.c
+++ b/tests/bench/timefn.c
@@ -22,7 +22,7 @@
 
 UTIL_time_t UTIL_getTime(void) { UTIL_time_t x; QueryPerformanceCounter(&x); return x; }
 
-U64 UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd)
+PTime UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd)
 {
     static LARGE_INTEGER ticksPerSecond;
     static int init = 0;
@@ -34,7 +34,7 @@ U64 UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd)
     return 1000000ULL*(clockEnd.QuadPart - clockStart.QuadPart)/ticksPerSecond.QuadPart;
 }
 
-U64 UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd)
+PTime UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd)
 {
     static LARGE_INTEGER ticksPerSecond;
     static int init = 0;
@@ -99,19 +99,19 @@ UTIL_time_t UTIL_getSpanTime(UTIL_time_t begin, UTIL_time_t end)
     return diff;
 }
 
-U64 UTIL_getSpanTimeMicro(UTIL_time_t begin, UTIL_time_t end)
+PTime UTIL_getSpanTimeMicro(UTIL_time_t begin, UTIL_time_t end)
 {
     UTIL_time_t const diff = UTIL_getSpanTime(begin, end);
-    U64 micro = 0;
+    PTime micro = 0;
     micro += 1000000ULL * diff.tv_sec;
     micro += diff.tv_nsec / 1000ULL;
     return micro;
 }
 
-U64 UTIL_getSpanTimeNano(UTIL_time_t begin, UTIL_time_t end)
+PTime UTIL_getSpanTimeNano(UTIL_time_t begin, UTIL_time_t end)
 {
     UTIL_time_t const diff = UTIL_getSpanTime(begin, end);
-    U64 nano = 0;
+    PTime nano = 0;
     nano += 1000000000ULL * diff.tv_sec;
     nano += diff.tv_nsec;
     return nano;
@@ -120,8 +120,8 @@ U64 UTIL_getSpanTimeNano(UTIL_time_t begin, UTIL_time_t end)
 #else   /* relies on standard C (note : clock_t measurements can be wrong when using multi-threading) */
 
 UTIL_time_t UTIL_getTime(void) { return clock(); }
-U64 UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
-U64 UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
+PTime UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
+PTime UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
 
 #endif
 


### PR DESCRIPTION
```
$ LC_ALL=C make
cc -O3 -Wall -Wextra -Wstrict-aliasing=1 -I../..  -c -o timefn.o timefn.c
timefn.c:123:1: error: unknown type name 'U64'
 U64 UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
 ^~~
timefn.c:123:5: error: conflicting types for 'UTIL_getSpanTimeMicro'
 U64 UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
     ^~~~~~~~~~~~~~~~~~~~~
In file included from timefn.c:14:0:
timefn.h:79:7: note: previous declaration of 'UTIL_getSpanTimeMicro' was here
 PTime UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd);
       ^~~~~~~~~~~~~~~~~~~~~
timefn.c:124:1: error: unknown type name 'U64'
 U64 UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
 ^~~
timefn.c:124:5: error: conflicting types for 'UTIL_getSpanTimeNano'
 U64 UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
     ^~~~~~~~~~~~~~~~~~~~
In file included from timefn.c:14:0:
timefn.h:80:7: note: previous declaration of 'UTIL_getSpanTimeNano' was here
 PTime UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd);
       ^~~~~~~~~~~~~~~~~~~~
<builtin>: recipe for target 'timefn.o' failed
make: *** [timefn.o] Error 1
```