### PR TITLE
XXH3_64bits_withSecret()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
         - CC=aarch64-linux-gnu-gcc CPPFLAGS=-DXXH_VECTOR=3 LDFLAGS=-static RUN_ENV=qemu-aarch64-static make check   # NEON code path
         - make clean
 
-    - name: PowerPC + PPC64 compilation and consistency checks
+    - name: PowerPC + PPC64 compilation and consistency checks (Trusty)
       dist: trusty
       install:
         - sudo apt-get install -qq qemu-system-ppc qemu-user-static gcc-powerpc-linux-gnu
@@ -58,4 +58,4 @@ matrix:
         - make clean
         - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec" LDFLAGS="-static -m64" make check   # VSX code path
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx" LDFLAGS="-static -m64" make check   # VSX code path

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,13 @@ matrix:
         - make clean
         - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CFLAGS="-O3 -m64 -maltivec -mvsx" LDFLAGS="-static -m64" make check   # Auto code path
+        # Note : the following test will fail
+        # because it will trigger the VSX code path
+        # while missing the `vec_revb()` instruction, hence compilation will fail.
+        # to be fixed one day.
+        # - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CFLAGS="-O3 -m64 -maltivec -mvsx" LDFLAGS="-static -m64" make check   # Auto code path
         - make clean
         # Note : the following test does not work on Ubuntu Trusty.
         # It requires support for `power9` instruction due to `vec_revb()`
         # which is missing from the powerpc-gcc compiler version shipped with Ubuntu Trusty (max `power8`)
-        #- CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx -mcpu=power8" LDFLAGS="-static -m64" make check   # VSX code path
+        # - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx -mcpu=power8" LDFLAGS="-static -m64" make check   # VSX code path

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
         - make clean
 
     - name: PowerPC + PPC64 compilation and consistency checks
+      dist: trusty
       install:
         - sudo apt-get install -qq qemu-system-ppc qemu-user-static gcc-powerpc-linux-gnu
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ matrix:
         - make clean
         - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # VSX code path
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec" LDFLAGS="-static -m64" make check   # VSX code path

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,9 @@ matrix:
         - make clean
         - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx -mcpu=power8" LDFLAGS="-static -m64" make check   # VSX code path
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CFLAGS="-O3 -m64 -maltivec -mvsx" LDFLAGS="-static -m64" make check   # Auto code path
+        - make clean
+        # Note : the following test does not work on Ubuntu Trusty.
+        # It requires support for `power9` instruction due to `vec_revb()`
+        # which is missing from the powerpc-gcc compiler version shipped with Ubuntu Trusty (max `power8`)
+        #- CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx -mcpu=power8" LDFLAGS="-static -m64" make check   # VSX code path

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,8 @@ matrix:
       install:
         - sudo apt-get install -qq qemu-system-ppc qemu-user-static gcc-powerpc-linux-gnu
       script:
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc-static CPPFLAGS=-m32 LDFLAGS=-static make check   # Only scalar code path available
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc-static CPPFLAGS=-m32 LDFLAGS=-static make check   # Scalar code path
         - make clean
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Only scalar code path available
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # VSX code path

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ matrix:
         - make clean
         - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx" LDFLAGS="-static -m64" make check   # VSX code path
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx -mcpu=power9" LDFLAGS="-static -m64" make check   # VSX code path

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ matrix:
         - make clean
         - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3 -m64" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
-        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx -mcpu=power9" LDFLAGS="-static -m64" make check   # VSX code path
+        - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -m64 -maltivec -mvsx -mcpu=power8" LDFLAGS="-static -m64" make check   # VSX code path

--- a/xxh3.h
+++ b/xxh3.h
@@ -744,12 +744,15 @@ XXH3_hashLong_64b(const void* data, size_t len, const void* secret, size_t secre
     return XXH3_mergeAccs(acc, secret, (U64)len * PRIME64_1);
 }
 
+/* XXH3_initKeySeed() :
+ * destination `key` is presumed allocated and have same size as kKey
+ */
 XXH_FORCE_INLINE void XXH3_initKeySeed(U32* key, U64 seed64)
 {
     U32 const seed1 = (U32)seed64;
     U32 const seed2 = (U32)(seed64 >> 32);
     int i;
-    assert(KEYSET_DEFAULT_SIZE & 3 == 0);
+    XXH_STATIC_ASSERT((KEYSET_DEFAULT_SIZE & 3) == 0);
     for (i=0; i < KEYSET_DEFAULT_SIZE; i+=4) {
         key[i+0] = kKey[i+0] + seed1;
         key[i+1] = kKey[i+1] - seed2;

--- a/xxh3.h
+++ b/xxh3.h
@@ -746,14 +746,14 @@ XXH_FORCE_INLINE U64 XXH3_mix2Accs(const U64* acc, const void* key)
                acc[1] ^ XXH3_readKey64(key64+1) );
 }
 
-static XXH64_hash_t XXH3_mergeAccs(const U64* acc, const U32* key, U64 start)
+static XXH64_hash_t XXH3_mergeAccs(const U64* acc, const void* key, U64 start)
 {
     U64 result64 = start;
 
-    result64 += XXH3_mix2Accs(acc+0, key+0);
-    result64 += XXH3_mix2Accs(acc+2, key+4);
-    result64 += XXH3_mix2Accs(acc+4, key+8);
-    result64 += XXH3_mix2Accs(acc+6, key+12);
+    result64 += XXH3_mix2Accs(acc+0, (const U64*)key + 0);
+    result64 += XXH3_mix2Accs(acc+2, (const U64*)key + 2);
+    result64 += XXH3_mix2Accs(acc+4, (const U64*)key + 4);
+    result64 += XXH3_mix2Accs(acc+6, (const U64*)key + 6);
 
     return XXH3_avalanche(result64);
 }

--- a/xxh3.h
+++ b/xxh3.h
@@ -383,18 +383,6 @@ XXH3_len_1to3_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t
 }
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_len_0to16_64b_s(const void* data, size_t len, const void* secret)
-{
-    assert(data != NULL);
-    assert(len <= 16);
-    {   if (len > 8) return XXH3_len_9to16_64b_s(data, len, secret);
-        if (len >= 4) return XXH3_len_4to8_64b_s(data, len, secret);
-        if (len) return XXH3_len_1to3_64b_s(data, len, secret);
-        return 0;  /* len == 0 */
-    }
-}
-
-XXH_FORCE_INLINE XXH64_hash_t
 XXH3_len_4to8_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
 {
     assert(data != NULL);
@@ -433,6 +421,26 @@ XXH3_len_0to16_64b(const void* data, size_t len, XXH64_hash_t seed)
         if (len) return XXH3_len_1to3_64b(data, len, kKey, seed);
         return seed;
     }
+}
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_len_0to16_64b_s(const void* data, size_t len, const void* secret)
+{
+    assert(data != NULL);
+    assert(len <= 16);
+#if 1
+    {   if (len > 8) return XXH3_len_9to16_64b_s(data, len, secret);
+        if (len >= 4) return XXH3_len_4to8_64b_s(data, len, secret);
+        if (len) return XXH3_len_1to3_64b_s(data, len, secret);
+        return 0;  /* len == 0 */
+    }
+#else
+    {   if (len > 8) return XXH3_len_9to16_64b(data, len, secret, 0);
+        if (len >= 4) return XXH3_len_4to8_64b(data, len, secret, 0);
+        if (len) return XXH3_len_1to3_64b(data, len, secret, 0);
+        return 0;
+    }
+#endif
 }
 
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -824,25 +824,21 @@ XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t 
     assert(secretSize >= XXH_SECRET_SIZE_MIN);
 
     if (len <= 16) return XXH3_len_0to16_64b(data, len, secret, 0);
+    if (len > 128) return XXH3_hashLong_64b_s(data, len, secret, secretSize);
 
     {   U64 acc = len * PRIME64_1;
         if (len > 32) {
             if (len > 64) {
                 if (len > 96) {
-                    if (len > 128) return XXH3_hashLong_64b_s(data, len, secret, secretSize);
-
                     acc += XXH3_mix16B(p+48, key+96, 0);
                     acc += XXH3_mix16B(p+len-64, key+112, 0);
                 }
-
                 acc += XXH3_mix16B(p+32, key+64, 0);
                 acc += XXH3_mix16B(p+len-48, key+80, 0);
             }
-
             acc += XXH3_mix16B(p+16, key+32, 0);
             acc += XXH3_mix16B(p+len-32, key+48, 0);
         }
-
         acc += XXH3_mix16B(p+0, key+0, 0);
         acc += XXH3_mix16B(p+len-16, key+16, 0);
 
@@ -857,25 +853,21 @@ XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
     const char* const key = (const char*)kKey;
 
     if (len <= 16) return XXH3_len_0to16_64b(data, len, kKey, seed);
+    if (len > 128) return XXH3_hashLong_64b(data, len, seed);
 
     {   U64 acc = len * PRIME64_1;
         if (len > 32) {
             if (len > 64) {
                 if (len > 96) {
-                    if (len > 128) return XXH3_hashLong_64b(data, len, seed);
-
                     acc += XXH3_mix16B(p+48, key+96, seed);
                     acc += XXH3_mix16B(p+len-64, key+112, seed);
                 }
-
                 acc += XXH3_mix16B(p+32, key+64, seed);
                 acc += XXH3_mix16B(p+len-48, key+80, seed);
             }
-
             acc += XXH3_mix16B(p+16, key+32, seed);
             acc += XXH3_mix16B(p+len-32, key+48, seed);
         }
-
         acc += XXH3_mix16B(p+0, key+0, seed);
         acc += XXH3_mix16B(p+len-16, key+16, seed);
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -372,7 +372,7 @@ XXH3_len_0to16_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_
     {   if (len > 8) return XXH3_len_9to16_64b(data, len, keyPtr, seed);
         if (len >= 4) return XXH3_len_4to8_64b(data, len, keyPtr, seed);
         if (len) return XXH3_len_1to3_64b(data, len, keyPtr, seed);
-        return seed;
+        return 0;
     }
 }
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -317,21 +317,20 @@ XXH3_readKey64(const void* ptr)
     }
 }
 
+
 XXH_FORCE_INLINE XXH64_hash_t
 XXH3_len_1to3_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
 {
     assert(data != NULL);
-    assert(len > 0 && len <= 3);
+    assert(len > 1 && len <= 3);
     assert(keyPtr != NULL);
-    {   const U32* const key32 = (const U32*) keyPtr;
-        BYTE const c1 = ((const BYTE*)data)[0];
+    {   BYTE const c1 = ((const BYTE*)data)[0];
         BYTE const c2 = ((const BYTE*)data)[len >> 1];
         BYTE const c3 = ((const BYTE*)data)[len - 1];
-        U32  const l1 = (U32)(c1) + ((U32)(c2) << 8);
-        U32  const l2 = (U32)(len) + ((U32)(c3) << 2);
-        U64  const ll11 = XXH_mult32to64(l1 + (U32)seed + key32[0],
-                                         l2 + (U32)(seed >> 32) + key32[1]);
-        return XXH3_avalanche(ll11);
+        U32  const combined = ((U32)c1) + (((U32)c2) << 8) + (((U32)c3) << 16) + (((U32)len) << 24);
+        U64  const keyed = (U64)combined ^ (XXH3_readKey64(keyPtr) + seed);
+        U64  const mixed = keyed * PRIME64_1;
+        return XXH3_avalanche(mixed);
     }
 }
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -138,26 +138,26 @@ XXH_FORCE_INLINE U64x2 XXH_vsxMultEven(U32x4 a, U32x4 b) {
  * XXH3 default settings
  * ========================================== */
 
-#define KEYSET_DEFAULT_SIZE 48   /* minimum SECRET_KEY_SIZE_MIN */
+#define KEYSET_DEFAULT_SIZE 192   /* minimum SECRET_KEY_SIZE_MIN */
 
-#if (KEYSET_DEFAULT_SIZE * 4 < XXH_SECRET_SIZE_MIN)
+#if (KEYSET_DEFAULT_SIZE < XXH_SECRET_SIZE_MIN)
 #  error "default keyset is not large enough"
 #endif
 
-XXH_ALIGN(64) static const U32 kKey[KEYSET_DEFAULT_SIZE] = {
-    0xb8fe6c39,0x23a44bbe,0x7c01812c,0xf721ad1c,
-    0xded46de9,0x839097db,0x7240a4a4,0xb7b3671f,
-    0xcb79e64e,0xccc0e578,0x825ad07d,0xccff7221,
-    0xb8084674,0xf743248e,0xe03590e6,0x813a264c,
-    0x3c2852bb,0x91c300cb,0x88d0658b,0x1b532ea3,
-    0x71644897,0xa20df94e,0x3819ef46,0xa9deacd8,
-    0xa8fa763f,0xe39c343f,0xf9dcbbc7,0xc70b4f1d,
-    0x8a51e04b,0xcdb45931,0xc89f7ec9,0xd9787364,
+XXH_ALIGN(64) static const BYTE kKey[KEYSET_DEFAULT_SIZE] = {
+    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c, 0xf7, 0x21, 0xad, 0x1c,
+    0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb, 0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f,
+    0xcb, 0x79, 0xe6, 0x4e, 0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
+    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6, 0x81, 0x3a, 0x26, 0x4c,
+    0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb, 0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3,
+    0x71, 0x64, 0x48, 0x97, 0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
+    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7, 0xc7, 0x0b, 0x4f, 0x1d,
+    0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31, 0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64,
 
-    0xeac5ac83,0x34d3ebc3,0xc581a0ff,0xfa1363eb,
-    0x170ddd51,0xb7f0da49,0xd3165526,0x29d4689e,
-    0x2b16be58,0x7d47a1fc,0x8ff8b8d1,0x7ad031ce,
-    0x45cb3a8f,0x95160428,0xafd7fbca,0xbb4b407e,
+    0xea, 0xc5, 0xac, 0x83, 0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
+    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26, 0x29, 0xd4, 0x68, 0x9e,
+    0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc, 0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce,
+    0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
 };
 
 
@@ -308,6 +308,9 @@ static XXH64_hash_t XXH3_avalanche(U64 h64)
 XXH_FORCE_INLINE U64
 XXH3_readKey64(const void* ptr)
 {
+#if 1
+    return XXH_readLE64(ptr);
+#else /* old */
     assert(((size_t)ptr & 7) == 0);   /* aligned on 8-bytes boundaries */
     if (XXH_CPU_LITTLE_ENDIAN) {
         return *(const U64*)ptr;
@@ -315,6 +318,7 @@ XXH3_readKey64(const void* ptr)
         const U32* const ptr32 = (const U32*)ptr;
         return (U64)ptr32[0] + (((U64)ptr32[1]) << 32);
     }
+#endif
 }
 
 
@@ -389,8 +393,8 @@ XXH3_accumulate_512(void* restrict acc, const void *restrict data, const void *r
 
     assert(((size_t)acc) & 31 == 0);
     {   XXH_ALIGN(32) __m256i* const xacc  =       (__m256i *) acc;
-        const         __m256i* const xdata = (const __m256i *) data;
-        const         __m256i* const xkey  = (const __m256i *) key;
+        const         __m256i* const xdata = (const __m256i *) data;  /* not really aligned, just for ptr arithmetic */
+        const         __m256i* const xkey  = (const __m256i *) key;   /* not really aligned, just for ptr arithmetic */
 
         size_t i;
         for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
@@ -407,8 +411,8 @@ XXH3_accumulate_512(void* restrict acc, const void *restrict data, const void *r
 
     assert(((size_t)acc) & 15 == 0);
     {   XXH_ALIGN(16) __m128i* const xacc  =       (__m128i *) acc;
-        const         __m128i* const xdata = (const __m128i *) data;
-        const         __m128i* const xkey  = (const __m128i *) key;
+        const         __m128i* const xdata = (const __m128i *) data;  /* not really aligned, just for ptr arithmetic */
+        const         __m128i* const xkey  = (const __m128i *) key;   /* not really aligned, just for ptr arithmetic */
 
         size_t i;
         for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
@@ -448,7 +452,7 @@ XXH3_accumulate_512(void* restrict acc, const void *restrict data, const void *r
             /* data_vec = xdata[i]; */
             uint32x4_t const data_vec    = vld1q_u32(xdata + (i * 4));
             /* key_vec  = xkey[i];  */
-            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));
+            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));   /* <================= does this require xkey to be aligned ? if yes, on 4 or 16 bytes boundaries ? */
             /* data_key = data_vec ^ key_vec; */
             uint32x4_t       data_key;
             /* Add first to prevent register swaps */
@@ -468,7 +472,7 @@ XXH3_accumulate_512(void* restrict acc, const void *restrict data, const void *r
             /* data_vec = xdata[i]; */
             uint32x4_t const data_vec    = vld1q_u32(xdata + (i * 4));
             /* key_vec  = xkey[i];  */
-            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));
+            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));   /* <================= does this require xkey to be aligned ? if yes, on 4 or 16 bytes boundaries ? */
             /* data_key = data_vec ^ key_vec; */
             uint32x4_t const data_key    = veorq_u32(data_vec, key_vec);
             /* data_key_lo = (uint32x2_t) (data_key & 0xFFFFFFFF); */
@@ -497,10 +501,10 @@ XXH3_accumulate_512(void* restrict acc, const void *restrict data, const void *r
         /* byteswap */
         U64x2 const data_vec = vec_revb(vec_vsx_ld(0, xdata + i));
         /* swap 32-bit words */
-        U64x2 const key_vec = vec_rl(vec_vsx_ld(0, xkey + i), v32);
+        U64x2 const key_vec = vec_rl(vec_vsx_ld(0, xkey + i), v32);   /* <================= does this require xkey to be aligned ? if yes, on 4 or 16 bytes boundaries ? */
 #else
         U64x2 const data_vec = vec_vsx_ld(0, xdata + i);
-        U64x2 const key_vec = vec_vsx_ld(0, xkey + i);
+        U64x2 const key_vec = vec_vsx_ld(0, xkey + i);                /* <================= does this require xkey to be aligned ? if yes, on 4 or 16 bytes boundaries ? */
 #endif
         U64x2 data_key = data_vec ^ key_vec;
         /* shuffled = (data_key << 32) | (data_key >> 32); */
@@ -515,8 +519,8 @@ XXH3_accumulate_512(void* restrict acc, const void *restrict data, const void *r
 #else   /* scalar variant of Accumulator - universal */
 
     XXH_ALIGN(16) U64* const xacc = (U64*) acc;   /* presumed aligned */
-    const U64* const xdata = (const U64*) data;
-    const U64* const xkey  = (const U64*) key;
+    const U64* const xdata = (const U64*) data;   /* not really aligned, just for ptr arithmetic */
+    const U64* const xkey  = (const U64*) key;    /* not really aligned, just for ptr arithmetic */
     size_t i;
 
     for (i=0; i < ACC_NB; i++) {
@@ -536,7 +540,7 @@ static void XXH3_scrambleAcc(void* restrict acc, const void* restrict key)
 
     assert(((size_t)acc) & 31 == 0);
     {   XXH_ALIGN(32) __m256i* const xacc = (__m256i*) acc;
-        const         __m256i* const xkey = (const __m256i *) key;
+        const         __m256i* const xkey = (const __m256i *) key;   /* not really aligned, just for ptr arithmetic */
         const __m256i k1 = _mm256_set1_epi32((int)PRIME32_1);
 
         size_t i;
@@ -561,7 +565,7 @@ static void XXH3_scrambleAcc(void* restrict acc, const void* restrict key)
 #elif (XXH_VECTOR == XXH_SSE2)
 
     {   XXH_ALIGN(16) __m128i* const xacc = (__m128i*) acc;
-        const         __m128i* const xkey = (const __m128i *) key;
+        const         __m128i* const xkey = (const __m128i *) key;   /* not really aligned, just for ptr arithmetic */
         const __m128i k1 = _mm_set1_epi32((int)PRIME32_1);
 
         size_t i;
@@ -601,7 +605,7 @@ static void XXH3_scrambleAcc(void* restrict acc, const void* restrict key)
             uint64x2_t const   data_vec = veorq_u64   (acc_vec, shifted);
 
             /* key_vec  = xkey[i]; */
-            uint32x4_t const   key_vec  = vld1q_u32   (xkey + (i * 4));
+            uint32x4_t const   key_vec  = vld1q_u32   (xkey + (i * 4));    /* <================= does this require xkey to be aligned ? if yes, on 4 or 16 bytes boundaries ? */
             /* data_key = data_vec ^ key_vec; */
             uint32x4_t const   data_key = veorq_u32   (vreinterpretq_u32_u64(data_vec), key_vec);
             /* shuffled = { data_key[0, 2], data_key[1, 3] }; */
@@ -633,9 +637,9 @@ static void XXH3_scrambleAcc(void* restrict acc, const void* restrict key)
         /* key_vec = xkey[i]; */
 #ifdef __BIG_ENDIAN__
         /* swap 32-bit words */
-        U64x2 const key_vec  = vec_rl(vec_vsx_ld(0, xkey + i), v32);
+        U64x2 const key_vec  = vec_rl(vec_vsx_ld(0, xkey + i), v32);    /* <================= does this require xkey to be aligned ? if yes, on 4 or 16 bytes boundaries ? */
 #else
-        U64x2 const key_vec  = vec_vsx_ld(0, xkey + i);
+        U64x2 const key_vec  = vec_vsx_ld(0, xkey + i);                 /* <================= does this require xkey to be aligned ? if yes, on 4 or 16 bytes boundaries ? */
 #endif
         U64x2 const data_key = data_vec ^ key_vec;
 
@@ -651,7 +655,7 @@ static void XXH3_scrambleAcc(void* restrict acc, const void* restrict key)
 #else   /* scalar variant of Scrambler - universal */
 
           U64* const xacc =       (U64*) acc;
-    const U64* const xkey = (const U64*) key;
+    const U64* const xkey = (const U64*) key;   /* not really aligned, just for ptr arithmetic */
 
     int i;
     assert(((size_t)acc) & 7 == 0);
@@ -713,7 +717,7 @@ XXH3_hashLong_internal(U64* restrict acc, const void* restrict data, size_t len,
 }
 
 
-XXH_FORCE_INLINE U64 XXH3_mix2Accs(const U64* acc, const void* key)
+XXH_FORCE_INLINE U64 XXH3_mix2Accs(const U64* restrict acc, const void* restrict key)
 {
     const U64* const key64 = (const U64*)key;
     return XXH3_mul128_fold64(
@@ -749,18 +753,22 @@ XXH3_hashLong_64b(const void* restrict data, size_t len, const void* restrict se
 
 /* XXH3_initKeySeed() :
  * destination `key` is presumed allocated and have same size as kKey
+ * both `key` and `kKey` are presumed aligned on 8-bytes boundaries
  */
-XXH_FORCE_INLINE void XXH3_initKeySeed(U32* key, U64 seed64)
+XXH_FORCE_INLINE void XXH3_initKeySeed(void* key, U64 seed64)
 {
-    U32 const seed1 = (U32)seed64;
-    U32 const seed2 = (U32)(seed64 >> 32);
+    U64* const dst = (U64*)key;
+    const U64* const src = (const U64*)kKey;
+    int const nbRounds = KEYSET_DEFAULT_SIZE / 16;
     int i;
-    XXH_STATIC_ASSERT((KEYSET_DEFAULT_SIZE & 3) == 0);
-    for (i=0; i < KEYSET_DEFAULT_SIZE; i+=4) {
-        key[i+0] = kKey[i+0] + seed1;
-        key[i+1] = kKey[i+1] - seed2;
-        key[i+2] = kKey[i+2] + seed2;
-        key[i+3] = kKey[i+3] - seed1;
+
+    XXH_STATIC_ASSERT((KEYSET_DEFAULT_SIZE & 15) == 0);
+    assert(((size_t)kKey & 7) == 0);
+    assert(((size_t)key & 7) == 0);
+
+    for (i=0; i < nbRounds; i+=2) {
+        dst[i+0] = src[i+0] + seed64;
+        dst[i+1] = src[i+1] - seed64;
     }
 }
 
@@ -775,7 +783,7 @@ XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLo
 XXH3_hashLong_64b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
 {
     XXH_ALIGN(64) U64 acc[ACC_NB] = { seed, PRIME64_1, PRIME64_2, PRIME64_3, PRIME64_4, PRIME64_5, (U64)0 - seed, 0 };
-    XXH_ALIGN(64) U32 key[KEYSET_DEFAULT_SIZE];
+    XXH_ALIGN(64) BYTE key[KEYSET_DEFAULT_SIZE];
 
     XXH3_initKeySeed(key, seed);
 
@@ -829,7 +837,7 @@ XXH3_len_17to128_64b(const void* restrict data, size_t len, const void* restrict
 
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_64bits_withSecret_internal(const void* data, size_t len, const void* secret, size_t secretSize)
+XXH3_64bits_withSecret_internal(const void* restrict data, size_t len, const void* restrict secret, size_t secretSize)
 {
     if (len <= 16) return XXH3_len_0to16_64b(data, len, secret, 0);
     if (len > 128) return XXH3_hashLong_64b(data, len, secret, secretSize);

--- a/xxh3.h
+++ b/xxh3.h
@@ -369,9 +369,9 @@ XXH3_len_0to16_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_
 {
     assert(data != NULL);
     assert(len <= 16);
-    {   if (len > 8) return XXH3_len_9to16_64b(data, len, kKey, seed);
-        if (len >= 4) return XXH3_len_4to8_64b(data, len, kKey, seed);
-        if (len) return XXH3_len_1to3_64b(data, len, kKey, seed);
+    {   if (len > 8) return XXH3_len_9to16_64b(data, len, keyPtr, seed);
+        if (len >= 4) return XXH3_len_4to8_64b(data, len, keyPtr, seed);
+        if (len) return XXH3_len_1to3_64b(data, len, keyPtr, seed);
         return seed;
     }
 }

--- a/xxh3.h
+++ b/xxh3.h
@@ -522,7 +522,7 @@ XXH3_accumulate_512(void* restrict acc, const void *restrict data, const void *r
     assert(((size_t)acc & 7) == 0);
     for (i=0; i < ACC_NB; i++) {
         U64 const data_val = XXH_readLE64(xdata + 8*i);
-        U64 const key_val = XXH3_readKey64(xkey + 8*i);
+        U64 const key_val = XXH_readLE64(xkey + 8*i);
         U64 const data_key  = key_val ^ data_val;
         xacc[i] += XXH_mult32to64(data_key & 0xFFFFFFFF, data_key >> 32);
         xacc[i] += data_val;
@@ -658,7 +658,7 @@ XXH3_scrambleAcc(void* restrict acc, const void* restrict key)
     int i;
     assert(((size_t)acc) & 7 == 0);
     for (i=0; i < (int)ACC_NB; i++) {
-        U64 const key64 = XXH3_readKey64(xkey + i);
+        U64 const key64 = XXH_readLE64(xkey + i);
         U64 acc64 = xacc[i];
         acc64 ^= acc64 >> 47;
         acc64 ^= key64;

--- a/xxhash.h
+++ b/xxhash.h
@@ -408,6 +408,15 @@ struct XXH64_state_s {
 #  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
 #endif
 
+/* note : variants without seed produce same result as variant with seed == 0 */
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits(const void* data, size_t len);
+
+#define XXH_SECRET_SIZE_MIN  136
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t size);
+
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, unsigned long long seed);
+
+
 
 typedef struct {
     XXH64_hash_t low64;
@@ -415,10 +424,6 @@ typedef struct {
 } XXH128_hash_t;
 
 XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, unsigned long long seed);
-
-/* note : variants without seed produce same result as variant with seed == 0 */
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits(const void* data, size_t len);
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, unsigned long long seed);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, unsigned long long seed);  /* == XXH128() */
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -401,37 +401,37 @@ struct XXH64_state_s {
  */
 
 #ifdef XXH_NAMESPACE
-#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
 #  define XXH3_64bits XXH_NAME2(XXH_NAMESPACE, XXH3_64bits)
-#  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
 #  define XXH3_64bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSecret)
+#  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
 #  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
 #  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
+#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
 #endif
 
 /* XXH3_64bits() :
  * default 64-bit variant, using default secret and a seed of 0.
  * it's also the fastest. */
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits(const void* data, size_t len);
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len);
 
 /* XXH3_64bits_withSecret() :
  * It's possible to provide any blob of bytes as a "secret" to generate the hash.
- * This makes it more difficult for an external observer to trigger an intentional collision.
+ * This makes it more difficult for an external actor to prepare an intentional collision.
  * The secret must be large enough (>= XXH_SECRET_SIZE_MIN)
  * and its starting address must be aligned on 8-bytes.
  * The secret is consumed by fields of 8 bytes,
  * meaning that if its size is not a multiple of 8,
  * the last bytes, beyond the last multiple of 8, are ignored.
  */
-#define XXH_SECRET_SIZE_MIN  136
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
+#define XXH_SECRET_SIZE_MIN 136
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
 
 /* XXH3_64bits_withSeed() :
  * This variant generates on the fly a custom secret,
  * based on the default secret, altered using the `seed` value.
  * While this operation is decently fast, note that it's not completely free.
  * note : seed==0 produces same results as XXH3_64bits() */
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
 
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -409,13 +409,29 @@ struct XXH64_state_s {
 #  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
 #endif
 
-/* note : variants without seed produce same result as variant with seed == 0 */
+/* XXH3_64bits() :
+ * default 64-bit variant, using default secret and a seed of 0.
+ * it's also the fastest. */
 XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits(const void* data, size_t len);
 
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
-
+/* XXH3_64bits_withSecret() :
+ * It's possible to provide any blob of bytes as a "secret" to generate the hash.
+ * This makes it more difficult for an external observer to trigger an intentional collision.
+ * The secret must be large enough (>= XXH_SECRET_SIZE_MIN)
+ * and its starting address must be aligned on 8-bytes.
+ * The secret is consumed by fields of 8 bytes,
+ * meaning that if its size is not a multiple of 8,
+ * the last bytes, beyond the last multiple of 8, are ignored.
+ */
 #define XXH_SECRET_SIZE_MIN  136
 XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
+
+/* XXH3_64bits_withSeed() :
+ * This variant generates on the fly a custom secret,
+ * based on the default secret, altered using the `seed` value.
+ * While this operation is decently fast, note that it's not completely free.
+ * note : seed==0 produces same results as XXH3_64bits() */
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
 
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -408,8 +408,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len);
 /* XXH3_64bits_withSecret() :
  * It's possible to provide any blob of bytes as a "secret" to generate the hash.
  * This makes it more difficult for an external actor to prepare an intentional collision.
- * The secret must be large enough (>= XXH_SECRET_SIZE_MIN)
- * and its starting address must be aligned on 8-bytes boundaries.
+ * The secret *must* be large enough (>= XXH_SECRET_SIZE_MIN).
  */
 #define XXH_SECRET_SIZE_MIN 136
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);

--- a/xxhash.h
+++ b/xxhash.h
@@ -404,17 +404,18 @@ struct XXH64_state_s {
 #  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
 #  define XXH3_64bits XXH_NAME2(XXH_NAMESPACE, XXH3_64bits)
 #  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
+#  define XXH3_64bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSecret)
 #  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
 #  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
 #endif
-
+ 
 /* note : variants without seed produce same result as variant with seed == 0 */
 XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits(const void* data, size_t len);
 
-#define XXH_SECRET_SIZE_MIN  136
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t size);
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
 
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed(const void* data, size_t len, unsigned long long seed);
+#define XXH_SECRET_SIZE_MIN  136
+XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
 
 
 
@@ -423,9 +424,9 @@ typedef struct {
     XXH64_hash_t high64;
 } XXH128_hash_t;
 
-XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, unsigned long long seed);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len);
-XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, unsigned long long seed);  /* == XXH128() */
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);  /* == XXH128() */
+XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed);
 
 
 #endif  /* XXH_NO_LONG_LONG */

--- a/xxhash.h
+++ b/xxhash.h
@@ -419,9 +419,6 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len);
  * This makes it more difficult for an external actor to prepare an intentional collision.
  * The secret must be large enough (>= XXH_SECRET_SIZE_MIN)
  * and its starting address must be aligned on 8-bytes.
- * The secret is consumed by fields of 8 bytes,
- * meaning that if its size is not a multiple of 8,
- * the last bytes, beyond the last multiple of 8, are ignored.
  */
 #define XXH_SECRET_SIZE_MIN 136
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);

--- a/xxhash.h
+++ b/xxhash.h
@@ -408,7 +408,7 @@ struct XXH64_state_s {
 #  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
 #  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
 #endif
- 
+
 /* note : variants without seed produce same result as variant with seed == 0 */
 XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits(const void* data, size_t len);
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -335,8 +335,7 @@ struct XXH64_state_s {
  * XXH3 is a new hash algorithm,
  * featuring vastly improved speed performance
  * for both small and large inputs.
- * A full speed analysis will be published,
- * it requires a lot more space than this comment can handle.
+ * See full speed analysis at : http://fastcompression.blogspot.com/2019/03/presenting-xxh3.html
  * In general, expect XXH3 to run about ~2x faster on large inputs,
  * and >3x faster on small ones, though exact difference depend on platform.
  *
@@ -346,16 +345,14 @@ struct XXH64_state_s {
  * XXH3 offers 2 variants, _64bits and _128bits.
  * When only 64 bits are needed, prefer calling the _64bits variant :
  * it reduces the amount of mixing, resulting in faster speed on small inputs.
- * It's also generally simpler to manipulate a scalar type than a struct.
- * Note : the low 64-bit field of the _128bits variant is the same as _64bits result.
+ * It's also generally simpler to manipulate a scalar return type than a struct.
  *
  * The XXH3 algorithm is still considered experimental.
+ * Produced results can still change between versions.
  * It's possible to use it for ephemeral data, but avoid storing long-term values for later re-use.
- * While labelled experimental, the produced result can still change between versions.
  *
  * The API currently supports one-shot hashing only.
- * The full version will include streaming capability, and canonical representation
- * Long term optional feature may include custom secret keys, and secret key generation.
+ * The full version will include streaming capability, and canonical representation.
  *
  * There are still a number of opened questions that community can influence during the experimental period.
  * I'm trying to list a few of them below, though don't consider this list as complete.
@@ -381,11 +378,6 @@ struct XXH64_state_s {
  *                          Would it be beneficial to declare and define a comparator function for XXH128_hash_t ?
  *                          Are there other operations on XXH128_hash_t which would be desirable ?
  *
- * - Variant compatibility : The low 64-bit field of the _128bits variant is the same as the result of _64bits.
- *                          This is not a compulsory behavior. It just felt that it "wouldn't hurt", and might even help in some (unidentified) cases.
- *                          But it might influence the design of XXH128_hash_t, in ways which may block other possibilities.
- *                          Good idea, bad idea ?
- *
  * - Seed type for 128-bits variant : currently, it's a single 64-bit value, like the 64-bit variant.
  *                          It could be argued that it's more logical to offer a 128-bit seed input parameter for a 128-bit hash.
  *                          Although it's also more difficult to use, since it requires to declare and pass a structure instead of a value.
@@ -393,11 +385,10 @@ struct XXH64_state_s {
  *                          Farmhash, for example, offers both variants (the 128-bits seed variant is called `doubleSeed`).
  *                          If both 64-bit and 128-bit seeds are possible, which variant should be called XXH128 ?
  *
- * - Result for len==0 : Currently, the result of hashing a zero-length input is the seed.
- *                          This mimics the behavior of a crc : in which case, a seed is effectively an accumulator, so it's not updated if input is empty.
- *                          Consequently, by default, when no seed specified, it returns zero. That part seems okay (it used to be a request for XXH32/XXH64).
- *                          But is it still fine to return the seed when the seed is non-zero ?
- *                          Are there use case which would depend on this behavior, or would prefer a mixing of the seed ?
+ * - Result for len==0 : Currently, the result of hashing a zero-length input is `0`.
+ *                          It seems okay as a return value when using all "default" secret and seed (it used to be a request for XXH32/XXH64).
+ *                          But is it still fine to return `0` when secret or seed are non-default ?
+ *                          Are there use case which would depend on a different hash result when the secret is different ?
  */
 
 #ifdef XXH_NAMESPACE
@@ -410,15 +401,15 @@ struct XXH64_state_s {
 #endif
 
 /* XXH3_64bits() :
- * default 64-bit variant, using default secret and a seed of 0.
- * it's also the fastest. */
+ * default 64-bit variant, using default secret and default seed of 0.
+ * it's also the fastest one. */
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len);
 
 /* XXH3_64bits_withSecret() :
  * It's possible to provide any blob of bytes as a "secret" to generate the hash.
  * This makes it more difficult for an external actor to prepare an intentional collision.
  * The secret must be large enough (>= XXH_SECRET_SIZE_MIN)
- * and its starting address must be aligned on 8-bytes.
+ * and its starting address must be aligned on 8-bytes boundaries.
  */
 #define XXH_SECRET_SIZE_MIN 136
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
@@ -429,7 +420,6 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len,
  * While this operation is decently fast, note that it's not completely free.
  * note : seed==0 produces same results as XXH3_64bits() */
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
-
 
 
 typedef struct {

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -679,6 +679,8 @@ static void BMK_sanityCheck(void)
     BMK_testSequence64(sanityBuffer,222, 0,     0x9DD507880DEBB03DULL);
     BMK_testSequence64(sanityBuffer,222, prime, 0xDC515172B8EE0600ULL);
 
+#if 0
+
     BMK_testXXH3(NULL,           0, 0,       0);                      /* zero-length hash is the seed == 0 by default */
     BMK_testXXH3(NULL,           0, prime64, prime64);
     BMK_testXXH3(sanityBuffer,   1, 0,       0xD00398B418222F66ULL);  /*  1 -  3 */
@@ -705,8 +707,6 @@ static void BMK_sanityCheck(void)
     BMK_testXXH3(sanityBuffer,2240, prime64, 0x02C46760EC80602FULL);  /* 3 blocks, finishing at stripe boundary */
     BMK_testXXH3(sanityBuffer,2243, 0,       0x072D949235D92E59ULL);  /* 3 blocks, last stripe is overlapping */
     BMK_testXXH3(sanityBuffer,2243, prime64, 0xBEDD0F5239FB92C8ULL);  /* 3 blocks, last stripe is overlapping */
-
-#if 0
 
     {   XXH128_hash_t const expected = { 0, 0 };
         BMK_testXXH128(NULL,           0, 0,     expected);         /* zero-length hash is { seed, -seed } by default */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -679,9 +679,10 @@ static void BMK_sanityCheck(void)
     BMK_testSequence64(sanityBuffer,222, 0,     0x9DD507880DEBB03DULL);
     BMK_testSequence64(sanityBuffer,222, prime, 0xDC515172B8EE0600ULL);
 
-#if 0
 
     BMK_testXXH3(NULL,           0, 0,       0);                      /* zero-length hash is the seed == 0 by default */
+    (void)prime64;
+#if 0
     BMK_testXXH3(NULL,           0, prime64, prime64);
     BMK_testXXH3(sanityBuffer,   1, 0,       0xD00398B418222F66ULL);  /*  1 -  3 */
     BMK_testXXH3(sanityBuffer,   1, prime64, 0x5EF5C7337AA1168CULL);  /*  1 -  3 */


### PR DESCRIPTION
Makes it possible to provide an arbitrary secret blob of bytes (of minimum size `XXH_SECRET_SIZE_MIN`) to make it more difficult for an external actor to generate a collision without knowing the secret.

Also : clarifies the role of the `seed`, which is a required preliminary for the streaming implementation.

This version also features a dramatic performance improvement under Visual 2019 with `AVX2` enabled.