### PR TITLE
Cmake opts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ xxhsum_inlinedXXH.exe
 *.html
 *.wasm
 *.js
+
+# CMake build directories
+build*/
+
+# project managers artifacts
+.projectile

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -41,16 +41,15 @@ set(XXHASH_BUILD_XXHSUM ON CACHE BOOL "Build the xxhsum binary")
 # If XXHASH is being bundled in another project, we don't want to
 # install anything.  However, we want to let people override this, so
 # we'll use the XXHASH_BUNDLED_MODE variable to let them do that; just
-# set it to OFF in your project before you add_subdirectory(xxhash/contrib/cmake_unofficial).
-if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
-  # Bundled mode hasn't been set one way or the other, set the default
-  # depending on whether or not we are the top-level project.
-  if("${PARENT_DIRECTORY}" STREQUAL "")
+# set it to OFF in your project before you add_subdirectory(xxhash/cmake_unofficial).
+if(NOT DEFINED XXHASH_BUNDLED_MODE)
+  if("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
     set(XXHASH_BUNDLED_MODE OFF)
   else()
     set(XXHASH_BUNDLED_MODE ON)
   endif()
 endif()
+set(XXHASH_BUNDLED_MODE ${XXHASH_BUNDLED_MODE} CACHE BOOL "" FORCE)
 mark_as_advanced(XXHASH_BUNDLED_MODE)
 
 # Allow people to choose whether to build shared or static libraries

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -34,9 +34,9 @@ else()
         LANGUAGES C)
 endif()
 
-option(BUILD_XXHSUM "Build the xxhsum binary" ON)
 option(BUILD_SHARED_LIBS "Build shared library" ON)
-option(BUILD_ENABLE_INLINE_API "add xxhash.c to includes for -DXXH_INLINE_ALL" ON)
+set(XXHASH_BUILD_ENABLE_INLINE_API ON CACHE BOOL "add xxhash.c to includes for -DXXH_INLINE_ALL")
+set(XXHASH_BUILD_XXHSUM ON CACHE BOOL "Build the xxhsum binary")
 
 # If XXHASH is being bundled in another project, we don't want to
 # install anything.  However, we want to let people override this, so
@@ -74,14 +74,14 @@ set_target_properties(xxhash PROPERTIES
   SOVERSION "${XXHASH_VERSION_STRING}"
   VERSION "${XXHASH_VERSION_STRING}")
 
-if(BUILD_XXHSUM)
+if(XXHASH_BUILD_XXHSUM)
   # xxhsum
   add_executable(xxhsum "${XXHASH_DIR}/xxhsum.c")
   add_executable(${PROJECT_NAME}::xxhsum ALIAS xxhsum)
 
   target_link_libraries(xxhsum PRIVATE xxhash)
   target_include_directories(xxhsum PRIVATE "${XXHASH_DIR}")
-endif(BUILD_XXHSUM)
+endif(XXHASH_BUILD_XXHSUM)
 
 # Extra warning flags
 include (CheckCCompilerFlag)
@@ -112,17 +112,17 @@ if(NOT XXHASH_BUNDLED_MODE)
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
   install(FILES "${XXHASH_DIR}/xxhash.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-  if(BUILD_ENABLE_INLINE_API)
+  if(XXHASH_BUILD_ENABLE_INLINE_API)
     install(FILES "${XXHASH_DIR}/xxhash.c"
       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
   endif()
-  if(BUILD_XXHSUM)
+  if(XXHASH_BUILD_XXHSUM)
     install(TARGETS xxhsum
       EXPORT xxHashTargets
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     install(FILES "${XXHASH_DIR}/xxhsum.1"
       DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
-  endif(BUILD_XXHSUM)
+  endif(XXHASH_BUILD_XXHSUM)
 
   include(CMakePackageConfigHelpers)
 
@@ -139,7 +139,7 @@ if(NOT XXHASH_BUNDLED_MODE)
     INSTALL_DESTINATION ${xxHash_CONFIG_INSTALL_DIR})
   if("${CMAKE_VERSION}" VERSION_LESS "3.0")
       set(XXHASH_EXPORT_SET xxhash)
-      if(BUILD_XXHSUM)
+      if(XXHASH_BUILD_XXHSUM)
         set(XXHASH_EXPORT_SET ${XXHASH_EXPORT_SET} xxhsum)
       endif()
       export(TARGETS ${XXHASH_EXPORT_SET}

--- a/cmake_unofficial/README.md
+++ b/cmake_unofficial/README.md
@@ -7,14 +7,14 @@ Build xxHash targets:
     cd </path/to/xxHash/>
     mkdir build
     cd build
-    cmake ../cmake_unofficial [options] #optionaly add -DCMAKE_INSTALL_PREFIX=</custom/install/prefix/path/>
+    cmake ../cmake_unofficial [options]
     cmake --build .
     cmake --build . --target install #optional
 
 Where possible options are:
-- `-DBUILD_XXHSUM=<ON|OFF>` : build the command line binary. ON by default
+- `-DXXHASH_BUILD_ENABLE_INLINE_API=<ON|OFF>` : adds xxhash.c for the `-DXXH_INLINE_ALL` api. ON by default.
+- `-DXXHASH_BUILD_XXHSUM=<ON|OFF>` : build the command line binary. ON by default
 - `-DBUILD_SHARED_LIBS=<ON|OFF>` : build dynamic library. ON by default.
-- `-DBUILD_ENABLE_INLINE_API=<ON|OFF>` : adds xxhash.c for the `-DXXH_INLINE_ALL` api. ON by default.
 - `-DCMAKE_INSTALL_PREFIX=<path>` : use custom install prefix path.
 
 Add lines into downstream CMakeLists.txt:
@@ -28,8 +28,8 @@ Add lines into downstream CMakeLists.txt:
 
     option(BUILD_SHARE_LIBS "Build shared libs" OFF) #optional
     ...
-    set(BUILD_ENABLE_INLINE_API OFF) #optional
-    set(BUILD_XXHSUM OFF) #optional
+    set(XXHASH_BUILD_ENABLE_INLINE_API OFF) #optional
+    set(XXHASH_BUILD_XXHSUM OFF) #optional
     add_subdirectory(</path/to/xxHash/cmake_unofficial/> </path/to/xxHash/build/> EXCLUDE_FROM_ALL)
     ...
     target_link_libraries(MyTarget PRIVATE xxHash::xxhash)


### PR DESCRIPTION
Hello!

## first commit

>For historical reasons in CMake 3.12 and below the `option()` command removes a normal (non-cached) variable
>of the same name when:
>
>- a cache entry of the specified name does not exist at all, or
>- a cache entry of the specified name exists but has not been given a type (e.g. via `-D<name>=ON` on the command line).

I've replaced `option()` commands with `set(... CACHE ...)` for build options (`BUILD_XXHSUM` and `BUILD_ENABLE_INLINE_API`) in order to provide possibility to hardcode build options (within downstream project) in BUNDLED_MODE with normal `set()` (for CMake < 3.13).

Also i've prefixed these options with `XXHASH_` for convenience.

## second commit

Fixes bundled mode determining logic and makes `XXHASH_BUNDLED_MODE` overridable cached var which can be set from downstream projects.

## third commit

It's common practice to create separate `build`/`build-<arhc>`/etc directory within project for CMake files/cache/artifatcs so i've added `build*/` entry into .gitignore.
 Also i've added `.projectile` (it's useful for emacs/projectile users) -- if it is "too much" i can remove it from commit.

Good luck!