### PR TITLE
Detect SSE2 on MSVC 32 bit as well

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -92,7 +92,7 @@
 #ifndef XXH_VECTOR    /* can be defined on command line */
 #  if defined(__AVX2__)
 #    define XXH_VECTOR XXH_AVX2
-#  elif defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || (_M_IX86_FP == 2)
+#  elif defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2))
 #    define XXH_VECTOR XXH_SSE2
 #  elif defined(__GNUC__) /* msvc support maybe later */ \
   && (defined(__ARM_NEON__) || defined(__ARM_NEON)) \

--- a/xxh3.h
+++ b/xxh3.h
@@ -92,7 +92,7 @@
 #ifndef XXH_VECTOR    /* can be defined on command line */
 #  if defined(__AVX2__)
 #    define XXH_VECTOR XXH_AVX2
-#  elif defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64)
+#  elif defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || (_M_IX86_FP == 2)
 #    define XXH_VECTOR XXH_SSE2
 #  elif defined(__GNUC__) /* msvc support maybe later */ \
   && (defined(__ARM_NEON__) || defined(__ARM_NEON)) \


### PR DESCRIPTION
Detecting SSE2 instructions on Visual Studio when it's compiling for x86 32-bit needs to be done by yet another macro, see https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019

The change turns performance graph from the red line into the blue one.

![Clipboard01](https://user-images.githubusercontent.com/348087/59176285-3f346e00-8b61-11e9-865d-6f2a97511b20.png)

Somewhat related to things discussed at #211 