### PR TITLE
Add configuration to reroll most loops.

### DIFF
--- a/xxhash.c
+++ b/xxhash.c
@@ -112,6 +112,7 @@ static void  XXH_free  (void* p)  { free(p); }
 static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcpy(dest,src,size); }
 
 #include <assert.h>   /* assert */
+#include <limits.h>   /* ULLONG_MAX for later */
 
 #define XXH_STATIC_LINKING_ONLY
 #include "xxhash.h"


### PR DESCRIPTION
`XXH_REROLL`: Rerolls the following functions:
 - `XXH32_finalize`
 - `XXH64_finalize`
 - `XXH3_64bitsWithSeed`
 - `XXH3_128bitsWithSeed`
 - `XXH3_accumulate` (disables pragma)

Automatically enabled with `__OPTIMIZE_SIZE__`.

`XXH_REROLL_XXH64`: Specifically controls rerolling `XXH64_finalize`. This is automatically defined on non-64-bit targets, as the unroll makes the binary huge (`XXH64_finalize` on i386 alone is the largest function in the program), and it actually slows things down.

If `XXH_REROLL` is defined, this is ignored and the loop is rerolled anyways.