### PR TITLE
Fixed rerolled version of 64-bit hash. 

### DIFF
--- a/xxhash.c
+++ b/xxhash.c
@@ -787,7 +787,7 @@ XXH64_finalize(U64 h64, const void* ptr, size_t len, XXH_alignment align)
             PROCESS8_64;
             len -= 8;
         }
-        if (len > 4) {
+        if (len >= 4) {
             PROCESS4_64;
             len -= 4;
         }


### PR DESCRIPTION
Was wrong for length == 4 on 32-bit platforms