### PR TITLE
Visual Studio tests on Appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# compilation chain
-.clang_complete
-
 # objects
 *.o
 *.s
@@ -18,6 +15,9 @@ xxhsum_privateXXH
 xxhsum_inlinedXXH
 xxhsum_inlinedXXH.exe
 
+# compilation chain
+.clang_complete
+
 # Mac OS-X artefacts
 *.dSYM
 .DS_Store
@@ -32,3 +32,6 @@ build*/
 
 # project managers artifacts
 .projectile
+
+# analyzer artifacts
+infer-out

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ build_script:
 
   - if [%COMPILER%]==[visual] (
       cd cmake_unofficial &&
-      cmake . -DCMAKE_BUILD_TYPE=Release -A %ARCH% -DCMAKE_C_FLAGS="/WX /W3" &&
+      cmake . -DCMAKE_BUILD_TYPE=Release -A %ARCH% -DXXHASH_C_FLAGS="/WX" &&
       cmake --build . --config Release
     )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ build_script:
 
   - if [%COMPILER%]==[visual] (
       cd cmake_unofficial &&
-      cmake . -DCMAKE_BUILD_TYPE=Release -A %ARCH% &&
+      cmake . -DCMAKE_BUILD_TYPE=Release -A %ARCH% -DCMAKE_C_FLAGS="/WX /W3" &&
       cmake --build . --config Release
     )
 

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -93,6 +93,9 @@ endif(XXHASH_BUILD_XXHSUM)
 
 # Extra warning flags
 include (CheckCCompilerFlag)
+if (XXHASH_C_FLAGS)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${XXHASH_C_FLAGS}")
+endif()
 foreach (flag
     -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow
     -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement
@@ -165,4 +168,3 @@ if(NOT XXHASH_BUNDLED_MODE)
     DESTINATION ${xxHash_CONFIG_INSTALL_DIR}
     NAMESPACE ${PROJECT_NAME}::)
 endif(NOT XXHASH_BUNDLED_MODE)
-

--- a/xxh3.h
+++ b/xxh3.h
@@ -1437,19 +1437,19 @@ XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
         int const nbRounds = (int)len / 32;
         int i;
         for (i=0; i<4; i++) {
-            acc1 += XXH3_mix16B(p+(32*i),    key+(32*i),     seed);
-            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*i)+16, -seed);
+            acc1 += XXH3_mix16B(p+(32*i),    key+(32*i),         seed);
+            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*i)+16, 0ULL-seed);
         }
         acc1 = XXH3_avalanche(acc1);
         acc2 = XXH3_avalanche(acc2);
         XXH_ASSERT(nbRounds >= 4);
         for (i=4 ; i < nbRounds; i++) {
-            acc1 += XXH3_mix16B(p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,  seed);
-            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, -seed);
+            acc1 += XXH3_mix16B(p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,      seed);
+            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, 0ULL-seed);
         }
         /* last bytes */
-        acc1 += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,  seed);
-        acc2 += XXH3_mix16B(p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, -seed);
+        acc1 += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,      seed);
+        acc2 += XXH3_mix16B(p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL-seed);
 
         {   U64 const low64 = acc1 + acc2;
             U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);

--- a/xxhash.c
+++ b/xxhash.c
@@ -996,8 +996,8 @@ XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long 
     state.v2 = seed + PRIME64_2;
     state.v3 = seed + 0;
     state.v4 = seed - PRIME64_1;
-     /* do not write into reserved, might be removed in a future version */
-    memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved));
+     /* do not write into reserved64, might be removed in a future version */
+    memcpy(statePtr, &state, sizeof(state) - sizeof(state.reserved64));
     return XXH_OK;
 }
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -303,7 +303,8 @@ struct XXH64_state_s {
    XXH64_hash_t v4;
    XXH64_hash_t mem64[4];
    XXH32_hash_t memsize;
-   XXH32_hash_t reserved[2];     /* never read nor write, might be removed in a future version */
+   XXH32_hash_t reserved32;  /* required for padding anyway */
+   XXH64_hash_t reserved64;  /* never read nor write, might be removed in a future version */
 };   /* typedef'd to XXH64_state_t */
 #endif   /* XXH_NO_LONG_LONG */
 
@@ -425,16 +426,16 @@ struct XXH3_state_s {
    XXH_ALIGN(64) XXH64_hash_t acc[8];
    XXH_ALIGN(64) char customSecret[XXH3_SECRET_DEFAULT_SIZE];  /* used to store a custom secret generated from the seed. Makes state larger. Design might change */
    XXH_ALIGN(64) char buffer[XXH3_INTERNALBUFFER_SIZE];
-   const void* secret;
    XXH32_hash_t bufferedSize;
    XXH32_hash_t nbStripesPerBlock;
    XXH32_hash_t nbStripesSoFar;
+   XXH32_hash_t secretLimit;
    XXH32_hash_t reserved32;
    XXH32_hash_t reserved32_2;
-   XXH32_hash_t secretLimit;
    XXH64_hash_t totalLen;
    XXH64_hash_t seed;
    XXH64_hash_t reserved64;
+   const void* secret;    /* note : there is some padding after, due to alignment on 64 bytes */
 };   /* typedef'd to XXH3_state_t */
 
 /* Streaming requires state maintenance.


### PR DESCRIPTION
now generates an error when Visual compiler emits a warning
also fix a few corresponding minor warnings on Visual.
fix #249
