### PR TITLE
Isolate multitarget code, add ARM Linux dispatching

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -20,6 +20,7 @@ mark_as_advanced(XXHASH_VERSION_MAJOR XXHASH_VERSION_MINOR XXHASH_VERSION_RELEAS
 
 option(BUILD_XXHSUM "Build the xxhsum binary" ON)
 option(BUILD_SHARED_LIBS "Build shared library" ON)
+option(MULTI_TARGET "Enable CPU dispatching if supported (Linux ARM32/x86/x86_64, MSVC, GCC, Clang, ICC only)" OFF)
 
 if("${CMAKE_VERSION}" VERSION_LESS "3.0")
   project(XXHASH C)
@@ -55,8 +56,71 @@ CMAKE_DEPENDENT_OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON "NOT XXHASH
 
 include_directories("${XXHASH_DIR}")
 
+set(MULTI_TARGET_LIBS "")
+if (MULTI_TARGET)
+    string (TOUPPER "${CMAKE_SYSTEM_PROCESSOR}" processor_name)
+    string (REGEX MATCH ".*ARM[^6].*" is_arm "${processor_name}")
+    string (REGEX MATCH ".*(AMD64|X86_64).*"  is_x86_64 "${processor_name}")
+    string (REGEX MATCH ".*(I386|I686|X86).*"  is_x86 "${processor_name}")
+    string (REGEX MATCH ".*(AppleClang|Clang|GNU|Intel).*" is_gcc_family "${CMAKE_C_COMPILER_ID} ${CMAKE_CXX_COMPILER_ID}")
+    if (((is_x86 OR is_x86_64) AND (is_gcc_family OR MSVC)) OR ((is_arm AND UNIX AND NOT APPLE) AND is_gcc_family))
+        set (CMAKE_C_FLAGS "-DXXH_MULTI_TARGET=1  ${CMAKE_C_FLAGS} ")
+        add_library(xxh3-scalar OBJECT  "${XXHASH_DIR}/xxh3-target.c")
+        set_property(TARGET xxh3-scalar PROPERTY POSITION_INDEPENDENT_CODE 1)
+        if (is_gcc_family)
+            target_compile_options(xxh3-scalar PRIVATE "-fno-tree-vectorize" "-fno-tree-slp-vectorize")
+        endif (is_gcc_family)
+        target_compile_definitions(xxh3-scalar PRIVATE XXH_VECTOR=0)
+
+        if (is_x86 OR is_x86_64)
+            add_library(xxh3-sse2 OBJECT "${XXHASH_DIR}/xxh3-target.c")
+            set_property(TARGET xxh3-sse2 PROPERTY POSITION_INDEPENDENT_CODE 1)
+            target_compile_definitions(xxh3-sse2 PRIVATE XXH_VECTOR=1)
+
+            add_library(xxh3-avx2 OBJECT "${XXHASH_DIR}/xxh3-target.c")
+            set_property(TARGET xxh3-avx2 PROPERTY POSITION_INDEPENDENT_CODE 1)
+            target_compile_definitions(xxh3-avx2 PRIVATE XXH_VECTOR=2)
+
+            if (MSVC)
+                if (NOT is_x86_64)
+                    target_compile_options(xxh3-sse2 PRIVATE "-arch:SSE2")
+                endif (NOT is_x86_64)
+                target_compile_options(xxh3-avx2 PRIVATE "-arch:AVX2")
+            else (MSVC)
+                target_compile_options(xxh3-sse2 PRIVATE "-msse2")
+                target_compile_options(xxh3-avx2 PRIVATE "-mavx2")
+            endif (MSVC)
+            set(MULTI_TARGET_LIBS "$<TARGET_OBJECTS:xxh3-scalar>" "$<TARGET_OBJECTS:xxh3-sse2>" "$<TARGET_OBJECTS:xxh3-avx2>")
+
+        else (is_x86 OR is_x86_64) # ARM
+            add_library(xxh3-neon OBJECT "${XXHASH_DIR}/xxh3-target.c")
+            set_property(TARGET xxh3-neon PROPERTY POSITION_INDEPENDENT_CODE 1)
+            target_compile_definitions(xxh3-neon PRIVATE XXH_VECTOR=3)
+            target_compile_options(xxh3-neon PRIVATE "-march=armv7-a" "-mfloat-abi=softfp" "-mfpu=neon-vfpv4")
+            set(MULTI_TARGET_LIBS "$<TARGET_OBJECTS:xxh3-scalar>" "$<TARGET_OBJECTS:xxh3-neon>")
+
+        endif (is_x86 OR is_x86_64)
+
+        message(STATUS "Multi target code enabled.")
+    else()
+        message(STATUS "Multi target code disabled (incompatible architecture)")
+    endif()
+    unset(processor_name)
+    unset(is_x86)
+    unset(is_x86_64)
+    unset(is_arm)
+    unset(is_gcc_family)
+endif (MULTI_TARGET)
+
+
+
+# Compile xxhash.c once as an object library.
+add_library(xxhash.c OBJECT "${XXHASH_DIR}/xxhash.c")
+set_property(TARGET xxhash.c PROPERTY POSITION_INDEPENDENT_CODE 1)
+
 # libxxhash
-add_library(xxhash "${XXHASH_DIR}/xxhash.c")
+add_library(xxhash "$<TARGET_OBJECTS:xxhash.c>" ${MULTI_TARGET_LIBS})
+
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(xxhash PUBLIC XXH_EXPORT)
 endif ()
@@ -66,7 +130,7 @@ set_target_properties(xxhash PROPERTIES
 
 # xxhsum
 add_executable(xxhsum "${XXHASH_DIR}/xxhsum.c")
-target_link_libraries(xxhsum xxhash)
+target_link_libraries(xxhsum "$<TARGET_OBJECTS:xxhash.c>" ${MULTI_TARGET_LIBS})
 
 # Extra warning flags
 include (CheckCCompilerFlag)

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -57,7 +57,7 @@ CMAKE_DEPENDENT_OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON "NOT XXHASH
 include_directories("${XXHASH_DIR}")
 
 set(MULTI_TARGET_LIBS "")
-if (MULTI_TARGET)
+if (MULTI_TARGET AND EXISTS "${XXHASH_DIR}/xxh3-target.c" AND EXISTS "${XXHASH_DIR}/xxh3-dispatch.h")
     string (TOUPPER "${CMAKE_SYSTEM_PROCESSOR}" processor_name)
     string (REGEX MATCH ".*ARM[^6].*" is_arm "${processor_name}")
     string (REGEX MATCH ".*(AMD64|X86_64).*"  is_x86_64 "${processor_name}")
@@ -86,20 +86,20 @@ if (MULTI_TARGET)
                     target_compile_options(xxh3-sse2 PRIVATE "-arch:SSE2")
                 endif (NOT is_x86_64)
                 target_compile_options(xxh3-avx2 PRIVATE "-arch:AVX2")
-            else (MSVC)
+            else ()
                 target_compile_options(xxh3-sse2 PRIVATE "-msse2")
                 target_compile_options(xxh3-avx2 PRIVATE "-mavx2")
-            endif (MSVC)
+            endif ()
             set(MULTI_TARGET_LIBS "$<TARGET_OBJECTS:xxh3-scalar>" "$<TARGET_OBJECTS:xxh3-sse2>" "$<TARGET_OBJECTS:xxh3-avx2>")
 
-        else (is_x86 OR is_x86_64) # ARM
+        else () # ARM
             add_library(xxh3-neon OBJECT "${XXHASH_DIR}/xxh3-target.c")
             set_property(TARGET xxh3-neon PROPERTY POSITION_INDEPENDENT_CODE 1)
             target_compile_definitions(xxh3-neon PRIVATE XXH_VECTOR=3)
             target_compile_options(xxh3-neon PRIVATE "-march=armv7-a" "-mfloat-abi=softfp" "-mfpu=neon-vfpv4")
             set(MULTI_TARGET_LIBS "$<TARGET_OBJECTS:xxh3-scalar>" "$<TARGET_OBJECTS:xxh3-neon>")
 
-        endif (is_x86 OR is_x86_64)
+        endif ()
 
         message(STATUS "Multi target code enabled.")
     else()
@@ -110,7 +110,7 @@ if (MULTI_TARGET)
     unset(is_x86_64)
     unset(is_arm)
     unset(is_gcc_family)
-endif (MULTI_TARGET)
+endif ()
 
 
 

--- a/xxh3-dispatch.h
+++ b/xxh3-dispatch.h
@@ -1,0 +1,277 @@
+/*
+   xxHash - Extremely Fast Hash algorithm
+   Development source file for `xxh3`
+   Copyright (C) 2019-present, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/* This is a private header which implements CPU dispatch code. */
+#ifndef XXH3_DISPATCH_H
+#define XXH3_DISPATCH_H
+
+#define XXH_TARGET_MODE_NONE 0
+#define XXH_TARGET_MODE_X86 1
+#define XXH_TARGET_MODE_ARM 2
+
+/* Figure out the best way to get a cpuid. */
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64))
+ /* MSVC has intrinsics for this. */
+#   include <intrin.h>
+#   define XXH_CPUID __cpuid
+#   define XXH_CPUIDEX __cpuidex
+#   define XXH_TARGET_MODE XXH_TARGET_MODE_X86
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+
+/* The GCC family can easily use inline assembly. */
+static void XXH_CPUIDEX(int* cpuInfo, int function_id, int function_ext)
+{
+    int eax, ecx;
+    eax = function_id;
+    ecx = function_ext;
+    __asm__ __volatile__(
+#ifdef (__x86_64__) /* EBX is required for PIC so save it */
+# define EBX "q %%rbx\n"
+#else
+# define EBX "l %%ebx\n"
+#endif
+        "push" EBX
+        "cpuid\n"
+        "movl %%ebx, %1\n"
+        "pop" EBX
+      : "+a" (eax), "=r" (cpuInfo[1]), "+c" (ecx), "=d" (cpuInfo[3]));
+#undef EBX
+    cpuInfo[0] = eax;
+    cpuInfo[2] = ecx;
+}
+static void XXH_CPUID(int *cpuInfo, int function_id)
+{
+    XXH_CPUIDEX(cpuInfo, function_id, 0);
+}
+#  define XXH_TARGET_MODE XXH_TARGET_MODE_X86
+/* ARM Linux */
+#elif defined(__linux__) && (defined(__arm__) || defined(__thumb__) || defined(__thumb2__))
+#  include <stdio.h> /* ARM needs fopen, fclose, and fgets */
+#  define XXH_TARGET_MODE XXH_TARGET_MODE_ARM
+#else
+#  define XXH_TARGET_MODE XXH_TARGET_MODE_NONE
+#  undef XXH_MULTI_TARGET
+#endif
+
+#if defined(XXH_MULTI_TARGET)
+/* Prototypes for our code. Because the code is in separate files, we need a symbol.
+ * The reserved identifiers are intentional. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+void _XXH3_hashLong_AVX2(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+void _XXH3_hashLong_SSE2(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+void _XXH3_hashLong_Scalar(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+void _XXH3_hashLong_NEON(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+#ifdef __cplusplus
+}
+#endif
+
+/* What hashLong version we decided on. cpuid is a SLOW instruction -- calling it takes anywhere
+ * from 30-40 to THOUSANDS of cycles), so we really don't want to call it more than once. */
+static XXH_cpu_mode_t cpu_mode = XXH_CPU_MODE_AUTO;
+
+/* What the best version supported is. This is used for verification on XXH_setCpuMode to prevent
+ * a SIGILL. It can be turned off with -DXXH_NO_VERIFY_MULTI_TARGET, in which the selected hash will
+ * be used unconditionally. */
+static XXH_cpu_mode_t supported_cpu_mode = XXH_CPU_MODE_AUTO;
+
+typedef void (*XXH3_hashLong_t)(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+
+
+/* We need to add a prototype for XXH3_dispatcher so we can refer to it later. */
+static void
+XXH3_dispatcher(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+
+/* We also store this as a function pointer, so we can just jump to it at runtime. */
+static XXH3_hashLong_t XXH3_hashLong = &XXH3_dispatcher;
+
+
+/* Tests features for x86 targets and sets the cpu_mode and the XXH3_hashLong function pointer
+ * to the correct value.
+ *
+ * On GCC compatible compilers, this will be run at program startup.
+ *
+ * xxh3-target.c will include this file. If we don't do this, the constructor will be called
+ * multiple times. We don't want that. */
+#if defined(__GNUC__) && !defined(XXH3_TARGET_C)
+__attribute__((__constructor__))
+#endif
+static XXH3_hashLong_t XXH3_featureTest(void)
+{
+    if (supported_cpu_mode != XXH_CPU_MODE_AUTO) {
+#if XXH_TARGET_MODE == XXH_TARGET_MODE_X86
+        if (supported_cpu_mode == XXH_CPU_MODE_AVX2) {
+            cpu_mode = XXH_CPU_MODE_AVX2;
+            XXH3_hashLong = &_XXH3_hashLong_AVX2;
+        } else if (supported_cpu_mode == XXH_CPU_MODE_SSE2 {
+            cpu_mode = XXH_CPU_MODE_SSE2;
+            XXH3_hashLong = &_XXH3_hashLong_SSE2;
+        } else
+#elif XXH_TARGET_MODE == XXH_TARGET_MODE_ARM
+        if (supported_cpu_mode == XXH_CPU_MODE_NEON) {
+            cpu_mode = XXH_CPU_MODE_NEON;
+            XXH3_hashLong = &_XXH3_hashLong_NEON;
+        } else
+#endif
+        {
+            cpu_mode = XXH_CPU_MODE_SCALAR;
+            XXH3_hashLong = &_XXH3_hashLong_Scalar;
+        }
+        return XXH3_hashLong;
+    }
+
+#if XXH_TARGET_MODE == XXH_TARGET_MODE_X86
+    {
+        int max, data[4];
+
+        /* First, get how many CPUID function parameters there are by calling CPUID with eax = 0. */
+        XXH_CPUID(data, /* eax */ 0);
+        max = data[0];
+        /* AVX2 is on the Extended Features page (eax = 7, ecx = 0), on bit 5 of ebx. */
+        if (max >= 7) {
+            XXH_CPUIDEX(data, /* eax */ 7, /* ecx */ 0);
+            if (data[1] & (1 << 5)) {
+                cpu_mode = supported_cpu_mode = XXH_CPU_MODE_AVX2;
+                XXH3_hashLong = &_XXH3_hashLong_AVX2;
+                return XXH3_hashLong;
+            }
+        }
+        /* SSE2 is on the Processor Info and Feature Bits page (eax = 1), on bit 26 of edx. */
+        if (max >= 1) {
+            XXH_CPUID(data, /* eax */ 1);
+            if (data[3] & (1 << 26)) {
+                cpu_mode = supported_cpu_mode = XXH_CPU_MODE_SSE2;
+                XXH3_hashLong = &_XXH3_hashLong_SSE2;
+                return XXH3_hashLong;
+            }
+        }
+    }
+#elif XXH_TARGET_MODE == XXH_TARGET_MODE_ARM
+    {
+        /* Parse /proc/cpuinfo. This is the best version on Linux because the test
+         * instruction needs privledged mode for no apparent reason. The cpufeatures
+         * library from the NDK also uses this method. */
+        char buf[1024];
+        FILE *f = fopen("/proc/cpuinfo", "r");
+
+        if (f != NULL) {
+            while (fgets(buf, 1024, f) != NULL) {
+                if (strstr(buf, "neon") != NULL || strstr(buf, "asimd") != NULL) {
+                    fclose(f);
+
+                    cpu_mode = supported_cpu_mode = XXH_CPU_MODE_NEON;
+                    XXH3_hashLong = &_XXH3_hashLong_NEON;
+                    return XXH3_hashLong;
+                }
+            }
+            fclose(f);
+        }
+    }
+#endif
+    /* Must be scalar. */
+    cpu_mode = supported_cpu_mode = XXH_CPU_MODE_SCALAR;
+    XXH3_hashLong = &_XXH3_hashLong_Scalar;
+    return XXH3_hashLong;
+}
+
+/* Sets up the dispatcher and then calls the actual hash function. */
+static void
+XXH3_dispatcher(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key)
+{
+    /* We haven't checked CPUID yet, so we check it now. On GCC, we try to get this to run
+     * at program startup to hide our very dirty secret from the benchmarks. */
+    return (XXH3_featureTest())(acc, data, len, key);
+}
+
+/* Sets the XXH3_hashLong variant. When XXH_MULTI_TARGET is not defined, this
+ * does nothing.
+ *
+ * Unless XXH_NO_VERIFY_MULTI_TARGET is defined, this will automatically fall back
+ * to the next best XXH3 mode, so, for example, even if you set it to AVX2, the code
+ * will not crash even if it is run on, for example, a Core 2 Duo which doesn't support
+ * AVX2. */
+XXH_PUBLIC_API XXH_cpu_mode_t XXH3_setCpuMode(XXH_cpu_mode_t mode)
+{
+/* Defining XXH_NO_VERIFY_MULTI_TARGET will allow you to set the CPU mode to
+ * an unsupported mode. */
+#ifndef XXH_NO_VERIFY_MULTI_TARGET
+    /* Call the featureTest if it hasn't been called already */
+    if (supported_cpu_mode == XXH_CPU_MODE_AUTO)
+        XXH3_featureTest();
+/* Even thougu XXH_CPU_MODE_NEON is greater than that, it will never
+ * be defined */
+#   define TRY_SET_MODE(mode_num, funcptr) \
+    do { \
+        if (mode == (mode_num) && supported_cpu_mode >= (mode_num)) { \
+            cpu_mode = (mode_num); \
+            XXH3_hashLong = &(funcptr); \
+            return (mode_num); \
+        } \
+   } while (0)
+#else
+#   define TRY_SET_MODE(mode_num, funcptr) \
+   do { \
+       if (mode == (mode_num)) { \
+            cpu_mode = (mode_num); \
+            XXH3_hashLong = &(funcptr); \
+            return (mode_num); \
+       }
+    } while (0)
+#endif
+
+#if XXH_TARGET_MODE == XXH_TARGET_MODE_X86
+    TRY_SET_MODE(XXH_CPU_MODE_AVX2, _XXH3_hashLong_AVX2);
+    TRY_SET_MODE(XXH_CPU_MODE_SSE2, _XXH3_hashLong_SSE2);
+#elif XXH_TARGET_MODE == XXH_TARGET_MODE_ARM
+    TRY_SET_MODE(XXH_CPU_MODE_NEON, _XXH3_hashLong_NEON);
+#endif
+    if (mode == XXH_CPU_MODE_SCALAR) {
+        cpu_mode = XXH_CPU_MODE_SCALAR;
+        XXH3_hashLong = &_XXH3_hashLong_Scalar;
+        return XXH_CPU_MODE_SCALAR;
+    }
+    cpu_mode = XXH_CPU_MODE_AUTO;
+    XXH3_hashLong = &XXH3_dispatcher;
+    return XXH_CPU_MODE_AUTO;
+#undef TRY_SET_MODE
+}
+
+/* Should we keep this? */
+XXH_PUBLIC_API XXH_cpu_mode_t XXH3_getCpuMode(void)
+{
+    return cpu_mode;
+}
+#endif /* XXH_MULTI_TARGET && !XXH3_TARGET_C */
+#endif /* XXH3_DISPATCH_H */

--- a/xxh3-target.c
+++ b/xxh3-target.c
@@ -1,0 +1,352 @@
+/*
+   xxHash - Extremely Fast Hash algorithm
+   Development source file for `xxh3`
+   Copyright (C) 2019-present, Yann Collet.
+
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/* Note :
+   This contains the target-dependent code for XXH3, namely
+   for the hashLong routine.
+   When XXH_MULTI_TARGET is defined, this will be compiled multiple times.
+*/
+
+
+/* ===   Dependencies   === */
+
+#ifndef XXH3_TARGET_C
+#define XXH3_TARGET_C
+
+#undef XXH_INLINE_ALL   /* in case it's already defined */
+#define XXH_INLINE_ALL
+#include "xxhash.h"
+
+#undef NDEBUG   /* avoid redefinition */
+#define NDEBUG
+#include <assert.h>
+
+
+/* ==========================================
+ * Vectorization detection
+ * ========================================== */
+#define XXH_SCALAR 0
+#define XXH_SSE2   1
+#define XXH_AVX2   2
+#define XXH_NEON   3
+
+#ifndef XXH_VECTOR    /* can be defined on command line */
+#  if defined(__AVX2__)
+#    define XXH_VECTOR XXH_AVX2
+#  elif defined(__SSE2__) \
+    || (defined(_MSC_VER) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2))) /* MSVC doesn't define __SSE2__. */
+#    define XXH_VECTOR XXH_SSE2
+/* msvc support maybe later */
+#  elif defined(__GNUC__) \
+  && (defined(__ARM_NEON__) || defined(__ARM_NEON)) \
+  && defined(__LITTLE_ENDIAN__) /* ARM big endian is a thing */
+#    define XXH_VECTOR XXH_NEON
+#  else
+#    define XXH_VECTOR XXH_SCALAR
+#  endif
+#endif
+
+
+#if XXH_VECTOR == XXH_SSE2 || XXH_VECTOR == XXH_AVX2
+#  include <immintrin.h>
+#elif XXH_VECTOR == XXH_NEON
+#  define inline __inline__ /* clang bug */
+#    include <arm_neon.h>
+#    undef inline
+#endif
+
+#undef hashLong
+#ifdef XXH_MULTI_TARGET
+#  if !defined(_WIN32) && defined(__GNUC__) && __GNUC__ >= 4
+     /* Avoid leaking a symbol */
+#    define XXH_VISIBILITY_HIDDEN  __attribute__ ((visibility ("hidden")))
+#  else
+#    define XXH_VISIBILITY_HIDDEN
+#  endif
+#  ifdef __cplusplus
+#    define XXH_HIDDEN_API extern "C" XXH_VISIBILITY_HIDDEN
+#  else
+#    define XXH_HIDDEN_API XXH_VISIBILITY_HIDDEN
+#  endif
+/* The use of reserved identifiers is intentional; these are not to be used directly. */
+#  if XXH_VECTOR == XXH_AVX2
+#    define hashLong _XXH3_hashLong_AVX2
+#  elif XXH_VECTOR == XXH_SSE2
+#    define hashLong _XXH3_hashLong_SSE2
+#  elif XXH_VECTOR == XXH_NEON
+#    define hashLong _XXH3_hashLong_NEON
+#  else
+#    define hashLong _XXH3_hashLong_Scalar
+#  endif
+#else
+#  define XXH_HIDDEN_API static
+#  define hashLong XXH3_hashLong
+#endif
+
+/* ===    Long Keys    === */
+
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512(void* acc, const void *restrict data, const void *restrict key)
+{
+#if (XXH_VECTOR == XXH_AVX2)
+
+    assert(((size_t)acc) & 31 == 0);
+    {   ALIGN(32) __m256i* const xacc  =       (__m256i *) acc;
+        const     __m256i* const xdata = (const __m256i *) data;
+        const     __m256i* const xkey  = (const __m256i *) key;
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+            __m256i const d   = _mm256_loadu_si256 (xdata+i);
+            __m256i const k   = _mm256_loadu_si256 (xkey+i);
+            __m256i const dk  = _mm256_xor_si256 (d,k);                                  /* uint32 dk[8]  = {d0+k0, d1+k1, d2+k2, d3+k3, ...} */
+            __m256i const res = _mm256_mul_epu32 (dk, _mm256_shuffle_epi32 (dk, 0x31));  /* uint64 res[4] = {dk0*dk1, dk2*dk3, ...} */
+            __m256i const add = _mm256_add_epi64(d, xacc[i]);
+            xacc[i]  = _mm256_add_epi64(res, add);
+        }
+    }
+
+#elif (XXH_VECTOR == XXH_SSE2)
+
+    assert(((size_t)acc) & 15 == 0);
+    {   ALIGN(16) __m128i* const xacc  =       (__m128i *) acc;
+        const     __m128i* const xdata = (const __m128i *) data;
+        const     __m128i* const xkey  = (const __m128i *) key;
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+            __m128i const d   = _mm_loadu_si128 (xdata+i);
+            __m128i const k   = _mm_loadu_si128 (xkey+i);
+            __m128i const dk  = _mm_xor_si128 (d,k);                                 /* uint32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+            __m128i const res = _mm_mul_epu32 (dk, _mm_shuffle_epi32 (dk, 0x31));    /* uint64 res[2] = {dk0*dk1,dk2*dk3} */
+            __m128i const add = _mm_add_epi64(d, xacc[i]);
+            xacc[i]  = _mm_add_epi64(res, add);
+        }
+    }
+
+#elif (XXH_VECTOR == XXH_NEON)   /* to be updated, no longer with latest sse/avx updates */
+
+    assert(((size_t)acc) & 15 == 0);
+    {       uint64x2_t* const xacc  =     (uint64x2_t *)acc;
+        const uint32_t* const xdata = (const uint32_t *)data;
+        const uint32_t* const xkey  = (const uint32_t *)key;
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN / sizeof(uint64x2_t); i++) {
+            uint32x4_t const d = vld1q_u32(xdata+i*4);                           /* U32 d[4] = xdata[i]; */
+            uint32x4_t const k = vld1q_u32(xkey+i*4);                            /* U32 k[4] = xkey[i]; */
+            uint32x4_t dk = veorq_u32(d, k);                                     /* U32 dk[4] = {d0^k0, d1^k1, d2^k2, d3^k3} */
+#if !defined(__aarch64__) && !defined(__arm64__) /* ARM32-specific hack */
+            /* vzip on ARMv7 Clang generates a lot of vmovs (technically vorrs) without this.
+             * vzip on 32-bit ARM NEON will overwrite the original register, and I think that Clang
+             * assumes I don't want to destroy it and tries to make a copy. This slows down the code
+             * a lot.
+             * aarch64 not only uses an entirely different syntax, but it requires three
+             * instructions...
+             *    ext    v1.16B, v0.16B, #8    // select high bits because aarch64 can't address them directly
+             *    zip1   v3.2s, v0.2s, v1.2s   // first zip
+             *    zip2   v2.2s, v0.2s, v1.2s   // second zip
+             * ...to do what ARM does in one:
+             *    vzip.32 d0, d1               // Interleave high and low bits and overwrite. */
+            __asm__("vzip.32 %e0, %f0" : "+w" (dk));                             /* dk = { dk0, dk2, dk1, dk3 }; */
+            xacc[i] = vaddq_u64(xacc[i], vreinterpretq_u64_u32(d));              /* xacc[i] += (U64x2)d; */
+            xacc[i] = vmlal_u32(xacc[i], vget_low_u32(dk), vget_high_u32(dk));   /* xacc[i] += { (U64)dk0*dk1, (U64)dk2*dk3 }; */
+#else
+            /* On aarch64, vshrn/vmovn seems to be equivalent to, if not faster than, the vzip method. */
+            uint32x2_t dkL = vmovn_u64(vreinterpretq_u64_u32(dk));               /* U32 dkL[2] = dk & 0xFFFFFFFF; */
+            uint32x2_t dkH = vshrn_n_u64(vreinterpretq_u64_u32(dk), 32);         /* U32 dkH[2] = dk >> 32; */
+            xacc[i] = vaddq_u64(xacc[i], vreinterpretq_u64_u32(d));              /* xacc[i] += (U64x2)d; */
+            xacc[i] = vmlal_u32(xacc[i], dkL, dkH);                              /* xacc[i] += (U64x2)dkL*(U64x2)dkH; */
+#endif
+        }
+    }
+
+#else   /* scalar variant of Accumulator - universal */
+
+          U64* const xacc  =       (U64*) acc;   /* presumed aligned */
+    const U32* const xdata = (const U32*) data;
+    const U32* const xkey  = (const U32*) key;
+
+    int i;
+    for (i=0; i < (int)ACC_NB; i++) {
+        int const left = 2*i;
+        int const right= 2*i + 1;
+        U32 const dataLeft  = XXH_readLE32(xdata + left);
+        U32 const dataRight = XXH_readLE32(xdata + right);
+        xacc[i] += XXH_mult32to64(dataLeft ^ xkey[left], dataRight ^ xkey[right]);
+        xacc[i] += dataLeft + ((U64)dataRight << 32);
+    }
+
+#endif
+}
+
+static void XXH3_scrambleAcc(void* acc, const void* key)
+{
+#if (XXH_VECTOR == XXH_AVX2)
+
+    assert(((size_t)acc) & 31 == 0);
+    {   ALIGN(32) __m256i* const xacc = (__m256i*) acc;
+        const     __m256i* const xkey  = (const __m256i *) key;
+        const __m256i k1 = _mm256_set1_epi32((int)PRIME32_1);
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+            __m256i data = xacc[i];
+            __m256i const shifted = _mm256_srli_epi64(data, 47);
+            data = _mm256_xor_si256(data, shifted);
+
+            {   __m256i const k   = _mm256_loadu_si256 (xkey+i);
+                __m256i const dk  = _mm256_xor_si256   (data, k);          /* U32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
+
+                __m256i const dk1 = _mm256_mul_epu32 (dk, k1);
+
+                __m256i const d2  = _mm256_shuffle_epi32 (dk, 0x31);
+                __m256i const dk2 = _mm256_mul_epu32 (d2, k1);
+                __m256i const dk2h= _mm256_slli_epi64 (dk2, 32);
+
+                xacc[i] = _mm256_add_epi64(dk1, dk2h);
+        }   }
+    }
+
+#elif (XXH_VECTOR == XXH_SSE2)
+
+    {   ALIGN(16) __m128i* const xacc = (__m128i*) acc;
+        const     __m128i* const xkey  = (const __m128i *) key;
+        const __m128i k1 = _mm_set1_epi32((int)PRIME32_1);
+
+        size_t i;
+        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+            __m128i data = xacc[i];
+            __m128i const shifted = _mm_srli_epi64(data, 47);
+            data = _mm_xor_si128(data, shifted);
+
+            {   __m128i const k   = _mm_loadu_si128 (xkey+i);
+                __m128i const dk  = _mm_xor_si128   (data,k);
+
+                __m128i const dk1 = _mm_mul_epu32 (dk,k1);
+
+                __m128i const d2  = _mm_shuffle_epi32 (dk, 0x31);
+                __m128i const dk2 = _mm_mul_epu32 (d2,k1);
+                __m128i const dk2h= _mm_slli_epi64(dk2, 32);
+
+                xacc[i] = _mm_add_epi64(dk1, dk2h);
+        }   }
+    }
+
+#elif (XXH_VECTOR == XXH_NEON)   /*  <============================================ Needs update !!!!!!!!!!! */
+
+    assert(((size_t)acc) & 15 == 0);
+    {       uint64x2_t* const xacc =     (uint64x2_t*) acc;
+        const uint32_t* const xkey = (const uint32_t*) key;
+        size_t i;
+        uint32x2_t const k1 = vdup_n_u32(PRIME32_1);
+        uint32x2_t const k2 = vdup_n_u32(PRIME32_2);
+
+        for (i=0; i < STRIPE_LEN/sizeof(uint64x2_t); i++) {
+            uint64x2_t data = xacc[i];
+            uint64x2_t const shifted = vshrq_n_u64(data, 47);          /* uint64 shifted[2] = data >> 47; */
+            data = veorq_u64(data, shifted);                           /* data ^= shifted; */
+            {
+                uint32x4_t const k = vld1q_u32(xkey+i*4);               /* load */
+                uint32x4_t const dk = veorq_u32(vreinterpretq_u32_u64(data), k); /* dk = data ^ key */
+                /* shuffle: 0, 1, 2, 3 -> 0, 2, 1, 3 */
+                uint32x2x2_t const split = vzip_u32(vget_low_u32(dk), vget_high_u32(dk));
+                uint64x2_t const dk1 = vmull_u32(split.val[0],k1);     /* U64 dk[2]  = {(U64)d0*k0, (U64)d2*k2} */
+                uint64x2_t const dk2 = vmull_u32(split.val[1],k2);     /* U64 dk2[2] = {(U64)d1*k1, (U64)d3*k3} */
+                xacc[i] = veorq_u64(dk1, dk2);                         /* xacc[i] = dk^dk2;             */
+        }   }
+    }
+
+#else   /* scalar variant of Scrambler - universal */
+
+          U64* const xacc =       (U64*) acc;
+    const U32* const xkey = (const U32*) key;
+
+    int i;
+    assert(((size_t)acc) & 7 == 0);
+    for (i=0; i < (int)ACC_NB; i++) {
+        U64 const key64 = XXH3_readKey64(xkey + 2*i);
+        U64 acc64 = xacc[i];
+        acc64 ^= acc64 >> 47;
+        acc64 ^= key64;
+        acc64 *= PRIME32_1;
+        xacc[i] = acc64;
+    }
+
+#endif
+}
+
+static void XXH3_accumulate(U64* acc, const void* restrict data, const U32* restrict key, size_t nbStripes)
+{
+    size_t n;
+    /* Clang doesn't unroll this loop without the pragma. Unrolling can be up to 1.4x faster. */
+#if defined(__clang__) && !defined(__OPTIMIZE_SIZE__)
+#  pragma clang loop unroll(enable)
+#endif
+    for (n = 0; n < nbStripes; n++ ) {
+        XXH3_accumulate_512(acc, (const BYTE*)data + n*STRIPE_LEN, key);
+        key += 2;
+    }
+}
+
+XXH_HIDDEN_API void
+hashLong(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key)
+{
+    #define NB_KEYS ((KEYSET_DEFAULT_SIZE - STRIPE_ELTS) / 2)
+
+    size_t const block_len = STRIPE_LEN * NB_KEYS;
+    size_t const nb_blocks = len / block_len;
+
+    size_t n;
+    for (n = 0; n < nb_blocks; n++) {
+        XXH3_accumulate(acc, (const BYTE*)data + n*block_len, key, NB_KEYS);
+        XXH3_scrambleAcc(acc, key + (KEYSET_DEFAULT_SIZE - STRIPE_ELTS));
+    }
+
+    /* last partial block */
+    assert(len > STRIPE_LEN);
+    {   size_t const nbStripes = (len % block_len) / STRIPE_LEN;
+        assert(nbStripes < NB_KEYS);
+        XXH3_accumulate(acc, (const BYTE*)data + nb_blocks*block_len, key, nbStripes);
+
+        /* last stripe */
+        if (len & (STRIPE_LEN - 1)) {
+            const BYTE* const p = (const BYTE*) data + len - STRIPE_LEN;
+            XXH3_accumulate_512(acc, p, key + nbStripes*2);
+    }   }
+}
+
+#undef hashLong
+#endif /* XXH3_TARGET_C */

--- a/xxh3.h
+++ b/xxh3.h
@@ -363,19 +363,24 @@ XXH_FORCE_INLINE void XXH3_initKeySeed(U32* key, U64 seed64)
 #define STRIPE_ELTS (STRIPE_LEN / sizeof(U32))
 #define ACC_NB (STRIPE_LEN / sizeof(U64))
 
-#ifdef XXH_MULTI_TARGET /* xxh3-dispatch may #undef XXH_MULTI_TARGET! */
+/* Check for __has_include so we can automatically include xxh3-target.c if it exists. */
+#ifndef __has_include
+#  define __has_include(x) 0
+#  define XXH_NO_HAS_INCLUDE 1
+#else
+#   define XXH_NO_HAS_INCLUDE 0
+#endif
+
+#ifdef XXH_MULTI_TARGET \
+    && (XXH_NO_HAS_INCLUDE \
+        || (__has_include("xxh3-target.c") && __has_include("xxh3-dispatch.h")))
+ /* xxh3-dispatch may #undef XXH_MULTI_TARGET! */
 #  include "xxh3-dispatch.h"
+#else
+#  undef XXH_MULTI_TARGET
 #endif
 
 #ifndef XXH_MULTI_TARGET
-/* Check for __has_include so we can automatically include xxh3-target.c if it exists. */
-#  ifndef __has_include
-#     define __has_include(x) 0
-#     define XXH_NO_HAS_INCLUDE 1
-#  else
-#     define XXH_NO_HAS_INCLUDE 0
-#  endif
-
 /* Define to 1 force native target if __has_include is missing or to 0 to force
  * scalar */
 #  ifndef XXH_NATIVE_TARGET

--- a/xxh3.h
+++ b/xxh3.h
@@ -59,44 +59,12 @@
 #endif
 
 #if defined(__GNUC__)
-#  if defined(__SSE2__)
-#    include <x86intrin.h>
-#  elif defined(__ARM_NEON__) || defined(__ARM_NEON)
-#    define inline __inline__ /* clang bug */
-#    include <arm_neon.h>
-#    undef inline
-#  endif
 #  define ALIGN(n)      __attribute__ ((aligned(n)))
 #elif defined(_MSC_VER)
 #  include <intrin.h>
 #  define ALIGN(n)      __declspec(align(n))
 #else
 #  define ALIGN(n)   /* disabled */
-#endif
-
-
-
-/* ==========================================
- * Vectorization detection
- * ========================================== */
-#define XXH_SCALAR 0
-#define XXH_SSE2   1
-#define XXH_AVX2   2
-#define XXH_NEON   3
-
-#ifndef XXH_VECTOR    /* can be defined on command line */
-#  if defined(__AVX2__)
-#    define XXH_VECTOR XXH_AVX2
-#  elif defined(__SSE2__)
-#    define XXH_VECTOR XXH_SSE2
-/* msvc support maybe later */
-#  elif defined(__GNUC__) \
-  && (defined(__ARM_NEON__) || defined(__ARM_NEON)) \
-  && defined(__LITTLE_ENDIAN__) /* ARM big endian is a thing */
-#    define XXH_VECTOR XXH_NEON
-#  else
-#    define XXH_VECTOR XXH_SCALAR
-#  endif
 #endif
 
 /* U64 XXH_mult32to64(U32 a, U64 b) { return (U64)a * (U64)b; } */
@@ -154,14 +122,6 @@ XXH3_mul128_fold64(U64 ll1, U64 ll2)
     U64 llhigh;
     U64 const lllow = _umul128(ll1, ll2, &llhigh);
     return lllow ^ llhigh;
-
-#elif defined(__aarch64__) && defined(__GNUC__)
-
-    U64 llow;
-    U64 llhigh;
-    __asm__("umulh %0, %1, %2" : "=r" (llhigh) : "r" (ll1), "r" (ll2));
-    __asm__("madd  %0, %1, %2, %3" : "=r" (llow) : "r" (ll1), "r" (ll2), "r" (llhigh));  /* <===================   to be modified => xor instead of add */
-    return lllow;
 
     /* Do it out manually on 32-bit.
      * This is a modified, unrolled, widened, and optimized version of the
@@ -357,243 +317,6 @@ XXH3_len_0to16_64b(const void* data, size_t len, XXH64_hash_t seed)
 }
 
 
-/* ===    Long Keys    === */
-
-#define STRIPE_LEN 64
-#define STRIPE_ELTS (STRIPE_LEN / sizeof(U32))
-#define ACC_NB (STRIPE_LEN / sizeof(U64))
-
-XXH_FORCE_INLINE void
-XXH3_accumulate_512(void* acc, const void *restrict data, const void *restrict key)
-{
-#if (XXH_VECTOR == XXH_AVX2)
-
-    assert(((size_t)acc) & 31 == 0);
-    {   ALIGN(32) __m256i* const xacc  =       (__m256i *) acc;
-        const     __m256i* const xdata = (const __m256i *) data;
-        const     __m256i* const xkey  = (const __m256i *) key;
-
-        size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
-            __m256i const d   = _mm256_loadu_si256 (xdata+i);
-            __m256i const k   = _mm256_loadu_si256 (xkey+i);
-            __m256i const dk  = _mm256_xor_si256 (d,k);                                  /* uint32 dk[8]  = {d0+k0, d1+k1, d2+k2, d3+k3, ...} */
-            __m256i const res = _mm256_mul_epu32 (dk, _mm256_shuffle_epi32 (dk, 0x31));  /* uint64 res[4] = {dk0*dk1, dk2*dk3, ...} */
-            __m256i const add = _mm256_add_epi64(d, xacc[i]);
-            xacc[i]  = _mm256_add_epi64(res, add);
-        }
-    }
-
-#elif (XXH_VECTOR == XXH_SSE2)
-
-    assert(((size_t)acc) & 15 == 0);
-    {   ALIGN(16) __m128i* const xacc  =       (__m128i *) acc;
-        const     __m128i* const xdata = (const __m128i *) data;
-        const     __m128i* const xkey  = (const __m128i *) key;
-
-        size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
-            __m128i const d   = _mm_loadu_si128 (xdata+i);
-            __m128i const k   = _mm_loadu_si128 (xkey+i);
-            __m128i const dk  = _mm_xor_si128 (d,k);                                 /* uint32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
-            __m128i const res = _mm_mul_epu32 (dk, _mm_shuffle_epi32 (dk, 0x31));    /* uint64 res[2] = {dk0*dk1,dk2*dk3} */
-            __m128i const add = _mm_add_epi64(d, xacc[i]);
-            xacc[i]  = _mm_add_epi64(res, add);
-        }
-    }
-
-#elif (XXH_VECTOR == XXH_NEON)   /* to be updated, no longer with latest sse/avx updates */
-
-    assert(((size_t)acc) & 15 == 0);
-    {       uint64x2_t* const xacc  =     (uint64x2_t *)acc;
-        const uint32_t* const xdata = (const uint32_t *)data;
-        const uint32_t* const xkey  = (const uint32_t *)key;
-
-        size_t i;
-        for (i=0; i < STRIPE_LEN / sizeof(uint64x2_t); i++) {
-            uint32x4_t const d = vld1q_u32(xdata+i*4);                           /* U32 d[4] = xdata[i]; */
-            uint32x4_t const k = vld1q_u32(xkey+i*4);                            /* U32 k[4] = xkey[i]; */
-            uint32x4_t dk = veorq_u32(d, k);                                     /* U32 dk[4] = {d0^k0, d1^k1, d2^k2, d3^k3} */
-#if !defined(__aarch64__) && !defined(__arm64__) /* ARM32-specific hack */
-            /* vzip on ARMv7 Clang generates a lot of vmovs (technically vorrs) without this.
-             * vzip on 32-bit ARM NEON will overwrite the original register, and I think that Clang
-             * assumes I don't want to destroy it and tries to make a copy. This slows down the code
-             * a lot.
-             * aarch64 not only uses an entirely different syntax, but it requires three
-             * instructions...
-             *    ext    v1.16B, v0.16B, #8    // select high bits because aarch64 can't address them directly
-             *    zip1   v3.2s, v0.2s, v1.2s   // first zip
-             *    zip2   v2.2s, v0.2s, v1.2s   // second zip
-             * ...to do what ARM does in one:
-             *    vzip.32 d0, d1               // Interleave high and low bits and overwrite. */
-            __asm__("vzip.32 %e0, %f0" : "+w" (dk));                             /* dk = { dk0, dk2, dk1, dk3 }; */
-            xacc[i] = vaddq_u64(xacc[i], vreinterpretq_u64_u32(d));              /* xacc[i] += (U64x2)d; */
-            xacc[i] = vmlal_u32(xacc[i], vget_low_u32(dk), vget_high_u32(dk));   /* xacc[i] += { (U64)dk0*dk1, (U64)dk2*dk3 }; */
-#else
-            /* On aarch64, vshrn/vmovn seems to be equivalent to, if not faster than, the vzip method. */
-            uint32x2_t dkL = vmovn_u64(vreinterpretq_u64_u32(dk));               /* U32 dkL[2] = dk & 0xFFFFFFFF; */
-            uint32x2_t dkH = vshrn_n_u64(vreinterpretq_u64_u32(dk), 32);         /* U32 dkH[2] = dk >> 32; */
-            xacc[i] = vaddq_u64(xacc[i], vreinterpretq_u64_u32(d));              /* xacc[i] += (U64x2)d; */
-            xacc[i] = vmlal_u32(xacc[i], dkL, dkH);                              /* xacc[i] += (U64x2)dkL*(U64x2)dkH; */
-#endif
-        }
-    }
-
-#else   /* scalar variant of Accumulator - universal */
-
-          U64* const xacc  =       (U64*) acc;   /* presumed aligned */
-    const U32* const xdata = (const U32*) data;
-    const U32* const xkey  = (const U32*) key;
-
-    int i;
-    for (i=0; i < (int)ACC_NB; i++) {
-        int const left = 2*i;
-        int const right= 2*i + 1;
-        U32 const dataLeft  = XXH_readLE32(xdata + left);
-        U32 const dataRight = XXH_readLE32(xdata + right);
-        xacc[i] += XXH_mult32to64(dataLeft ^ xkey[left], dataRight ^ xkey[right]);
-        xacc[i] += dataLeft + ((U64)dataRight << 32);
-    }
-
-#endif
-}
-
-static void XXH3_scrambleAcc(void* acc, const void* key)
-{
-#if (XXH_VECTOR == XXH_AVX2)
-
-    assert(((size_t)acc) & 31 == 0);
-    {   ALIGN(32) __m256i* const xacc = (__m256i*) acc;
-        const     __m256i* const xkey  = (const __m256i *) key;
-        const __m256i k1 = _mm256_set1_epi32((int)PRIME32_1);
-
-        size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
-            __m256i data = xacc[i];
-            __m256i const shifted = _mm256_srli_epi64(data, 47);
-            data = _mm256_xor_si256(data, shifted);
-
-            {   __m256i const k   = _mm256_loadu_si256 (xkey+i);
-                __m256i const dk  = _mm256_xor_si256   (data, k);          /* U32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
-
-                __m256i const dk1 = _mm256_mul_epu32 (dk, k1);
-
-                __m256i const d2  = _mm256_shuffle_epi32 (dk, 0x31);
-                __m256i const dk2 = _mm256_mul_epu32 (d2, k1);
-                __m256i const dk2h= _mm256_slli_epi64 (dk2, 32);
-
-                xacc[i] = _mm256_add_epi64(dk1, dk2h);
-        }   }
-    }
-
-#elif (XXH_VECTOR == XXH_SSE2)
-
-    {   ALIGN(16) __m128i* const xacc = (__m128i*) acc;
-        const     __m128i* const xkey  = (const __m128i *) key;
-        const __m128i k1 = _mm_set1_epi32((int)PRIME32_1);
-
-        size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
-            __m128i data = xacc[i];
-            __m128i const shifted = _mm_srli_epi64(data, 47);
-            data = _mm_xor_si128(data, shifted);
-
-            {   __m128i const k   = _mm_loadu_si128 (xkey+i);
-                __m128i const dk  = _mm_xor_si128   (data,k);
-
-                __m128i const dk1 = _mm_mul_epu32 (dk,k1);
-
-                __m128i const d2  = _mm_shuffle_epi32 (dk, 0x31);
-                __m128i const dk2 = _mm_mul_epu32 (d2,k1);
-                __m128i const dk2h= _mm_slli_epi64(dk2, 32);
-
-                xacc[i] = _mm_add_epi64(dk1, dk2h);
-        }   }
-    }
-
-#elif (XXH_VECTOR == XXH_NEON)   /*  <============================================ Needs update !!!!!!!!!!! */
-
-    assert(((size_t)acc) & 15 == 0);
-    {       uint64x2_t* const xacc =     (uint64x2_t*) acc;
-        const uint32_t* const xkey = (const uint32_t*) key;
-        size_t i;
-        uint32x2_t const k1 = vdup_n_u32(PRIME32_1);
-        uint32x2_t const k2 = vdup_n_u32(PRIME32_2);
-
-        for (i=0; i < STRIPE_LEN/sizeof(uint64x2_t); i++) {
-            uint64x2_t data = xacc[i];
-            uint64x2_t const shifted = vshrq_n_u64(data, 47);          /* uint64 shifted[2] = data >> 47; */
-            data = veorq_u64(data, shifted);                           /* data ^= shifted; */
-            {
-                uint32x4_t const k = vld1q_u32(xkey+i*4);               /* load */
-                uint32x4_t const dk = veorq_u32(vreinterpretq_u32_u64(data), k); /* dk = data ^ key */
-                /* shuffle: 0, 1, 2, 3 -> 0, 2, 1, 3 */
-                uint32x2x2_t const split = vzip_u32(vget_low_u32(dk), vget_high_u32(dk));
-                uint64x2_t const dk1 = vmull_u32(split.val[0],k1);     /* U64 dk[2]  = {(U64)d0*k0, (U64)d2*k2} */
-                uint64x2_t const dk2 = vmull_u32(split.val[1],k2);     /* U64 dk2[2] = {(U64)d1*k1, (U64)d3*k3} */
-                xacc[i] = veorq_u64(dk1, dk2);                         /* xacc[i] = dk^dk2;             */
-        }   }
-    }
-
-#else   /* scalar variant of Scrambler - universal */
-
-          U64* const xacc =       (U64*) acc;
-    const U32* const xkey = (const U32*) key;
-
-    int i;
-    assert(((size_t)acc) & 7 == 0);
-    for (i=0; i < (int)ACC_NB; i++) {
-        U64 const key64 = XXH3_readKey64(xkey + 2*i);
-        U64 acc64 = xacc[i];
-        acc64 ^= acc64 >> 47;
-        acc64 ^= key64;
-        acc64 *= PRIME32_1;
-        xacc[i] = acc64;
-    }
-
-#endif
-}
-
-static void XXH3_accumulate(U64* acc, const void* restrict data, const U32* restrict key, size_t nbStripes)
-{
-    size_t n;
-    /* Clang doesn't unroll this loop without the pragma. Unrolling can be up to 1.4x faster. */
-#if defined(__clang__) && !defined(__OPTIMIZE_SIZE__)
-#  pragma clang loop unroll(enable)
-#endif
-    for (n = 0; n < nbStripes; n++ ) {
-        XXH3_accumulate_512(acc, (const BYTE*)data + n*STRIPE_LEN, key);
-        key += 2;
-    }
-}
-
-static void
-XXH3_hashLong(U64* acc, const void* data, size_t len)
-{
-    #define NB_KEYS ((KEYSET_DEFAULT_SIZE - STRIPE_ELTS) / 2)
-
-    size_t const block_len = STRIPE_LEN * NB_KEYS;
-    size_t const nb_blocks = len / block_len;
-
-    size_t n;
-    for (n = 0; n < nb_blocks; n++) {
-        XXH3_accumulate(acc, (const BYTE*)data + n*block_len, kKey, NB_KEYS);
-        XXH3_scrambleAcc(acc, kKey + (KEYSET_DEFAULT_SIZE - STRIPE_ELTS));
-    }
-
-    /* last partial block */
-    assert(len > STRIPE_LEN);
-    {   size_t const nbStripes = (len % block_len) / STRIPE_LEN;
-        assert(nbStripes < NB_KEYS);
-        XXH3_accumulate(acc, (const BYTE*)data + nb_blocks*block_len, kKey, nbStripes);
-
-        /* last stripe */
-        if (len & (STRIPE_LEN - 1)) {
-            const BYTE* const p = (const BYTE*) data + len - STRIPE_LEN;
-            XXH3_accumulate_512(acc, p, kKey + nbStripes*2);
-    }   }
-}
-
 
 XXH_FORCE_INLINE U64 XXH3_mix2Accs(const U64* acc, const void* key)
 {
@@ -630,6 +353,269 @@ XXH_FORCE_INLINE void XXH3_initKeySeed(U32* key, U64 seed64)
     }
 }
 
+#define XXH_TARGET_MODE_NONE 0
+#define XXH_TARGET_MODE_X86 1
+#define XXH_TARGET_MODE_ARM 2
+
+#ifdef XXH_MULTI_TARGET
+/* Figure out the best way to get a cpuid. */
+#  if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64))
+   /* MSVC has intrinsics for this. */
+#     include <intrin.h>
+#     define XXH_CPUID __cpuid
+#     define XXH_CPUIDEX __cpuidex
+#     define XXH_TARGET_MODE XXH_TARGET_MODE_X86
+#  elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+
+   /* The GCC family can easily use inline assembly. */
+   static void XXH_CPUIDEX(int* cpuInfo, int function_id, int function_ext)
+   {
+       int eax, ecx;
+       eax = function_id;
+       ecx = function_ext;
+       __asm__ __volatile__(
+#ifdef (__x86_64__) /* EBX is required for PIC so save it */
+            "pushq %%rbx\n"
+#else
+            "pushl %%ebx\n"
+#endif
+            "cpuid\n"
+            "movl %%ebx, %1\n"
+#ifdef __x86_64__
+            "popq %%rbx\n"
+#else
+            "popl %%ebx\n"
+#endif
+         : "+a" (eax), "=r" (cpuInfo[1]), "+c" (ecx), "=d" (cpuInfo[3]));
+       cpuInfo[0] = eax;
+       cpuInfo[2] = ecx;
+   }
+   static void XXH_CPUID(int *cpuInfo, int function_id)
+   {
+       XXH_CPUIDEX(cpuInfo, function_id, 0);
+   }
+#  define XXH_TARGET_MODE XXH_TARGET_MODE_X86
+/* ARM Linux */
+#elif defined(__linux__) && (defined(__arm__) || defined(__thumb__) || defined(__thumb2__))
+   #include <stdio.h>
+   /* Parse /proc/cpuinfo. This is the best version on Linux because the test instruction
+    * stupidly needs privledged mode. The cpufeatures library from the NDK also uses
+    * this method. */
+   static int supports_neon(void)
+   {
+       char buf[1024];
+       FILE *f = fopen("/proc/cpuinfo", "rb");
+
+       if (f == NULL) {
+           return 0;
+       }
+       while (fgets(buf, 1024, f) != NULL) {
+           if (strstr(buf, "neon") != NULL || strstr(buf, "asimd") != NULL) {
+                fclose(f);
+                return 1;
+           }
+       }
+       fclose(f);
+       return 0;
+   }
+#  define XXH_TARGET_MODE XXH_TARGET_MODE_ARM
+#else
+     /* We don't know how to do this, just let them use the default. */
+#    undef XXH_MULTI_TARGET
+#    define XXH_TARGET_MODE XXH_TARGET_MODE_NONE
+#  endif /* else */
+#endif /* XXH_MULTI_TARGET */
+
+
+#define STRIPE_LEN 64
+#define STRIPE_ELTS (STRIPE_LEN / sizeof(U32))
+#define ACC_NB (STRIPE_LEN / sizeof(U64))
+
+#ifdef XXH_MULTI_TARGET
+/* Prototypes for our code. Because the code is in separate files, we need a symbol.
+ * The reserved identifiers are intentional. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+void _XXH3_hashLong_AVX2(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+void _XXH3_hashLong_SSE2(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+void _XXH3_hashLong_Scalar(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+void _XXH3_hashLong_NEON(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+#ifdef __cplusplus
+}
+#endif
+
+/* What hashLong version we decided on. cpuid is a SLOW instruction -- calling it takes anywhere
+ * from 30-40 to THOUSANDS of cycles), so we really don't want to call it more than once. */
+static XXH_cpu_mode_t cpu_mode = XXH_CPU_MODE_AUTO;
+
+/* What the best version supported is. This is used for verification on XXH_setCpuMode to prevent
+ * a SIGILL. It can be turned off with -DXXH_NO_VERIFY_MULTI_TARGET, in which the selected hash will
+ * be used unconditionally. */
+static XXH_cpu_mode_t supported_cpu_mode = XXH_CPU_MODE_AUTO;
+
+/* We need to add a prototype for XXH3_dispatcher so we can refer to it later. */
+static void
+XXH3_dispatcher(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key);
+
+/* We also store this as a function pointer, so we can just jump to it at runtime. */
+static void (*XXH3_hashLong)(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key) = &XXH3_dispatcher;
+
+/* Tests features for x86 targets and sets the cpu_mode and the XXH3_hashLong function pointer
+ * to the correct value.
+ *
+ * On GCC compatible compilers, this will be run at program startup.
+ *
+ * xxh3-target.c will include this file. If we don't do this, the constructor will be called
+ * multiple times. We don't want that. */
+#if !defined(XXH3_TARGET_C) && defined(__GNUC__)
+__attribute__((__constructor__))
+#endif
+static void XXH3_featureTest(void)
+{
+    if (supported_cpu_mode != XXH_CPU_MODE_AUTO) {
+#if XXH_TARGET_MODE == XXH_TARGET_MODE_X86
+        if (supported_cpu_mode == XXH_CPU_MODE_AVX2) {
+            cpu_mode = XXH_CPU_MODE_AVX2;
+            XXH3_hashLong = &_XXH3_hashLong_AVX2;
+            return;
+        }
+        if (supported_cpu_mode == XXH_CPU_MODE_SSE2 {
+            cpu_mode = XXH_CPU_MODE_SSE2;
+            XXH3_hashLong = &_XXH3_hashLong_SSE2;
+            return;
+        }
+#elif XXH_TARGET_MODE == XXH_TARGET_MODE_ARM
+        if (supported_cpu_mode == XXH_CPU_MODE_NEON) {
+            cpu_mode = XXH_CPU_MODE_NEON;
+            XXH3_hashLong = &_XXH3_hashLong_NEON;
+            return;
+        }
+#endif
+        cpu_mode = XXH_CPU_MODE_SCALAR;
+        XXH3_hashLong = &_XXH3_hashLong_Scalar;
+        return;
+    }
+
+#if XXH_TARGET_MODE == XXH_TARGET_MODE_X86
+    int max, data[4];
+
+    /* First, get how many CPUID function parameters there are by calling CPUID with eax = 0. */
+    XXH_CPUID(data, /* eax */ 0);
+    max = data[0];
+    /* AVX2 is on the Extended Features page (eax = 7, ecx = 0), on bit 5 of ebx. */
+    if (max >= 7) {
+        XXH_CPUIDEX(data, /* eax */ 7, /* ecx */ 0);
+        if (data[1] & (1 << 5)) {
+            cpu_mode = supported_cpu_mode = XXH_CPU_MODE_AVX2;
+            XXH3_hashLong = &_XXH3_hashLong_AVX2;
+            return;
+        }
+    }
+    /* SSE2 is on the Processor Info and Feature Bits page (eax = 1), on bit 26 of edx. */
+    if (max >= 1) {
+        XXH_CPUID(data, /* eax */ 1);
+        if (data[3] & (1 << 26)) {
+            cpu_mode = supported_cpu_mode = XXH_CPU_MODE_SSE2;
+            XXH3_hashLong = &_XXH3_hashLong_SSE2;
+            return;
+        }
+    }
+#elif XXH_TARGET_MODE == XXH_TARGET_MODE_ARM
+    if (supports_neon()) {
+        cpu_mode = supported_cpu_mode = XXH_CPU_MODE_NEON;
+        XXH3_hashLong = &_XXH3_hashLong_NEON;
+        return;
+    }
+#endif
+    /* Must be scalar. */
+    cpu_mode = supported_cpu_mode = XXH_CPU_MODE_SCALAR;
+    XXH3_hashLong = &_XXH3_hashLong_Scalar;
+}
+
+/* Sets up the dispatcher and then calls the actual hash function. */
+static void
+XXH3_dispatcher(U64* restrict acc, const void* restrict data, size_t len, const U32* restrict key)
+{
+    /* We haven't checked CPUID yet, so we check it now. On GCC, we try to get this to run
+     * at program startup to hide our very dirty secret from the benchmarks. */
+    XXH3_featureTest();
+    XXH3_hashLong(acc, data, len, key);
+}
+
+#else /* !XXH_MULTI_TARGET */
+   /* Include the C file directly and let the compiler decide which implementation to use. */
+#  include "xxh3-target.c"
+#endif /* XXH_MULTI_TARGET */
+
+/* Sets the XXH3_hashLong variant. When XXH_MULTI_TARGET is not defined, this
+ * does nothing.
+ *
+ * Unless XXH_NO_VERIFY_MULTI_TARGET is defined, this will automatically fall back
+ * to the next best XXH3 mode, so, for example, even if you set it to AVX2, the code
+ * will not crash even if it is run on, for example, a Core 2 Duo which doesn't support
+ * AVX2. */
+XXH_PUBLIC_API XXH_cpu_mode_t XXH3_setCpuMode(XXH_cpu_mode_t mode)
+{
+#ifdef XXH_MULTI_TARGET
+/* Defining XXH_NO_VERIFY_MULTI_TARGET will allow you to set the CPU mode to
+ * an unsupported mode. */
+#ifndef XXH_NO_VERIFY_MULTI_TARGET
+    /* Call the featureTest if it hasn't been called already */
+    if (supported_cpu_mode == XXH_CPU_MODE_AUTO)
+        XXH3_featureTest();
+/* Even thougu XXH_CPU_MODE_NEON is greater than that, it will never
+ * be defined */
+#   define TRY_SET_MODE(mode_num, funcptr) \
+    do { \
+        if (mode == (mode_num) && supported_cpu_mode >= (mode_num)) { \
+            cpu_mode = (mode_num); \
+            XXH3_hashLong = &(funcptr); \
+            return (mode_num); \
+        } \
+   } while (0)
+#else
+#   define TRY_SET_MODE(mode_num, funcptr) \
+   do { \
+       if (mode == (mode_num)) { \
+            cpu_mode = (mode_num); \
+            XXH3_hashLong = &(funcptr); \
+            return (mode_num); \
+       }
+    } while (0)
+#endif
+
+#if XXH_TARGET_MODE == XXH_TARGET_MODE_X86
+    TRY_SET_MODE(XXH_CPU_MODE_AVX2, _XXH3_hashLong_AVX2);
+    TRY_SET_MODE(XXH_CPU_MODE_SSE2, _XXH3_hashLong_SSE2);
+#elif XXH_TARGET_MODE == XXH_TARGET_MODE_ARM
+    TRY_SET_MODE(XXH_CPU_MODE_NEON, _XXH3_hashLong_NEON);
+#endif
+    if (mode == XXH_CPU_MODE_SCALAR) {
+        cpu_mode = XXH_CPU_MODE_SCALAR;
+        XXH3_hashLong = &_XXH3_hashLong_Scalar;
+        return XXH_CPU_MODE_SCALAR;
+    }
+    cpu_mode = XXH_CPU_MODE_AUTO;
+    XXH3_hashLong = &XXH3_dispatcher;
+    return XXH_CPU_MODE_AUTO;
+#undef TRY_SET_MODE
+#else
+    (void) mode;
+    return (XXH_cpu_mode_t)XXH_VECTOR;
+#endif
+}
+
+/* Should we keep this? */
+XXH_PUBLIC_API XXH_cpu_mode_t XXH3_getCpuMode(void)
+{
+#ifdef XXH_MULTI_TARGET
+    return cpu_mode;
+#else
+    return (XXH_cpu_mode_t) XXH_VECTOR;
+#endif
+}
+
 XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
 XXH3_hashLong_64b(const void* data, size_t len, XXH64_hash_t seed)
 {
@@ -638,7 +624,7 @@ XXH3_hashLong_64b(const void* data, size_t len, XXH64_hash_t seed)
 
     XXH3_initKeySeed(key, seed);
 
-    XXH3_hashLong(acc, data, len);
+    XXH3_hashLong(acc, data, len, kKey);
 
     /* converge into final hash */
     assert(sizeof(acc) == 64);
@@ -779,7 +765,7 @@ XXH3_hashLong_128b(const void* data, size_t len, XXH64_hash_t seed)
     ALIGN(64) U64 acc[ACC_NB] = { seed, PRIME64_1, PRIME64_2, PRIME64_3, PRIME64_4, PRIME64_5, (U64)0 - seed, 0 };
     assert(len > 128);
 
-    XXH3_hashLong(acc, data, len);
+    XXH3_hashLong(acc, data, len, kKey);
 
     /* converge into final hash */
     assert(sizeof(acc) == 64);

--- a/xxhash.h
+++ b/xxhash.h
@@ -406,6 +406,14 @@ struct XXH64_state_s {
 #  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
 #  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
 #  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
+#  define XXH3_setCpuMode XXH_NAME2(XXH_NAMESPACE, XXH3_setCpuMode)
+#  define XXH3_getCpuMode XXH_NAME2(XXH_NAMESPACE, XXH3_getCpuMode)
+/* Private API, but it still needs a namespace because the mulit target code always
+ * emits a symbol. */
+#  define _XXH3_hashLong_Scalar XXH_NAME2(XXH_NAMESPACE, _XXH3_hashLong_Scalar)
+#  define _XXH3_hashLong_SSE2 XXH_NAME2(XXH_NAMESPACE, _XXH3_hashLong_SSE2)
+#  define _XXH3_hashLong_AVX2 XXH_NAME2(XXH_NAMESPACE, _XXH3_hashLong_AVX2)
+#  define _XXH3_hashLong_NEON XXH_NAME2(XXH_NAMESPACE, _XXH3_hashLong_NEON)
 #endif
 
 
@@ -422,6 +430,22 @@ XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, 
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, unsigned long long seed);  /* == XXH128() */
 
+typedef enum { /* KEEP IN SYNC WITH XXH_VECTOR */
+    XXH_CPU_MODE_AUTO = -1,
+    XXH_CPU_MODE_SCALAR = 0,
+    XXH_CPU_MODE_SSE2 = 1,
+    XXH_CPU_MODE_AVX2 = 2,
+    XXH_CPU_MODE_NEON = 3
+} XXH_cpu_mode_t;
+
+/* Tries to change the hashLong method to one of the above. If the selected CPU mode
+ * is not supported, it selects what it deems to be the next best one and returns it
+ * Setting it to XXH_CPU_MODE_AUTO will use the automatically detected version.
+ *
+ * If XXH_MULTI_TARGET was not defined, this does nothing but return the mode that
+ * it was compiled with. */
+XXH_PUBLIC_API XXH_cpu_mode_t XXH3_setCpuMode(XXH_cpu_mode_t mode);
+XXH_PUBLIC_API XXH_cpu_mode_t XXH3_getCpuMode(void);
 
 #endif  /* XXH_NO_LONG_LONG */
 


### PR DESCRIPTION
- This is the multitargeting code, just the multitargeting code, and nothing but the multitargeting code
- I also added support for dispatching on ARM Linux (incl. Android) which checks /proc/cpuinfo.
- Switches are removed because it triggered -Wswitch-enum.