### PR TITLE
MSVC Fixed warning C4244 in xxh3.h

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -295,7 +295,7 @@ XXH3_len_1to3_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t
         BYTE const c3 = ((const BYTE*)data)[len - 1];
         U32  const l1 = (U32)(c1) + ((U32)(c2) << 8);
         U32  const l2 = (U32)(len) + ((U32)(c3) << 2);
-        U64  const ll11 = XXH_mult32to64((l1 + seed + key32[0]), (l2 + key32[1]));
+        U64  const ll11 = XXH_mult32to64((unsigned int)(l1 + seed + key32[0]), (unsigned int)(l2 + key32[1]));
         return XXH3_avalanche(ll11);
     }
 }
@@ -689,8 +689,8 @@ XXH3_len_1to3_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_
         BYTE const c3 = ((const BYTE*)data)[len - 1];
         U32  const l1 = (U32)(c1) + ((U32)(c2) << 8);
         U32  const l2 = (U32)(len) + ((U32)(c3) << 2);
-        U64  const ll11 = XXH_mult32to64(l1 + seed + key32[0], l2 + key32[1]);
-        U64  const ll12 = XXH_mult32to64(l1 + key32[2], l2 - seed + key32[3]);
+        U64  const ll11 = XXH_mult32to64((unsigned int)(l1 + seed + key32[0]), (unsigned int)(l2 + key32[1]));
+        U64  const ll12 = XXH_mult32to64((unsigned int)(l1 + key32[2]), (unsigned int)(l2 - seed + key32[3]));
         XXH128_hash_t const h128 = { XXH3_avalanche(ll11), XXH3_avalanche(ll12) };
         return h128;
     }


### PR DESCRIPTION
Small change to the usage of XXH_mult32to64 in xxh3.h that fixes the C4244 warning in MSVC.

- Fixed warning C4244 conversion from 'XXH64_hash_t' to 'unsigned int', possible loss of data