### PR TITLE
Update XXH128

### DIFF
--- a/tests/bench/hashes.h
+++ b/tests/bench/hashes.h
@@ -96,6 +96,12 @@ size_t xxh3_wrapper(const void* src, size_t srcSize, void* dst, size_t dstCapaci
 }
 
 
+size_t XXH128_wrapper(const void* src, size_t srcSize, void* dst, size_t dstCapacity, void* customPayload)
+{
+    (void)dst; (void)dstCapacity; (void)customPayload;
+    return (size_t) XXH3_128bits(src, srcSize).low64;
+}
+
 
 
 /* ==================================================
@@ -105,16 +111,17 @@ size_t xxh3_wrapper(const void* src, size_t srcSize, void* dst, size_t dstCapaci
 #include "bhDisplay.h"   /* Bench_Entry */
 
 #ifndef HARDWARE_SUPPORT
-#  define NB_HASHES 3
+#  define NB_HASHES 4
 #else
-#  define NB_HASHES 3
+#  define NB_HASHES 4
 #endif
 
 Bench_Entry const hashCandidates[NB_HASHES] = {
-    {  "xxh3", xxh3_wrapper },
-    { "XXH32", XXH32_wrapper },
-    { "XXH64", XXH64_wrapper },
+    { "xxh3"  , xxh3_wrapper },
+    { "XXH32" , XXH32_wrapper },
+    { "XXH64" , XXH64_wrapper },
+    { "XXH128", XXH128_wrapper },
 #ifdef HARDWARE_SUPPORT
-
+    /* list here codecs which require specific hardware support, such SSE4.1, PCLMUL, AVX2, etc. */
 #endif
 };

--- a/xxh3.h
+++ b/xxh3.h
@@ -451,7 +451,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
             __m256i const dk  = _mm256_xor_si256 (d,k);                                  /* uint32 dk[8]  = {d0+k0, d1+k1, d2+k2, d3+k3, ...} */
             __m256i const mul = _mm256_mul_epu32 (dk, _mm256_shuffle_epi32 (dk, 0x31));  /* uint64 mul[4] = {dk0*dk1, dk2*dk3, ...} */
             if (accWidth == XXH3_acc_128bits) {
-                __m256i const dswap = _mm256_shuffle_epi32(d, _MM_SHUFFLE(0,1,2,3));
+                __m256i const dswap = _mm256_shuffle_epi32(d, _MM_SHUFFLE(1,0,3,2));
                 __m256i const add = _mm256_add_epi64(xacc[i], dswap);
                 xacc[i]  = _mm256_add_epi64(mul, add);
             } else {  /* XXH3_acc_64bits */
@@ -474,7 +474,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
             __m128i const dk  = _mm_xor_si128 (d,k);                                 /* uint32 dk[4]  = {d0+k0, d1+k1, d2+k2, d3+k3} */
             __m128i const mul = _mm_mul_epu32 (dk, _mm_shuffle_epi32 (dk, 0x31));    /* uint64 mul[2] = {dk0*dk1,dk2*dk3} */
             if (accWidth == XXH3_acc_128bits) {
-                __m128i const dswap = _mm_shuffle_epi32(d, _MM_SHUFFLE(0,1,2,3));
+                __m128i const dswap = _mm_shuffle_epi32(d, _MM_SHUFFLE(1,0,3,2));
                 __m128i const add = _mm_add_epi64(xacc[i], dswap);
                 xacc[i]  = _mm_add_epi64(mul, add);
             } else {  /* XXH3_acc_64bits */

--- a/xxh3.h
+++ b/xxh3.h
@@ -339,7 +339,7 @@ XXH_FORCE_INLINE XXH64_hash_t
 XXH3_len_4to8_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
 {
     assert(data != NULL);
-    assert(key != NULL);
+    assert(keyPtr != NULL);
     assert(len >= 4 && len <= 8);
     {   U32 const in1 = XXH_readLE32(data);
         U32 const in2 = XXH_readLE32((const BYTE*)data + len - 4);
@@ -354,7 +354,7 @@ XXH_FORCE_INLINE XXH64_hash_t
 XXH3_len_9to16_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
 {
     assert(data != NULL);
-    assert(key != NULL);
+    assert(keyPtr != NULL);
     assert(len >= 9 && len <= 16);
     {   const U64* const key64 = (const U64*) keyPtr;
         U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(key64) + seed);
@@ -814,6 +814,7 @@ XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLo
 XXH3_hashLong_64b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
 {
     XXH_ALIGN(8) char secret[XXH_SECRET_DEFAULT_SIZE];
+    if (seed==0) return XXH3_hashLong_64b_defaultSecret(data, len);
     XXH3_initKeySeed(secret, seed);
     return XXH3_hashLong_internal(data, len, secret, sizeof(secret));
 }
@@ -922,12 +923,6 @@ XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t 
 XXH_PUBLIC_API XXH64_hash_t
 XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
 {
-    /* note : opened question : would it be faster to
-     * route to XXH3_64bits_withSecret_internal()
-     * when `seed == 0` ?
-     * This would add a branch though.
-     * Maybe do it into XXH3_hashLong_64b_withSeed() instead,
-     * since that's where it matters */
     if (len <= 16) return XXH3_len_0to16_64b(data, len, kSecret, seed);
     if (len <= 128) return XXH3_len_17to128_64b(data, len, kSecret, sizeof(kSecret), seed);
     if (len <= 240) return XXH3_len_129to240_64b(data, len, kSecret, sizeof(kSecret), seed);
@@ -1128,11 +1123,13 @@ XXH3_len_1to3_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_
         BYTE const c1 = ((const BYTE*)data)[0];
         BYTE const c2 = ((const BYTE*)data)[len >> 1];
         BYTE const c3 = ((const BYTE*)data)[len - 1];
-        U32  const l1 = (U32)(c1) + ((U32)(c2) << 8);
-        U32  const l2 = (U32)(len) + ((U32)(c3) << 2);
-        U64  const ll11 = XXH_mult32to64((unsigned int)(l1 + seed + key32[0]), (unsigned int)(l2 + key32[1]));
-        U64  const ll12 = XXH_mult32to64((unsigned int)(l1 + key32[2]), (unsigned int)(l2 - seed + key32[3]));
-        XXH128_hash_t const h128 = { XXH3_avalanche(ll11), XXH3_avalanche(ll12) };
+        U32  const combinedl = ((U32)c1) + (((U32)c2) << 8) + (((U32)c3) << 16) + (((U32)len) << 24);
+        U32  const combinedh = XXH_swap32(combinedl);
+        U64  const keyedl = (U64)combinedl ^ (XXH_readLE32(key32)   + seed);
+        U64  const keyedh = (U64)combinedh ^ (XXH_readLE32(key32+1) - seed);
+        U64  const mixedl = keyedl * PRIME64_1;
+        U64  const mixedh = keyedh * PRIME64_2;
+        XXH128_hash_t const h128 = { XXH3_avalanche(mixedl) /*low64*/, XXH3_avalanche(mixedh) /*high64*/ };
         return h128;
     }
 }
@@ -1142,116 +1139,216 @@ XXH_FORCE_INLINE XXH128_hash_t
 XXH3_len_4to8_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
 {
     assert(data != NULL);
+    assert(keyPtr != NULL);
     assert(len >= 4 && len <= 8);
-    {   const U32* const key32 = (const U32*) keyPtr;
-        U32 const l1 = XXH_readLE32(data) + (U32)seed + key32[0];
-        U32 const l2 = XXH_readLE32((const BYTE*)data + len - 4) + (U32)(seed >> 32) + key32[1];
-        U64 const acc1 = len + l1 + ((U64)l2 << 32) + XXH_mult32to64(l1, l2);
-        U64 const acc2 = len*PRIME64_1 + l1*PRIME64_2 + l2*PRIME64_3;
-        {   XXH128_hash_t const h128 = { XXH3_avalanche(acc1), XXH3_avalanche(acc2) };
+    {   U32 const in1 = XXH_readLE32(data);
+        U32 const in2 = XXH_readLE32((const BYTE*)data + len - 4);
+        U64 const in64l = in1 + ((U64)in2 << 32);
+        U64 const in64h = XXH_swap64(in64l);
+        U64 const keyedl = in64l ^ (XXH_readLE64(keyPtr) + seed);
+        U64 const keyedh = in64h ^ (XXH_readLE64((const char*)keyPtr + 8) - seed);
+        U64 const mix64l1 = len + ((keyedl ^ (keyedl >> 51)) * PRIME32_1);
+        U64 const mix64l2 = (mix64l1 ^ (mix64l1 >> 47)) * PRIME64_2;
+        U64 const mix64h1 = ((keyedh ^ (keyedh >> 47)) * PRIME64_1) - len;
+        U64 const mix64h2 = (mix64h1 ^ (mix64h1 >> 43)) * PRIME64_4;
+        {   XXH128_hash_t const h128 = { XXH3_avalanche(mix64l2) /*low64*/, XXH3_avalanche(mix64h2) /*high64*/ };
             return h128;
-        }
-    }
+    }   }
+}
+
+static XXH128_hash_t
+XXH3_mul128(U64 ll1, U64 ll2)
+{
+#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+
+    __uint128_t lll = (__uint128_t)ll1 * ll2;
+    XXH128_hash_t const r128 = { (U64)(lll), (U64)(lll >> 64) };
+    return r128;
+
+#elif defined(_M_X64) || defined(_M_IA64)
+
+#ifndef _MSC_VER
+#   pragma intrinsic(_umul128)
+#endif
+    U64 llhigh;
+    U64 const lllow = _umul128(ll1, ll2, &llhigh);
+    XXH128_hash_t const r128 = { lllow, llhigh };
+    return r128;
+
+#else /* Portable scalar version */
+
+    /* emulate 64x64->128b multiplication, using four 32x32->64 */
+    U32 const h1 = (U32)(ll1 >> 32);
+    U32 const h2 = (U32)(ll2 >> 32);
+    U32 const l1 = (U32)ll1;
+    U32 const l2 = (U32)ll2;
+
+    U64 const llh  = XXH_mult32to64(h1, h2);
+    U64 const llm1 = XXH_mult32to64(l1, h2);
+    U64 const llm2 = XXH_mult32to64(h1, l2);
+    U64 const lll  = XXH_mult32to64(l1, l2);
+
+    U64 const t = lll + (llm1 << 32);
+    U64 const carry1 = t < lll;
+
+    U64 const lllow = t + (llm2 << 32);
+    U64 const carry2 = lllow < t;
+    U64 const llhigh = llh + (llm1 >> 32) + (llm2 >> 32) + carry1 + carry2;
+
+    XXH128_hash_t const r128 = { lllow, llhigh };
+    return r128;
+
+#endif
 }
 
 XXH_FORCE_INLINE XXH128_hash_t
 XXH3_len_9to16_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
 {
     assert(data != NULL);
-    assert(key != NULL);
+    assert(keyPtr != NULL);
     assert(len >= 9 && len <= 16);
     {   const U64* const key64 = (const U64*) keyPtr;
-        U64 acc1 = PRIME64_1 * ((U64)len + seed);
-        U64 acc2 = PRIME64_2 * ((U64)len - seed);
-        U64 const ll1 = XXH_readLE64(data);
-        U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8);
-        acc1 += XXH3_mul128_fold64(ll1 + XXH_readLE64(key64+0), ll2 + XXH_readLE64(key64+1));
-        acc2 += XXH3_mul128_fold64(ll1 + XXH_readLE64(key64+2), ll2 + XXH_readLE64(key64+3));
-        {   XXH128_hash_t const h128 = { XXH3_avalanche(acc1), XXH3_avalanche(acc2) };
+        U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(key64) + seed);
+        U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8) ^ (XXH_readLE64(key64+1) - seed);
+        U64 const inlow = ll1 ^ ll2;
+        XXH128_hash_t m128 = XXH3_mul128(inlow, PRIME64_1);
+        m128.high64 += ll2 * PRIME64_1;
+        m128.low64  ^= (m128.high64 >> 32);
+        {   XXH128_hash_t h128 = XXH3_mul128(m128.low64, PRIME64_2);
+            h128.high64 += m128.high64 * PRIME64_2;
+            h128.low64   = XXH3_avalanche(h128.low64);
+            h128.high64  = XXH3_avalanche(h128.high64);
+            return h128;
+    }   }
+}
+
+/* Assumption : `secret` size is >= 16
+ * Note : it should be >= XXH3_SECRET_SIZE_MIN anyway */
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_len_0to16_128b(const void* data, size_t len, const void* secret, XXH64_hash_t seed)
+{
+    assert(data != NULL);
+    assert(len <= 16);
+    {   if (len > 8) return XXH3_len_9to16_128b(data, len, secret, seed);
+        if (len >= 4) return XXH3_len_4to8_128b(data, len, secret, seed);
+        if (len) return XXH3_len_1to3_128b(data, len, secret, seed);
+        {   XXH128_hash_t const h128 = { 0, 0 };
             return h128;
         }
     }
 }
 
 XXH_FORCE_INLINE XXH128_hash_t
-XXH3_len_0to16_128b(const void* data, size_t len, XXH64_hash_t seed)
+XXH3_hashLong_128b_internal(const void* XXH_RESTRICT data, size_t len,
+                            const void* XXH_RESTRICT secret, size_t secretSize)
 {
-    assert(data != NULL);
-    assert(len <= 16);
-    {   if (len > 8) return XXH3_len_9to16_128b(data, len, kSecret, seed);
-        if (len >= 4) return XXH3_len_4to8_128b(data, len, kSecret, seed);
-        if (len) return XXH3_len_1to3_128b(data, len, kSecret, seed);
-        {   XXH128_hash_t const h128 = { seed, (XXH64_hash_t)0 - seed };
-            return h128;
-        }
-    }
-}
+    XXH_ALIGN(XXH_ACC_ALIGN) U64 acc[ACC_NB] = { PRIME32_3, PRIME64_1, PRIME64_2, PRIME64_3, PRIME64_4, PRIME32_2, PRIME64_5, PRIME32_1 };
 
-XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_128b(const void* data, size_t len, XXH64_hash_t seed)
-{
-    XXH_ALIGN(64) U64 acc[ACC_NB] = { seed, PRIME64_1, PRIME64_2, PRIME64_3, PRIME64_4, PRIME64_5, (U64)0 - seed, 0 };
-    assert(len > 128);
-
-    XXH3_hashLong_internal_loop(acc, data, len, kSecret, sizeof(kSecret));
+    XXH3_hashLong_internal_loop(acc, data, len, secret, secretSize);
 
     /* converge into final hash */
-    assert(sizeof(acc) == 64);
-    {   U64 const low64 = XXH3_mergeAccs(acc, kSecret, (U64)len * PRIME64_1);
-        U64 const high64 = XXH3_mergeAccs(acc, kSecret+16, ((U64)len+1) * PRIME64_2);
+    XXH_STATIC_ASSERT(sizeof(acc) == 64);
+    assert(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+    {   U64 const low64 = XXH3_mergeAccs(acc, (const char*)secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
+        U64 const high64 = XXH3_mergeAccs(acc, (const char*)secret + secretSize - 64 - XXH_SECRET_MERGEACCS_START, ~((U64)len * PRIME64_2));
         XXH128_hash_t const h128 = { low64, high64 };
         return h128;
     }
 }
 
-XXH_PUBLIC_API XXH128_hash_t
-XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_128b_defaultSecret(const void* XXH_RESTRICT data, size_t len)
 {
-    if (len <= 16) return XXH3_len_0to16_128b(data, len, seed);
+    return XXH3_hashLong_128b_internal(data, len, kSecret, sizeof(kSecret));
+}
 
-    {   U64 acc1 = PRIME64_1 * (len + seed);
+XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_128b_withSecret(const void* XXH_RESTRICT data, size_t len,
+                              const void* XXH_RESTRICT secret, size_t secretSize)
+{
+    return XXH3_hashLong_128b_internal(data, len, secret, secretSize);
+}
+
+XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
+XXH3_hashLong_128b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+{
+    XXH_ALIGN(8) char secret[XXH_SECRET_DEFAULT_SIZE];
+    if (seed == 0) return XXH3_hashLong_128b_defaultSecret(data, len);
+    XXH3_initKeySeed(secret, seed);
+    return XXH3_hashLong_128b_internal(data, len, secret, sizeof(secret));
+}
+
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_len_17to128_128b(const void* XXH_RESTRICT data, size_t len,
+                     const void* XXH_RESTRICT secret, size_t secretSize,
+                     XXH64_hash_t seed)
+{
+    const BYTE* const p = (const BYTE*)data;
+    const char* const key = (const char*)secret;
+
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    assert(16 < len && len <= 128);
+
+    {   U64 acc1 = len * PRIME64_1;
         U64 acc2 = 0;
-        const BYTE* const p = (const BYTE*)data;
-        const char* const key = (const char*)kSecret;
         if (len > 32) {
             if (len > 64) {
                 if (len > 96) {
-                    if (len > 128) return XXH3_hashLong_128b(data, len, seed);
-
                     acc1 += XXH3_mix16B(p+48, key+96, seed);
                     acc2 += XXH3_mix16B(p+len-64, key+112, seed);
                 }
-
                 acc1 += XXH3_mix16B(p+32, key+64, seed);
                 acc2 += XXH3_mix16B(p+len-48, key+80, seed);
             }
-
             acc1 += XXH3_mix16B(p+16, key+32, seed);
             acc2 += XXH3_mix16B(p+len-32, key+48, seed);
         }
-
         acc1 += XXH3_mix16B(p+0, key+0, seed);
         acc2 += XXH3_mix16B(p+len-16, key+16, seed);
 
-        {   U64 const part1 = acc1 + acc2;
-            U64 const part2 = (acc1 * PRIME64_3) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
-            XXH128_hash_t const h128 = { XXH3_avalanche(part1), (XXH64_hash_t)0 - XXH3_avalanche(part2) };
+        {   U64 const low64 = acc1 + acc2;
+            U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
+            XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
             return h128;
         }
     }
 }
 
-
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len)
 {
-    return XXH3_128bits_withSeed(data, len, 0);
+    if (len <= 16) return XXH3_len_0to16_128b(data, len, kSecret, 0);
+    if (len <= 128) return XXH3_len_17to128_128b(data, len, kSecret, sizeof(kSecret), 0);
+    return XXH3_hashLong_128b_defaultSecret(data, len);
 }
 
+XXH_PUBLIC_API XXH128_hash_t
+XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize)
+{
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN);
+    /* if an action must be taken should `secret` conditions not be respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash */
+     if (len <= 16) return XXH3_len_0to16_128b(data, len, secret, 0);
+     if (len <= 128) return XXH3_len_17to128_128b(data, len, secret, secretSize, 0);
+     return XXH3_hashLong_128b_withSecret(data, len, secret, secretSize);
+}
 
-XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed)
+XXH_PUBLIC_API XXH128_hash_t
+XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+{
+    if (len <= 16) return XXH3_len_0to16_128b(data, len, kSecret, seed);
+    if (len <= 128) return XXH3_len_17to128_128b(data, len, kSecret, sizeof(kSecret), seed);
+    return XXH3_hashLong_128b_withSeed(data, len, seed);
+}
+
+XXH_PUBLIC_API XXH128_hash_t
+XXH128(const void* data, size_t len, XXH64_hash_t seed)
 {
     return XXH3_128bits_withSeed(data, len, seed);
 }
+
 
 /* ===   XXH3 128-bit streaming   === */
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -1250,21 +1250,21 @@ XXH3_hashLong_128b_internal(const void* XXH_RESTRICT data, size_t len,
     XXH_STATIC_ASSERT(sizeof(acc) == 64);
     assert(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
     {   U64 const low64 = XXH3_mergeAccs(acc, (const char*)secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
-        U64 const high64 = XXH3_mergeAccs(acc, (const char*)secret + secretSize - 64 - XXH_SECRET_MERGEACCS_START, ~((U64)len * PRIME64_2));
+        U64 const high64 = XXH3_mergeAccs(acc, (const char*)secret + secretSize - sizeof(acc) - XXH_SECRET_MERGEACCS_START, ~((U64)len * PRIME64_2));
         XXH128_hash_t const h128 = { low64, high64 };
         return h128;
     }
 }
 
 XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_128b_defaultSecret(const void* XXH_RESTRICT data, size_t len)
+XXH3_hashLong_128b_defaultSecret(const void* data, size_t len)
 {
     return XXH3_hashLong_128b_internal(data, len, kSecret, sizeof(kSecret));
 }
 
 XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_128b_withSecret(const void* XXH_RESTRICT data, size_t len,
-                              const void* XXH_RESTRICT secret, size_t secretSize)
+XXH3_hashLong_128b_withSecret(const void* data, size_t len,
+                              const void* secret, size_t secretSize)
 {
     return XXH3_hashLong_128b_internal(data, len, secret, secretSize);
 }

--- a/xxh3.h
+++ b/xxh3.h
@@ -1543,6 +1543,29 @@ XXH_PUBLIC_API int XXH128_cmp(const void* h128_1, const void* h128_2)
 }
 
 
+/*======   Canonical representation   ======*/
+XXH_PUBLIC_API void
+XXH128_canonicalFromHash(XXH128_canonical_t* dst, XXH128_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH128_canonical_t) == sizeof(XXH128_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) {
+        hash.high64 = XXH_swap64(hash.high64);
+        hash.low64  = XXH_swap64(hash.low64);
+    }
+    memcpy(dst, &hash.high64, sizeof(hash.high64));
+    memcpy((char*)dst + sizeof(hash.high64), &hash.low64, sizeof(hash.low64));
+}
+
+XXH_PUBLIC_API XXH128_hash_t
+XXH128_hashFromCanonical(const XXH128_canonical_t* src)
+{
+    XXH128_hash_t h;
+    h.high64 = XXH_readBE64(src);
+    h.low64  = XXH_readBE64(src->digest + 8);
+    return h;
+}
+
+
 
 
 #ifdef UNDEF_NDEBUG

--- a/xxh3.h
+++ b/xxh3.h
@@ -539,8 +539,15 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
             uint32x2_t const data_key_lo = vmovn_u64  (vreinterpretq_u64_u32(data_key));
             /* data_key_hi = (uint32x2_t) (data_key >> 32); */
             uint32x2_t const data_key_hi = vshrn_n_u64 (vreinterpretq_u64_u32(data_key), 32);
-            /* xacc[i] += data_vec; */
-            xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u32(data_vec));
+            if (accWidth == XXH3_acc_64bits) {
+                /* xacc[i] += data_vec; */
+                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u32(data_vec));
+            } else {  /* XXH3_acc_128bits */
+                /* xacc[i] += swap(data_vec); */
+                uint64x2_t const data64 = vreinterpretq_u64_u32(data_vec);
+                uint64x2_t const swapped= vextq_u64(data64, data64, 1);
+                xacc[i] = vaddq_u64 (xacc[i], swapped);
+            }
             /* xacc[i] += (uint64x2_t) data_key_lo * (uint64x2_t) data_key_hi; */
             xacc[i] = vmlal_u32 (xacc[i], data_key_lo, data_key_hi);
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -1350,27 +1350,24 @@ XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
     assert(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     assert(128 < len && len <= XXH3_MIDSIZE_MAX);
 
-    #define XXH3_MIDSIZE_STARTOFFSET 3
-    #define XXH3_MIDSIZE_LASTOFFSET  17
-
     {   U64 acc1 = len * PRIME64_1;
         U64 acc2 = 0;
         int const nbRounds = (int)len / 32;
         int i;
         for (i=0; i<4; i++) {
-            acc1 += XXH3_mix16B(p+(16*i),    key+(16*i),    seed);
-            acc2 += XXH3_mix16B(p+(16*i+16), key+(16*i+16), seed);
+            acc1 += XXH3_mix16B(p+(32*i),    key+(32*i),     seed);
+            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*i)+16, -seed);
         }
         acc1 = XXH3_avalanche(acc1);
         acc2 = XXH3_avalanche(acc2);
-        assert(nbRounds >= 8);
+        assert(nbRounds >= 4);
         for (i=4 ; i < nbRounds; i++) {
-            acc1 += XXH3_mix16B(p+(16*i)   , key+(16*(i-8))    + XXH3_MIDSIZE_STARTOFFSET, seed);
-            acc2 += XXH3_mix16B(p+(16*i)+16, key+(16*(i-8))+16 + XXH3_MIDSIZE_STARTOFFSET, seed);
+            acc1 += XXH3_mix16B(p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,  seed);
+            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, -seed);
         }
         /* last bytes */
-        acc1 += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     , seed);
-        acc2 += XXH3_mix16B(p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, seed);
+        acc1 += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,  seed);
+        acc2 += XXH3_mix16B(p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, -seed);
 
         {   U64 const low64 = acc1 + acc2;
             U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);

--- a/xxh3.h
+++ b/xxh3.h
@@ -1517,6 +1517,32 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
     return XXH3_128bits_withSecret(state->buffer, (size_t)(state->totalLen), state->secret, state->secretLimit + STRIPE_LEN);
 }
 
+/* 128-bit utility functions */
+
+#include <string.h>   /* memcmp */
+
+/* return : 1 is equal, 0 if different */
+XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)
+{
+    /* note : XXH128_hash_t is compact, it has no padding byte */
+    return !(memcmp(&h1, &h2, sizeof(h1)));
+}
+
+/* This prototype is compatible with stdlib's qsort().
+ * return : >0 if *h128_1  > *h128_2
+ *          <0 if *h128_1  < *h128_2
+ *          =0 if *h128_1 == *h128_2  */
+XXH_PUBLIC_API int XXH128_cmp(const void* h128_1, const void* h128_2)
+{
+    XXH128_hash_t const h1 = *(const XXH128_hash_t*)h128_1;
+    XXH128_hash_t const h2 = *(const XXH128_hash_t*)h128_2;
+    int const hcmp = (h1.high64 > h2.high64) - (h2.high64 > h1.high64);
+    /* note : bets that, in most cases, hash values are different */
+    if (hcmp) return hcmp;
+    return (h1.low64 > h2.low64) - (h2.low64 > h1.low64);
+}
+
+
 
 
 #ifdef UNDEF_NDEBUG

--- a/xxhash.h
+++ b/xxhash.h
@@ -447,9 +447,10 @@ struct XXH3_state_s {
  * As a consequence, streaming is slower than one-shot hashing.
  * For better performance, prefer using one-shot functions whenever possible. */
 
-XXH_PUBLIC_API XXH3_state_t* XXH3_64bits_createState(void);
-XXH_PUBLIC_API XXH_errorcode XXH3_64bits_freeState(XXH3_state_t* statePtr);
-XXH_PUBLIC_API void XXH3_64bits_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state);
+XXH_PUBLIC_API XXH3_state_t* XXH3_createState(void);
+XXH_PUBLIC_API XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr);
+XXH_PUBLIC_API void XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state);
+
 
 /* XXH3_64bits_reset() :
  * initialize with default parameters.
@@ -482,6 +483,11 @@ XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_digest (const XXH3_state_t* statePtr);
 #  define XXH3_128bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSecret)
 #  define XXH3_128bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_update)
 #  define XXH3_128bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_digest)
+
+#  define XXH128_isEqual XXH_NAME2(XXH_NAMESPACE, XXH128_isEqual)
+#  define XXH128_cmp     XXH_NAME2(XXH_NAMESPACE, XXH128_cmp)
+#  define XXH128_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH128_canonicalFromHash)
+#  define XXH128_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH128_hashFromCanonical)
 #endif
 
 typedef struct {
@@ -507,7 +513,7 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr);
 /* return : 1 is equal, 0 if different */
 XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2);
 
-/* This prototype is compatible with stdlib's qsort().
+/* This comparator is compatible with stdlib's qsort().
  * return : >0 if *h128_1  > *h128_2
  *          <0 if *h128_1  < *h128_2
  *          =0 if *h128_1 == *h128_2  */

--- a/xxhash.h
+++ b/xxhash.h
@@ -378,9 +378,10 @@ struct XXH64_state_s {
 #  define XXH3_64bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSecret)
 #  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
 
-#  define XXH3_64bits_createState XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_createState)
-#  define XXH3_64bits_freeState XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_freeState)
-#  define XXH3_64bits_copyState XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_copyState)
+#  define XXH3_createState XXH_NAME2(XXH_NAMESPACE, XXH3_createState)
+#  define XXH3_freeState XXH_NAME2(XXH_NAMESPACE, XXH3_freeState)
+#  define XXH3_copyState XXH_NAME2(XXH_NAMESPACE, XXH3_copyState)
+
 #  define XXH3_64bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset)
 #  define XXH3_64bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSeed)
 #  define XXH3_64bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSecret)
@@ -393,6 +394,9 @@ struct XXH64_state_s {
 #  define XXH3_128bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSecret)
 
 #  define XXH3_128bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset)
+#  define XXH3_128bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSeed)
+#  define XXH3_128bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSecret)
+#  define XXH3_128bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_update)
 #  define XXH3_128bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_digest)
 #endif
 
@@ -494,6 +498,10 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len,
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
 
 XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr);
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed);
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize);
+
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update (XXH3_state_t* statePtr, const void* input, size_t length);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr);
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -319,7 +319,7 @@ struct XXH64_state_s {
  * for both small and large inputs.
  * See full speed analysis at : http://fastcompression.blogspot.com/2019/03/presenting-xxh3.html
  * In general, expect XXH3 to run about ~2x faster on large inputs,
- * and >3x faster on small ones, though exact difference depend on platform.
+ * and >3x faster on small ones, though exact differences depend on platform.
  *
  * The algorithm is portable, will generate the same hash on all platforms.
  * It benefits greatly from vectorization units, but does not require it.
@@ -333,8 +333,8 @@ struct XXH64_state_s {
  * Produced results can still change between versions.
  * It's possible to use it for ephemeral data, but avoid storing long-term values for later re-use.
  *
- * The API currently supports one-shot hashing only.
- * The full version will include streaming capability, and canonical representation.
+ * The API currently supports one-shot hashing and streaming mode, as well as custom secrets.
+ * The full version will include canonical representation.
  *
  * There are still a number of opened questions that community can influence during the experimental period.
  * I'm trying to list a few of them below, though don't consider this list as complete.
@@ -354,11 +354,6 @@ struct XXH64_state_s {
  *                          One possibility : represent it as the concatenation of two 64-bits canonical representation (aka 2x big-endian)
  *                          Another one : represent it in the same order as natural order in the struct for little-endian platforms.
  *                                        Less consistent with existing convention for XXH32/XXH64, but may be more natural for little-endian platforms.
- *
- * - Associated functions for 128-bit hash : simple things, such as checking if 2 hashes are equal, become more difficult with struct.
- *                          Granted, it's not terribly difficult to create a comparator, but it's still a workload.
- *                          Would it be beneficial to declare and define a comparator function for XXH128_hash_t ?
- *                          Are there other operations on XXH128_hash_t which would be desirable ?
  *
  * - Seed type for 128-bits variant : currently, it's a single 64-bit value, like the 64-bit variant.
  *                          It could be argued that it's more logical to offer a 128-bit seed input parameter for a 128-bit hash.
@@ -387,17 +382,6 @@ struct XXH64_state_s {
 #  define XXH3_64bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSecret)
 #  define XXH3_64bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_update)
 #  define XXH3_64bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_digest)
-
-#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
-#  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
-#  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
-#  define XXH3_128bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSecret)
-
-#  define XXH3_128bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset)
-#  define XXH3_128bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSeed)
-#  define XXH3_128bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSecret)
-#  define XXH3_128bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_update)
-#  define XXH3_128bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_digest)
 #endif
 
 /* XXH3_64bits() :
@@ -461,7 +445,7 @@ struct XXH3_state_s {
 /* Streaming requires state maintenance.
  * This operation costs memory and cpu.
  * As a consequence, streaming is slower than one-shot hashing.
- * For better performance, prefer using one-short functions anytime possible. */
+ * For better performance, prefer using one-shot functions whenever possible. */
 
 XXH_PUBLIC_API XXH3_state_t* XXH3_64bits_createState(void);
 XXH_PUBLIC_API XXH_errorcode XXH3_64bits_freeState(XXH3_state_t* statePtr);
@@ -469,11 +453,11 @@ XXH_PUBLIC_API void XXH3_64bits_copyState(XXH3_state_t* dst_state, const XXH3_st
 
 /* XXH3_64bits_reset() :
  * initialize with default parameters.
- * result will be equivalent to `XXH3_64bits()` */
+ * result will be equivalent to `XXH3_64bits()`. */
 XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr);
 /* XXH3_64bits_reset_withSeed() :
  * generate a custom secret from `seed`, and store it into state.
- * digest will be equivalent to `XXH3_64bits_withSeed()` */
+ * digest will be equivalent to `XXH3_64bits_withSeed()`. */
 XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed);
 /* XXH3_64bits_reset_withSecret() :
  * `secret` is referenced, and must outlive the hash streaming session.
@@ -486,6 +470,19 @@ XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_digest (const XXH3_state_t* statePtr);
 
 
 /* 128-bit */
+
+#ifdef XXH_NAMESPACE
+#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
+#  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
+#  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
+#  define XXH3_128bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSecret)
+
+#  define XXH3_128bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset)
+#  define XXH3_128bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSeed)
+#  define XXH3_128bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSecret)
+#  define XXH3_128bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_update)
+#  define XXH3_128bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_digest)
+#endif
 
 typedef struct {
     XXH64_hash_t low64;
@@ -505,31 +502,16 @@ XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update (XXH3_state_t* statePtr, const 
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr);
 
 
-/* The following functions are implemented directly in header,
- * in order for them to be inlined */
-
-#include <string.h>   /* memcmp */
+/* Note : for better performance, following functions should better be inlined */
 
 /* return : 1 is equal, 0 if different */
-static int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)
-{
-    /* note : XXH128_hash_t is compact, it has no padding byte */
-    return !(memcmp(h1, h2, sizeof(h1)));
-}
+XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2);
 
 /* This prototype is compatible with stdlib's qsort().
  * return : >0 if *h128_1  > *h128_2
  *          <0 if *h128_1  < *h128_2
  *          =0 if *h128_1 == *h128_2  */
-static int XXH128_cmp(const void* h128_1, const void* h128_2)
-{
-    XXH128_hash_t const h1 = *(const XXH128_hash_t*)h128_1;
-    XXH128_hash_t const h2 = *(const XXH128_hash_t*)h128_2;
-    int const hcmp = (h1.high64 > h2.high64) - (h2.high64 > h1.high64);
-    /* note : bets that, in most cases, hash values are different */
-    if (hcmp) return hcmp;
-    return (h1.low64 > h2.low64) - (h2.low64 > h1.low64);
-}
+XXH_PUBLIC_API int XXH128_cmp(const void* h128_1, const void* h128_2);
 
 
 #endif  /* XXH_NO_LONG_LONG */

--- a/xxhash.h
+++ b/xxhash.h
@@ -505,6 +505,33 @@ XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update (XXH3_state_t* statePtr, const 
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr);
 
 
+/* The following functions are implemented directly in header,
+ * in order for them to be inlined */
+
+#include <string.h>   /* memcmp */
+
+/* return : 1 is equal, 0 if different */
+static int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)
+{
+    /* note : XXH128_hash_t is compact, it has no padding byte */
+    return !(memcmp(h1, h2, sizeof(h1)));
+}
+
+/* This prototype is compatible with stdlib's qsort().
+ * return : >0 if *h128_1  > *h128_2
+ *          <0 if *h128_1  < *h128_2
+ *          =0 if *h128_1 == *h128_2  */
+static int XXH128_cmp(const void* h128_1, const void* h128_2)
+{
+    XXH128_hash_t const h1 = *(const XXH128_hash_t*)h128_1;
+    XXH128_hash_t const h2 = *(const XXH128_hash_t*)h128_2;
+    int const hcmp = (h1.high64 > h2.high64) - (h2.high64 > h1.high64);
+    /* note : bets that, in most cases, hash values are different */
+    if (hcmp) return hcmp;
+    return (h1.low64 > h2.low64) - (h2.low64 > h1.low64);
+}
+
+
 #endif  /* XXH_NO_LONG_LONG */
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -339,7 +339,7 @@ struct XXH64_state_s {
  * There are still a number of opened questions that community can influence during the experimental period.
  * I'm trying to list a few of them below, though don't consider this list as complete.
  *
- * - 128-bits output type : currently defined as a structure of 2 64-bits fields.
+ * - 128-bits output type : currently defined as a structure of two 64-bits fields.
  *                          That's because 128-bit values do not exist in C standard.
  *                          Note that it means that, at byte level, result is not identical depending on endianess.
  *                          However, at field level, they are identical on all platforms.
@@ -349,23 +349,23 @@ struct XXH64_state_s {
  *                          Are the names of the inner 64-bit fields important ? Should they be changed ?
  *
  * - Canonical representation : for the 64-bit variant, canonical representation is the same as XXH64() (aka big-endian).
- *                          What should it be for the 128-bit variant ?
- *                          Since it's no longer a scalar value, big-endian representation is no longer an obvious choice.
- *                          One possibility : represent it as the concatenation of two 64-bits canonical representation (aka 2x big-endian)
- *                          Another one : represent it in the same order as natural order in the struct for little-endian platforms.
- *                                        Less consistent with existing convention for XXH32/XXH64, but may be more natural for little-endian platforms.
+ *                          For consistency with existing variants, the same rule has been selected for the 128-bit hash,
+ *                          and canonical representation also uses big-endian convention.
+ *                          It's less convenient for little-endian cpus (requires swapping registers),
+ *                          but canonical representation is expected to be useful for serialization and display only,
+ *                          hence is not a speed critical operation.
  *
  * - Seed type for 128-bits variant : currently, it's a single 64-bit value, like the 64-bit variant.
  *                          It could be argued that it's more logical to offer a 128-bit seed input parameter for a 128-bit hash.
- *                          Although it's also more difficult to use, since it requires to declare and pass a structure instead of a value.
- *                          It would either replace current choice, or add a new one.
+ *                          But 128-bit seed is more difficult to use, since it requires to pass a structure instead of a scalar value.
+ *                          Such a variant could either replace current choice, or add a new one.
  *                          Farmhash, for example, offers both variants (the 128-bits seed variant is called `doubleSeed`).
  *                          If both 64-bit and 128-bit seeds are possible, which variant should be called XXH128 ?
  *
  * - Result for len==0 : Currently, the result of hashing a zero-length input is `0`.
  *                          It seems okay as a return value when using all "default" secret and seed (it used to be a request for XXH32/XXH64).
  *                          But is it still fine to return `0` when secret or seed are non-default ?
- *                          Are there use case which would depend on a different hash result when the secret is different ?
+ *                          Are there use cases which would depend on a different hash result for zero-length input when the secret is different ?
  */
 
 #ifdef XXH_NAMESPACE
@@ -512,6 +512,12 @@ XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2);
  *          <0 if *h128_1  < *h128_2
  *          =0 if *h128_1 == *h128_2  */
 XXH_PUBLIC_API int XXH128_cmp(const void* h128_1, const void* h128_2);
+
+
+/*======   Canonical representation   ======*/
+typedef struct { unsigned char digest[16]; } XXH128_canonical_t;
+XXH_PUBLIC_API void XXH128_canonicalFromHash(XXH128_canonical_t* dst, XXH128_hash_t hash);
+XXH_PUBLIC_API XXH128_hash_t XXH128_hashFromCanonical(const XXH128_canonical_t* src);
 
 
 #endif  /* XXH_NO_LONG_LONG */

--- a/xxhash.h
+++ b/xxhash.h
@@ -387,9 +387,10 @@ struct XXH64_state_s {
 #  define XXH3_64bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_update)
 #  define XXH3_64bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_digest)
 
+#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
 #  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
 #  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
-#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
+#  define XXH3_128bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSecret)
 
 #  define XXH3_128bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset)
 #  define XXH3_128bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_digest)
@@ -487,9 +488,10 @@ typedef struct {
     XXH64_hash_t high64;
 } XXH128_hash_t;
 
+XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);  /* == XXH128() */
-XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed);
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize);
 
 XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr);
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr);

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -726,7 +726,6 @@ static void BMK_sanityCheck(void)
     BMK_testXXH64(sanityBuffer,222, 0,     0xB641AE8CB691C174ULL);
     BMK_testXXH64(sanityBuffer,222, prime, 0x20CB8AB7AE10C14AULL);
 
-
     BMK_testXXH3(NULL,           0, 0,       0);                      /* zero-length hash is always 0 */
     BMK_testXXH3(NULL,           0, prime64, 0);
     BMK_testXXH3(sanityBuffer,   1, 0,       0x7198D737CFE7F386ULL);  /*  1 -  3 */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -853,34 +853,34 @@ static void BMK_sanityCheck(void)
     {   XXH128_hash_t const expected = { 0x54135EB88AD8B75EULL, 0xBC45CE6AE50BCF53ULL };
         BMK_testXXH128(sanityBuffer, 222, prime, expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xD790F5F57DE832EBULL, 0x74955A24E6544BDBULL };
+    {   XXH128_hash_t const expected = { 0xB0C48E6D18E9D084ULL, 0xB16FC17E992FF45DULL };
         BMK_testXXH128(sanityBuffer, 403, 0,     expected);         /* one block, last stripe is overlapping */
     }
-    {   XXH128_hash_t const expected = { 0x487B67FA407601EFULL, 0x8598DA94F345694FULL };
+    {   XXH128_hash_t const expected = { 0x0A1D320C9520871DULL, 0xCE11CB376EC93252ULL };
         BMK_testXXH128(sanityBuffer, 403, prime64, expected);       /* one block, last stripe is overlapping */
     }
-    {   XXH128_hash_t const expected = { 0x764128E310D0271EULL, 0xB449E9DE76EE8224ULL };
+    {   XXH128_hash_t const expected = { 0xA03428558AC97327ULL, 0x4ECF51281BA406F7ULL };
         BMK_testXXH128(sanityBuffer, 512, 0,     expected);         /* one block, finishing at stripe boundary */
     }
-    {   XXH128_hash_t const expected = { 0xA85053BF488E24D2ULL, 0xAFFDC2C9FBD8FCC8ULL };
+    {   XXH128_hash_t const expected = { 0xAF67A482D6C893F2ULL, 0x1382D92F25B84D90ULL };
         BMK_testXXH128(sanityBuffer, 512, prime64, expected);       /* one block, finishing at stripe boundary */
     }
-    {   XXH128_hash_t const expected = { 0xAF61276CDEA9B39BULL, 0x1CABC67A0F550C56ULL };
+    {   XXH128_hash_t const expected = { 0x21901B416B3B9863ULL, 0x212AF8E6326F01E0ULL };
         BMK_testXXH128(sanityBuffer,2048, 0,     expected);         /* two blocks, finishing at block boundary */
     }
-    {   XXH128_hash_t const expected = { 0x9475618498556F27ULL, 0xCECD1C4AA3169D20ULL };
+    {   XXH128_hash_t const expected = { 0xBDBB2282577DADECULL, 0xF78CDDC2C9A9A692ULL };
         BMK_testXXH128(sanityBuffer,2048, prime, expected);         /* two blocks, finishing at block boundary */
     }
-    {   XXH128_hash_t const expected = { 0xA54D221EB84E5ED7ULL, 0x234E4EF809C9B05DULL };
+    {   XXH128_hash_t const expected = { 0x00AD52FA9385B6FEULL, 0xC705BAD3356CE302ULL };
         BMK_testXXH128(sanityBuffer,2240, 0,     expected);         /* two blocks, ends at stripe boundary */
     }
-    {   XXH128_hash_t const expected = { 0x551FE60DB07C751FULL, 0x4DF158B413CBB80FULL };
+    {   XXH128_hash_t const expected = { 0x10FD0072EC68BFAAULL, 0xE1312F3458817F15ULL };
         BMK_testXXH128(sanityBuffer,2240, prime, expected);         /* two blocks, ends at stripe boundary */
     }
-    {   XXH128_hash_t const expected = { 0xBE244F6C1FB590ACULL, 0x9AE190EF791860F6ULL };
+    {   XXH128_hash_t const expected = { 0x970C91411533862CULL, 0x4BBD06FF7BFF0AB1ULL };
         BMK_testXXH128(sanityBuffer,2237, 0,     expected);         /* two blocks, ends at stripe boundary */
     }
-    {   XXH128_hash_t const expected = { 0x7EA979C9FA51F8CCULL, 0x72243D5655B36789ULL };
+    {   XXH128_hash_t const expected = { 0xD80282846D814431ULL, 0x14EBB157B84D9785ULL };
         BMK_testXXH128(sanityBuffer,2237, prime, expected);         /* two blocks, ends at stripe boundary */
     }
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -841,16 +841,16 @@ static void BMK_sanityCheck(void)
     {   XXH128_hash_t const expected = { 0xFA2086367CDB177FULL, 0x0AEDEA68C988B0C0ULL };
         BMK_testXXH128(sanityBuffer, 103, prime, expected);         /* 97-128 */
     }
-    {   XXH128_hash_t const expected = { 0x98C565DBCA0E3A10ULL, 0xC75FF93AFF70D9EBULL };
+    {   XXH128_hash_t const expected = { 0xC3142FDDD9102A3FULL, 0x06F1747E77185F97ULL };
         BMK_testXXH128(sanityBuffer, 192, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xF572C0DAC09595B4ULL, 0x26548FAF92F65AD1ULL };
+    {   XXH128_hash_t const expected = { 0xA89F07B35987540FULL, 0xCF1B35FB2C557F54ULL };
         BMK_testXXH128(sanityBuffer, 192, prime, expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0x74C5757F67860DBAULL, 0x27DFB9B0E09A7390ULL };
+    {   XXH128_hash_t const expected = { 0xA61AC4EB3295F86BULL, 0x33FA7B7598C28A07ULL };
         BMK_testXXH128(sanityBuffer, 222, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xCD75640ECDE915DAULL, 0x030A838A4580250AULL };
+    {   XXH128_hash_t const expected = { 0x54135EB88AD8B75EULL, 0xBC45CE6AE50BCF53ULL };
         BMK_testXXH128(sanityBuffer, 222, prime, expected);         /* 129-240 */
     }
     {   XXH128_hash_t const expected = { 0xD790F5F57DE832EBULL, 0x74955A24E6544BDBULL };


### PR DESCRIPTION
`XXH128()` is updated to follow the same model as `XXH3_64bits()`.
It can accept a custom secret of any size (> minimum), implements a "mid-size" strategy for 128-240 range, and a streaming implementation is available.

Not completed yet (hence failing tests) :
`ARM` and `VSX` targets must be updated for 128-bit output (`accumulate512` function).

Also to add :
utility function for 128-bit hashes, such as `isEqual` and `cmp`,
and 128-bit canonical representation.

_edit_ : utility functions completed
_edit 2_: 128-bit canonical representation is completed