### PR TITLE
Fix XXH3 streaming result when update block size happens to land exactly on buffer size/

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1066,7 +1066,7 @@ XXH3_64bits_update(XXH3_state_t* state, const void* input, size_t len)
             } while (p<=limit);
         }
 
-        if (p < bEnd) { /* some remaining input data : buffer it */
+        if (p <= bEnd) { /* some remaining input data : buffer it */
             XXH_memcpy(state->buffer, p, (size_t)(bEnd-p));
             state->bufferedSize = (XXH32_hash_t)(bEnd-p);
         }


### PR DESCRIPTION
I was testing the non-streaming XXH3 on 512 byte block, and a streaming API that happened to do a "3 bytes update, then 509 bytes update", and the result was different. Looks like `bufferedSize` was not properly updated if the incoming block size landed exactly on multiple of the internal buffer size. With this proposed fix it seems to be better.