### PR TITLE
Midsize

### DIFF
--- a/tests/bench/.gitignore
+++ b/tests/bench/.gitignore
@@ -5,3 +5,7 @@ benchHash
 benchHash32
 benchHash_avx2
 benchHash_hw
+
+# test files
+
+test*

--- a/xxhash.h
+++ b/xxhash.h
@@ -400,13 +400,13 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len);
 /* XXH3_64bits_withSecret() :
  * It's possible to provide any blob of bytes as a "secret" to generate the hash.
  * This makes it more difficult for an external actor to prepare an intentional collision.
- * The secret *must* be large enough (>= XXH_SECRET_SIZE_MIN).
+ * The secret *must* be large enough (>= XXH3_SECRET_SIZE_MIN).
  * It should consist of random bytes.
  * Avoid repeating same character, and especially avoid swathes of \0.
  * Avoid repeating sequences of bytes within the secret.
  * Failure to respect these conditions will result in a bad quality hash.
  */
-#define XXH_SECRET_SIZE_MIN 136
+#define XXH3_SECRET_SIZE_MIN 136
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
 
 /* XXH3_64bits_withSeed() :
@@ -432,8 +432,8 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSeed(const void* data, size_t len, X
 
 typedef struct XXH3_state_s XXH3_state_t;
 
-#define XXH3_SECRET_DEFAULT_SIZE 192   /* minimum XXH_SECRET_SIZE_MIN */
-#define XXH3_INTERNALBUFFER_SIZE 128
+#define XXH3_SECRET_DEFAULT_SIZE 192   /* minimum XXH3_SECRET_SIZE_MIN */
+#define XXH3_INTERNALBUFFER_SIZE 256
 struct XXH3_state_s {
    XXH_ALIGN(64) XXH64_hash_t acc[8];
    XXH_ALIGN(64) char customSecret[XXH3_SECRET_DEFAULT_SIZE];  /* used to store a custom secret generated from the seed. Makes state larger. Design might change */
@@ -469,7 +469,7 @@ XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr);
 XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed);
 /* XXH3_64bits_reset_withSecret() :
  * `secret` is referenced, and must outlive the hash streaming session.
- * secretSize must be >= XXH_SECRET_SIZE_MIN.
+ * secretSize must be >= XXH3_SECRET_SIZE_MIN.
  */
 XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize);
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -733,11 +733,13 @@ static void BMK_sanityCheck(void)
     BMK_testXXH3(sanityBuffer,  80, prime64, 0xC9D55256965B7093ULL);  /* 65 - 96 */
     BMK_testXXH3(sanityBuffer, 112, 0,       0xE43E5717A61D3759ULL);  /* 97 -128 */
     BMK_testXXH3(sanityBuffer, 112, prime64, 0x5A5F89A3FECE44A5ULL);  /* 97 -128 */
+    BMK_testXXH3(sanityBuffer, 195, 0,       0x0F4A0BBE808382AEULL);  /* 129-240 */
+    BMK_testXXH3(sanityBuffer, 195, prime64, 0x9DF94C96C46AF6CCULL);  /* 129-240 */
 
-    BMK_testXXH3(sanityBuffer, 192, 0,       0x657FDAF1B5B85A98ULL);  /* one block, finishing at stripe boundary */
-    BMK_testXXH3(sanityBuffer, 192, prime64, 0xCE739A124E5395BFULL);  /* one block, finishing at stripe boundary */
-    BMK_testXXH3(sanityBuffer, 222, 0,       0x9D1CEA1C7134C072ULL);  /* one block, last stripe is overlapping */
-    BMK_testXXH3(sanityBuffer, 222, prime64, 0x71CFC4572F8FCD9DULL);  /* one block, last stripe is overlapping */
+    BMK_testXXH3(sanityBuffer, 384, 0,       0x45CCC94C86BE739FULL);  /* one block, finishing at stripe boundary */
+    BMK_testXXH3(sanityBuffer, 384, prime64, 0x79C743D8B9A54FBCULL);  /* one block, finishing at stripe boundary */
+    BMK_testXXH3(sanityBuffer, 403, 0,       0x4834389B15D981E8ULL);  /* one block, last stripe is overlapping */
+    BMK_testXXH3(sanityBuffer, 403, prime64, 0x85CE5DFFC7B07C87ULL);  /* one block, last stripe is overlapping */
     BMK_testXXH3(sanityBuffer,2048, 0,       0xEFEFD4449323CDD4ULL);  /* 2 blocks, finishing at block boundary */
     BMK_testXXH3(sanityBuffer,2048, prime64, 0x01C85E405ECA3F6EULL);  /* 2 blocks, finishing at block boundary */
     BMK_testXXH3(sanityBuffer,2240, 0,       0x998C0437486672C7ULL);  /* 3 blocks, finishing at stripe boundary */
@@ -746,7 +748,7 @@ static void BMK_sanityCheck(void)
     BMK_testXXH3(sanityBuffer,2243, prime64, 0x96E051AB57F21FC8ULL);  /* 3 blocks, last stripe is overlapping */
 
     {   const void* const secret = sanityBuffer + 7;
-        const size_t secretSize = XXH_SECRET_SIZE_MIN + 11;
+        const size_t secretSize = XXH3_SECRET_SIZE_MIN + 11;
         BMK_testXXH3_withSecret(NULL,           0, secret, secretSize,       0);                      /* zero-length hash is always 0 */
         BMK_testXXH3_withSecret(sanityBuffer,   1, secret, secretSize,       0x420EAC06C004273FULL);  /*  1 -  3 */
         BMK_testXXH3_withSecret(sanityBuffer,   6, secret, secretSize,       0x5A90048A433D5017ULL);  /*  6 -  8 */
@@ -755,9 +757,10 @@ static void BMK_sanityCheck(void)
         BMK_testXXH3_withSecret(sanityBuffer,  48, secret, secretSize,       0xA785256D9D65D514ULL);  /* 33 - 64 */
         BMK_testXXH3_withSecret(sanityBuffer,  80, secret, secretSize,       0x6F3053360D21BBB7ULL);  /* 65 - 96 */
         BMK_testXXH3_withSecret(sanityBuffer, 112, secret, secretSize,       0x560E82D25684154CULL);  /* 97 -128 */
+        BMK_testXXH3_withSecret(sanityBuffer, 195, secret, secretSize,       0x08AD6AB5ACA1B218ULL);  /* 129-240 */
 
-        BMK_testXXH3_withSecret(sanityBuffer, 192, secret, secretSize,       0x615B7F3B2DA09681ULL);  /* one block, finishing at stripe boundary */
-        BMK_testXXH3_withSecret(sanityBuffer, 222, secret, secretSize,       0x6E5D78EEE071A11AULL);  /* one block, last stripe is overlapping */
+        BMK_testXXH3_withSecret(sanityBuffer, 384, secret, secretSize,       0x9656E0F288042CB9ULL);  /* one block, finishing at stripe boundary */
+        BMK_testXXH3_withSecret(sanityBuffer, 403, secret, secretSize,       0xFC3911BBA656DB58ULL);  /* one block, last stripe is overlapping */
         BMK_testXXH3_withSecret(sanityBuffer,2048, secret, secretSize,       0x2836B83880AD3C0CULL);  /* > one block, at least one scrambling */
         BMK_testXXH3_withSecret(sanityBuffer,2243, secret, secretSize,       0x3446E248A00CB44AULL);  /* > one block, at least one scrambling, last stripe unaligned */
     }


### PR DESCRIPTION
Extend "short mode" to longer input sizes, up to 240 bytes.

This is a bit lower than initial intention, but a good compromise with streaming mode's requirements.
It manages to reduce substantially the performance cliff when moving from short to long mode.
State's internal buffer is doubled, to 256 bytes.