### PR TITLE
Prevent Clang from emitting unaligned ldm/ldrd on ARMv6, better arm macros

### DIFF
--- a/xxhash.c
+++ b/xxhash.c
@@ -50,10 +50,10 @@
  * Prefer these methods in priority order (0 > 1 > 2)
  */
 #ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
-#  if defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED) && __ARM_ARCH == 6
+#  if defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED) && defined(__ARM_ARCH) && (__ARM_ARCH == 6)
 #    define XXH_FORCE_MEMORY_ACCESS 2
 #  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
-  (defined(__GNUC__) && ( __ARM_ARCH >= 7))
+  (defined(__GNUC__) && (defined(__ARM_ARCH) && __ARM_ARCH >= 7))
 #    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif

--- a/xxhash.c
+++ b/xxhash.c
@@ -50,14 +50,10 @@
  * Prefer these methods in priority order (0 > 1 > 2)
  */
 #ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
-#  if defined(__GNUC__) && ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) \
-                        || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) \
-                        || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
+#  if defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED) && __ARM_ARCH == 6
 #    define XXH_FORCE_MEMORY_ACCESS 2
 #  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
-  (defined(__GNUC__) && ( defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) \
-                    || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) \
-                    || defined(__ARM_ARCH_7S__) ))
+  (defined(__GNUC__) && ( __ARM_ARCH >= 7))
 #    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif


### PR DESCRIPTION
Clang was using ldmia and ldrd on unaligned pointers on ARMv6. These instructions don't support unaligned access.

When `-munaligned-access` is used, this will emit normal ldr sequences which do support unaligned access.
I also check the numerical value of __ARM_ARCH.