### PR TITLE
XXH128

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,8 +254,8 @@ namespaceTest:  ## ensure XXH_NAMESPACE redefines all public symbols
 
 MD2ROFF ?= ronn
 MD2ROFF_FLAGS ?= --roff --warnings --manual="User Commands" --organization="xxhsum $(XXHSUM_VERSION)"
-xxhsum.1: xxhsum.1.md
-	cat $^ | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
+xxhsum.1: xxhsum.1.md xxhash.h
+	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
 
 .PHONY: man
 man: xxhsum.1  ## generate man page from markdown source

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 	$(RUN_ENV) ./xxhsum -bi1
 	# file bench
 	$(RUN_ENV) ./xxhsum -bi1 xxhash.c
+	# 128-bit
+	$(RUN_ENV) ./xxhsum -H2 xxhash.c
+	# request incorrect variant
+	! $(RUN_ENV) ./xxhsum -H9 xxhash.c
 
 
 .PHONY: test-mem

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 	# 128-bit
 	$(RUN_ENV) ./xxhsum -H2 xxhash.c
 	# request incorrect variant
-	! $(RUN_ENV) ./xxhsum -H9 xxhash.c
+	$(RUN_ENV) ./xxhsum -H9 xxhash.c ; test $$? -eq 1
 
 
 .PHONY: test-mem
@@ -188,8 +188,10 @@ test-xxhsum-c: xxhsum
 	# xxhsum to/from file, shell redirection
 	./xxhsum xxh* > .test.xxh64
 	./xxhsum -H0 xxh* > .test.xxh32
+	./xxhsum -H2 xxh* > .test.xxh128
 	./xxhsum -c .test.xxh64
 	./xxhsum -c .test.xxh32
+	./xxhsum -c .test.xxh128
 	./xxhsum -c < .test.xxh64
 	./xxhsum -c < .test.xxh32
 	# xxhsum -c warns improperly format lines.
@@ -338,10 +340,12 @@ install: lib xxhsum  ## install libraries, CLI, links and man page
 	@$(INSTALL_PROGRAM) xxhsum $(DESTDIR)$(BINDIR)/xxhsum
 	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh32sum
 	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh64sum
+	@ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh128sum
 	@echo Installing man pages
 	@$(INSTALL_DATA) xxhsum.1 $(DESTDIR)$(MANDIR)/xxhsum.1
 	@ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh32sum.1
 	@ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh64sum.1
+	@ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh128sum.1
 	@echo xxhash installation completed
 
 .PHONY: uninstall
@@ -353,9 +357,11 @@ uninstall:  ## uninstall libraries, CLI, links and man page
 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/xxhash.h
 	@$(RM) $(DESTDIR)$(BINDIR)/xxh32sum
 	@$(RM) $(DESTDIR)$(BINDIR)/xxh64sum
+	@$(RM) $(DESTDIR)$(BINDIR)/xxh128sum
 	@$(RM) $(DESTDIR)$(BINDIR)/xxhsum
 	@$(RM) $(DESTDIR)$(MANDIR)/xxh32sum.1
 	@$(RM) $(DESTDIR)$(MANDIR)/xxh64sum.1
+	@$(RM) $(DESTDIR)$(MANDIR)/xxh128sum.1
 	@$(RM) $(DESTDIR)$(MANDIR)/xxhsum.1
 	@echo xxhsum successfully uninstalled
 

--- a/Makefile
+++ b/Makefile
@@ -181,13 +181,13 @@ test32: clean xxhsum32
 .PHONY: test-xxhsum-c
 test-xxhsum-c: xxhsum
 	# xxhsum to/from pipe
-	./xxhsum lib* | ./xxhsum -c -
-	./xxhsum -H0 lib* | ./xxhsum -c -
+	./xxhsum xxh* | ./xxhsum -c -
+	./xxhsum -H0 xxh* | ./xxhsum -c -
 	# xxhsum -q does not display "Loading" message into stderr (#251)
 	! ./xxhsum -q xxh* 2>&1 | grep Loading
 	# xxhsum to/from file, shell redirection
-	./xxhsum lib* > .test.xxh64
-	./xxhsum -H0 lib* > .test.xxh32
+	./xxhsum xxh* > .test.xxh64
+	./xxhsum -H0 xxh* > .test.xxh32
 	./xxhsum -c .test.xxh64
 	./xxhsum -c .test.xxh32
 	./xxhsum -c < .test.xxh64

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,8 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 	$(RUN_ENV) ./xxhsum -bi1
 	# file bench
 	$(RUN_ENV) ./xxhsum -bi1 xxhash.c
+	# 32-bit
+	$(RUN_ENV) ./xxhsum -H0 xxhash.c
 	# 128-bit
 	$(RUN_ENV) ./xxhsum -H2 xxhash.c
 	# request incorrect variant
@@ -168,10 +170,8 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 
 .PHONY: test-mem
 VALGRIND = valgrind --leak-check=yes --error-exitcode=1
-test-mem: xxhsum  ## valgrind tests for xxhsum CLI, looking for memory leaks
-	$(VALGRIND) ./xxhsum -bi1 xxhash.c
-	$(VALGRIND) ./xxhsum -H0  xxhash.c
-	$(VALGRIND) ./xxhsum -H1  xxhash.c
+test-mem: RUN_ENV = $(VALGRIND)
+test-mem: xxhsum check
 
 .PHONY: test32
 test32: clean xxhsum32

--- a/xxh3.h
+++ b/xxh3.h
@@ -1336,7 +1336,7 @@ XXH3_len_9to16_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash
         U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8) ^ (XXH_readLE64(key64+1) - seed);
         U64 const inlow = ll1 ^ ll2;
         XXH128_hash_t m128 = XXH_mult64to128(inlow, PRIME64_1);
-        //U64 const lenContrib = (U64)(U32)len * (U64)PRIME32_5; m128.low64 += lenContrib;
+        U64 const lenContrib = (U64)(U32)len * (U64)PRIME32_5; m128.low64 += lenContrib;
         m128.high64 += ll2 * PRIME64_1;
         m128.low64  ^= (m128.high64 >> 32);
         {   XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);

--- a/xxh3.h
+++ b/xxh3.h
@@ -1336,6 +1336,7 @@ XXH3_len_9to16_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash
         U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8) ^ (XXH_readLE64(key64+1) - seed);
         U64 const inlow = ll1 ^ ll2;
         XXH128_hash_t m128 = XXH_mult64to128(inlow, PRIME64_1);
+        //U64 const lenContrib = (U64)(U32)len * (U64)PRIME32_5; m128.low64 += lenContrib;
         m128.high64 += ll2 * PRIME64_1;
         m128.low64  ^= (m128.high64 >> 32);
         {   XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);

--- a/xxhash.h
+++ b/xxhash.h
@@ -164,7 +164,7 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 ***************************************/
 #define XXH_VERSION_MAJOR    0
 #define XXH_VERSION_MINOR    7
-#define XXH_VERSION_RELEASE  1
+#define XXH_VERSION_RELEASE  2
 #define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
 XXH_PUBLIC_API unsigned XXH_versionNumber (void);
 

--- a/xxhsum.1
+++ b/xxhsum.1
@@ -1,5 +1,5 @@
 .
-.TH "XXHSUM" "1" "July 2019" "xxhsum 0.7.1" "User Commands"
+.TH "XXHSUM" "1" "September 2019" "xxhsum 0.7.2" "User Commands"
 .
 .SH "NAME"
 \fBxxhsum\fR \- print or check xxHash non\-cryptographic checksums

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -814,10 +814,10 @@ static void BMK_sanityCheck(void)
     {   XXH128_hash_t const expected = { 0x97B28D3079F8541FULL, 0xEFC0B954298E6555ULL };
         BMK_testXXH128(sanityBuffer,   6, prime, expected);         /* 4-8 */
     }
-    {   XXH128_hash_t const expected = { 0x0E0CD01F05AC2F0DULL, 0x2B55C95951070D4BULL };
+    {   XXH128_hash_t const expected = { 0x9044570967199F91ULL, 0x738EE3E642A85165ULL };
         BMK_testXXH128(sanityBuffer,  12, 0,     expected);         /* 9-16 */
     }
-    {   XXH128_hash_t const expected = { 0xA9DE561CA04CDF37ULL, 0x609E31FDC00A43C9ULL };
+    {   XXH128_hash_t const expected = { 0xE3C75A78FE67D411ULL, 0xD4396DA60355312BULL };
         BMK_testXXH128(sanityBuffer,  12, prime, expected);         /* 9-16 */
     }
     {   XXH128_hash_t const expected = { 0x46796F3F78B20F6BULL, 0x58FF55C3926C13FAULL };

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -943,7 +943,7 @@ static void BMK_hashStream(void* xxhHashValue, const algoType hashType,
             (void)XXH3_128bits_update(&state128, buffer, readSize);
             break;
         default:
-            break;
+            assert(0);
         }
     }
 
@@ -965,7 +965,7 @@ static void BMK_hashStream(void* xxhHashValue, const algoType hashType,
             break;
         }
     default:
-            break;
+        assert(0);
     }
 }
 
@@ -1682,8 +1682,8 @@ int main(int argc, const char** argv)
     endianess displayEndianess = big_endian;
 
     /* special case : xxhNNsum default to NN bits checksum */
-    if (strstr(exename, "xxh32sum") != NULL) algo = algo_xxh32;
-    if (strstr(exename, "xxh64sum") != NULL) algo = algo_xxh64;
+    if (strstr(exename,  "xxh32sum") != NULL) algo = algo_xxh32;
+    if (strstr(exename,  "xxh64sum") != NULL) algo = algo_xxh64;
     if (strstr(exename, "xxh128sum") != NULL) algo = algo_xxh128;
 
     for(i=1; i<argc; i++) {
@@ -1723,6 +1723,8 @@ int main(int argc, const char** argv)
             case 'H':
                 algo = (algoType)(argument[1] - '0');
                 argument+=2;
+                if (!((algo >= algo_xxh32) && (algo <= algo_xxh128)))
+                    return badusage(exename);
                 break;
 
             /* File check mode */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1280,6 +1280,16 @@ static ParseLineResult parseLine(ParsedLine* parsedLine, const char* line)
                 break;
             }
 
+        case 32:
+            {   XXH128_canonical_t* xxh128c = &parsedLine->canonical.xxh128;
+                if (canonicalFromString(xxh128c->digest, sizeof(xxh128c->digest), line)
+                    != CanonicalFromString_ok) {
+                    return ParseLine_invalidFormat;
+                }
+                parsedLine->xxhBits = 128;
+                break;
+            }
+
         default:
                 return ParseLine_invalidFormat;
                 break;


### PR DESCRIPTION
- fix #259 : improve collision rate for distances 9-16
- `xxhsum -H2` can now generate 128-bit hashes
- `xxh128sum` triggers 128-bit hashes by default
- `xxhsum -c` compatible with 128-bit hashes
- bumped version number to v0.7.2