### PR TITLE
improve xxh128 for mid-size

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1435,7 +1435,7 @@ XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
         acc1 += XXH3_mix16B (p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,      seed);
         acc1 ^= XXH_readLE64(p+len-32) + XXH_readLE64(p+len-24);
         acc2 += XXH3_mix16B (p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL-seed);
-        acc1 ^= XXH_readLE64(p+len-16) + XXH_readLE64(p+len-8);
+        acc2 ^= XXH_readLE64(p+len-16) + XXH_readLE64(p+len-8);
 
         {   U64 const low64 = acc1 + acc2;
             U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
@@ -1444,6 +1444,7 @@ XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
         }
     }
 }
+
 
 XXH_FORCE_INLINE XXH128_hash_t
 XXH3_len_17to128_128b(const void* XXH_RESTRICT data, size_t len,

--- a/xxh3.h
+++ b/xxh3.h
@@ -1401,6 +1401,17 @@ XXH3_hashLong_128b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
     return XXH3_hashLong_128b_internal(data, len, secret, sizeof(secret));
 }
 
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH128_mix32B(XXH128_hash_t acc, const BYTE* p1, const BYTE* p2, const char* secret, XXH64_hash_t seed)
+{
+    acc.low64  += XXH3_mix16B (p1, secret+0, seed);
+    acc.low64  ^= XXH_readLE64(p2) + XXH_readLE64(p2+8);
+    acc.high64 += XXH3_mix16B (p2, secret+16, seed);
+    acc.high64 ^= XXH_readLE64(p1) + XXH_readLE64(p1+8);
+    return acc;
+}
+
 XXH_NO_INLINE XXH128_hash_t
 XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
                       const void* XXH_RESTRICT secret, size_t secretSize,
@@ -1412,49 +1423,31 @@ XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
 
-    {   U64 acc1 = len * PRIME64_1;
-        U64 acc2 = 0;
+    {   XXH128_hash_t acc;
         int const nbRounds = (int)len / 32;
         int i;
+        acc.low64 = len * PRIME64_1;
+        acc.high64 = 0;
         for (i=0; i<4; i++) {
-            acc1 += XXH3_mix16B (p+(32*i),    key+(32*i),         seed);
-            acc1 ^= XXH_readLE64(p+(32*i)+16) + XXH_readLE64(p+(32*i)+24);
-            acc2 += XXH3_mix16B (p+(32*i)+16, key+(32*i)+16, 0ULL-seed);
-            acc2 ^= XXH_readLE64(p+(32*i)) + XXH_readLE64(p+(32*i)+8);
+            acc = XXH128_mix32B(acc, p+(32*i), p+(32*i)+16, key+(32*i), seed);
         }
-        acc1 = XXH3_avalanche(acc1);
-        acc2 = XXH3_avalanche(acc2);
+        acc.low64 = XXH3_avalanche(acc.low64);
+        acc.high64 = XXH3_avalanche(acc.high64);
         XXH_ASSERT(nbRounds >= 4);
         for (i=4 ; i < nbRounds; i++) {
-            acc1 += XXH3_mix16B (p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,      seed);
-            acc1 ^= XXH_readLE64(p+(32*i)+16) + XXH_readLE64(p+(32*i)+24);
-            acc2 += XXH3_mix16B (p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, 0ULL-seed);
-            acc2 ^= XXH_readLE64(p+(32*i)) + XXH_readLE64(p+(32*i)+8);
+            acc = XXH128_mix32B(acc, p+(32*i), p+(32*i)+16, key+XXH3_MIDSIZE_STARTOFFSET+(32*(i-4)), seed);
         }
         /* last bytes */
-        acc1 += XXH3_mix16B (p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,      seed);
-        acc1 ^= XXH_readLE64(p+len-32) + XXH_readLE64(p+len-24);
-        acc2 += XXH3_mix16B (p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL-seed);
-        acc2 ^= XXH_readLE64(p+len-16) + XXH_readLE64(p+len-8);
+        acc = XXH128_mix32B(acc, p + len - 16, p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL - seed);
 
-        {   U64 const low64 = acc1 + acc2;
-            U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
+        {   U64 const low64 = acc.low64 + acc.high64;
+            U64 const high64 = (acc.low64 * PRIME64_1) + (acc.high64 * PRIME64_4) + ((len - seed) * PRIME64_2);
             XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
             return h128;
         }
     }
 }
 
-
-XXH_FORCE_INLINE XXH128_hash_t
-XXH128_mix32B(XXH128_hash_t acc, const BYTE* p1, const BYTE* p2, const char* secret, XXH64_hash_t seed)
-{
-    acc.low64  += XXH3_mix16B (p1, secret+0, seed);
-    acc.low64  ^= XXH_readLE64(p2) + XXH_readLE64(p2+8);
-    acc.high64 += XXH3_mix16B (p2, secret+16, seed);
-    acc.high64 ^= XXH_readLE64(p1) + XXH_readLE64(p1+8);
-    return acc;
-}
 
 XXH_FORCE_INLINE XXH128_hash_t
 XXH3_len_17to128_128b(const void* XXH_RESTRICT data, size_t len,
@@ -1473,14 +1466,7 @@ XXH3_len_17to128_128b(const void* XXH_RESTRICT data, size_t len,
         if (len > 32) {
             if (len > 64) {
                 if (len > 96) {
-#if 0
-                    acc.low64 += XXH3_mix16B(p+48, key+96, seed);
-                    acc.low64 ^= XXH_readLE64(p+len-64) + XXH_readLE64(p+len-56);
-                    acc.high64 += XXH3_mix16B(p+len-64, key+112, seed);
-                    acc.high64 ^= XXH_readLE64(p+48) + XXH_readLE64(p+56);
-#else
                     acc = XXH128_mix32B(acc, p+48, p+len-64, key+96, seed);
-#endif
                 }
                 acc = XXH128_mix32B(acc, p+32, p+len-48, key+64, seed);
             }

--- a/xxh3.h
+++ b/xxh3.h
@@ -1417,19 +1417,25 @@ XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
         int const nbRounds = (int)len / 32;
         int i;
         for (i=0; i<4; i++) {
-            acc1 += XXH3_mix16B(p+(32*i),    key+(32*i),         seed);
-            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*i)+16, 0ULL-seed);
+            acc1 += XXH3_mix16B (p+(32*i),    key+(32*i),         seed);
+            acc1 ^= XXH_readLE64(p+(32*i)+16) + XXH_readLE64(p+(32*i)+24);
+            acc2 += XXH3_mix16B (p+(32*i)+16, key+(32*i)+16, 0ULL-seed);
+            acc2 ^= XXH_readLE64(p+(32*i)) + XXH_readLE64(p+(32*i)+8);
         }
         acc1 = XXH3_avalanche(acc1);
         acc2 = XXH3_avalanche(acc2);
         XXH_ASSERT(nbRounds >= 4);
         for (i=4 ; i < nbRounds; i++) {
-            acc1 += XXH3_mix16B(p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,      seed);
-            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, 0ULL-seed);
+            acc1 += XXH3_mix16B (p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,      seed);
+            acc1 ^= XXH_readLE64(p+(32*i)+16) + XXH_readLE64(p+(32*i)+24);
+            acc2 += XXH3_mix16B (p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, 0ULL-seed);
+            acc2 ^= XXH_readLE64(p+(32*i)) + XXH_readLE64(p+(32*i)+8);
         }
         /* last bytes */
-        acc1 += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,      seed);
-        acc2 += XXH3_mix16B(p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL-seed);
+        acc1 += XXH3_mix16B (p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,      seed);
+        acc1 ^= XXH_readLE64(p+len-32) + XXH_readLE64(p+len-24);
+        acc2 += XXH3_mix16B (p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL-seed);
+        acc1 ^= XXH_readLE64(p+len-16) + XXH_readLE64(p+len-8);
 
         {   U64 const low64 = acc1 + acc2;
             U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
@@ -1456,16 +1462,24 @@ XXH3_len_17to128_128b(const void* XXH_RESTRICT data, size_t len,
             if (len > 64) {
                 if (len > 96) {
                     acc1 += XXH3_mix16B(p+48, key+96, seed);
+                    acc1 ^= XXH_readLE64(p+len-64) + XXH_readLE64(p+len-56);
                     acc2 += XXH3_mix16B(p+len-64, key+112, seed);
+                    acc2 ^= XXH_readLE64(p+48) + XXH_readLE64(p+56);
                 }
                 acc1 += XXH3_mix16B(p+32, key+64, seed);
+                acc1 ^= XXH_readLE64(p+len-48) + XXH_readLE64(p+len-40);
                 acc2 += XXH3_mix16B(p+len-48, key+80, seed);
+                acc2 ^= XXH_readLE64(p+32) + XXH_readLE64(p+40);
             }
             acc1 += XXH3_mix16B(p+16, key+32, seed);
+            acc1 ^= XXH_readLE64(p+len-32) + XXH_readLE64(p+len-24);
             acc2 += XXH3_mix16B(p+len-32, key+48, seed);
+            acc2 ^= XXH_readLE64(p+16) + XXH_readLE64(p+24);
         }
         acc1 += XXH3_mix16B(p+0, key+0, seed);
+        acc1 ^= XXH_readLE64(p+len-16) + XXH_readLE64(p+len-8);
         acc2 += XXH3_mix16B(p+len-16, key+16, seed);
+        acc2 ^= XXH_readLE64(p) + XXH_readLE64(p+8);
 
         {   U64 const low64 = acc1 + acc2;
             U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -844,16 +844,16 @@ static void BMK_sanityCheck(void)
     {   XXH128_hash_t const expected = { 0x784D8A364F48D048ULL, 0x9010B884DAA01151ULL };
         BMK_testXXH128(sanityBuffer, 103, prime, expected);         /* 97-128 */
     }
-    {   XXH128_hash_t const expected = { 0xFCA375168D678DACULL, 0xC2B390268C9F1BD7ULL };
+    {   XXH128_hash_t const expected = { 0x44D1C25FE64177F0ULL, 0xFAD36798F8CFF331ULL };
         BMK_testXXH128(sanityBuffer, 192, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xDBDAD8954A75F298ULL, 0x81B1E2FA1FC95D46ULL };
+    {   XXH128_hash_t const expected = { 0x6EA8E25C1908B2F1ULL, 0x0FE029DC274DEF34ULL };
         BMK_testXXH128(sanityBuffer, 192, prime, expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0x43638640DC41D801ULL, 0x5FD2859D914DA4DFULL };
+    {   XXH128_hash_t const expected = { 0xB944359DBAAE26FBULL, 0x5FA52A65D423092AULL };
         BMK_testXXH128(sanityBuffer, 222, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xEBD480FA63971D7AULL, 0xB480FB428B4E9260ULL };
+    {   XXH128_hash_t const expected = { 0x9FC2FB64EE8EE116ULL, 0xFE82C0903701C6F5ULL };
         BMK_testXXH128(sanityBuffer, 222, prime, expected);         /* 129-240 */
     }
     {   XXH128_hash_t const expected = { 0xB0C48E6D18E9D084ULL, 0xB16FC17E992FF45DULL };

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -844,16 +844,16 @@ static void BMK_sanityCheck(void)
     {   XXH128_hash_t const expected = { 0x784D8A364F48D048ULL, 0x9010B884DAA01151ULL };
         BMK_testXXH128(sanityBuffer, 103, prime, expected);         /* 97-128 */
     }
-    {   XXH128_hash_t const expected = { 0x44D1C25FE64177F0ULL, 0xFAD36798F8CFF331ULL };
+    {   XXH128_hash_t const expected = { 0x5FA77B9DFE8B5CAEULL, 0x2834B37CEC6A753FULL };
         BMK_testXXH128(sanityBuffer, 192, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0x6EA8E25C1908B2F1ULL, 0x0FE029DC274DEF34ULL };
+    {   XXH128_hash_t const expected = { 0x75441CE0359A979AULL, 0x399E2847427B3904ULL };
         BMK_testXXH128(sanityBuffer, 192, prime, expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xB944359DBAAE26FBULL, 0x5FA52A65D423092AULL };
+    {   XXH128_hash_t const expected = { 0xB02CC10BCFE61194ULL, 0xA27C9ABC8C06E4DDULL };
         BMK_testXXH128(sanityBuffer, 222, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0x9FC2FB64EE8EE116ULL, 0xFE82C0903701C6F5ULL };
+    {   XXH128_hash_t const expected = { 0x972CB9C6BD8123EDULL, 0x3488C87B4B6FCE5FULL };
         BMK_testXXH128(sanityBuffer, 222, prime, expected);         /* 129-240 */
     }
     {   XXH128_hash_t const expected = { 0xB0C48E6D18E9D084ULL, 0xB16FC17E992FF45DULL };

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -820,40 +820,40 @@ static void BMK_sanityCheck(void)
     {   XXH128_hash_t const expected = { 0xE3C75A78FE67D411ULL, 0xD4396DA60355312BULL };
         BMK_testXXH128(sanityBuffer,  12, prime, expected);         /* 9-16 */
     }
-    {   XXH128_hash_t const expected = { 0x46796F3F78B20F6BULL, 0x58FF55C3926C13FAULL };
+    {   XXH128_hash_t const expected = { 0x3FD725B2AABCF17DULL, 0x140592647F61C3E1ULL };
         BMK_testXXH128(sanityBuffer,  24, 0,     expected);         /* 17-32 */
     }
-    {   XXH128_hash_t const expected = { 0x30D5C4E9EB415C55ULL, 0x8868344B3A4645D0ULL };
+    {   XXH128_hash_t const expected = { 0x9A09D0F4A694DC09ULL, 0x1291B0C7375510E3ULL };
         BMK_testXXH128(sanityBuffer,  24, prime, expected);         /* 17-32 */
     }
-    {   XXH128_hash_t const expected = { 0xD8D4D3590D136E11ULL, 0x5527A42843020A62ULL };
+    {   XXH128_hash_t const expected = { 0x891306BA9DD1D15BULL, 0x32A41AEEC6DE94DEULL };
         BMK_testXXH128(sanityBuffer,  48, 0,     expected);         /* 33-64 */
     }
-    {   XXH128_hash_t const expected = { 0x1D8834E1A5407A1CULL, 0x44375B9FB060F541ULL };
+    {   XXH128_hash_t const expected = { 0xA199D324899B838EULL, 0x9BB6C003E18B3F75ULL };
         BMK_testXXH128(sanityBuffer,  48, prime, expected);         /* 33-64 */
     }
-    {   XXH128_hash_t const expected = { 0x4B9B448ED8DFD3DDULL, 0xE805A6D1A43D70E5ULL };
+    {   XXH128_hash_t const expected = { 0x33AA30F9947E2743ULL, 0x46307D818EC98842ULL };
         BMK_testXXH128(sanityBuffer,  81, 0,     expected);         /* 65-96 */
     }
-    {   XXH128_hash_t const expected = { 0xD2D6B075945617BAULL, 0xE58BE5736F6E7550ULL };
+    {   XXH128_hash_t const expected = { 0xAAF9F05DA0993E3CULL, 0x01752B9AFA24C856ULL };
         BMK_testXXH128(sanityBuffer,  81, prime, expected);         /* 65-96 */
     }
-    {   XXH128_hash_t const expected = { 0xC5A9F97B29EFA44EULL, 0x254DB7BE881E125CULL };
+    {   XXH128_hash_t const expected = { 0x01EE4637BFB66A1BULL, 0xE5CF6E0E85E92048ULL };
         BMK_testXXH128(sanityBuffer, 103, 0,     expected);         /* 97-128 */
     }
-    {   XXH128_hash_t const expected = { 0xFA2086367CDB177FULL, 0x0AEDEA68C988B0C0ULL };
+    {   XXH128_hash_t const expected = { 0x784D8A364F48D048ULL, 0x9010B884DAA01151ULL };
         BMK_testXXH128(sanityBuffer, 103, prime, expected);         /* 97-128 */
     }
-    {   XXH128_hash_t const expected = { 0xC3142FDDD9102A3FULL, 0x06F1747E77185F97ULL };
+    {   XXH128_hash_t const expected = { 0xFCA375168D678DACULL, 0xC2B390268C9F1BD7ULL };
         BMK_testXXH128(sanityBuffer, 192, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xA89F07B35987540FULL, 0xCF1B35FB2C557F54ULL };
+    {   XXH128_hash_t const expected = { 0xDBDAD8954A75F298ULL, 0x81B1E2FA1FC95D46ULL };
         BMK_testXXH128(sanityBuffer, 192, prime, expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0xA61AC4EB3295F86BULL, 0x33FA7B7598C28A07ULL };
+    {   XXH128_hash_t const expected = { 0x43638640DC41D801ULL, 0x5FD2859D914DA4DFULL };
         BMK_testXXH128(sanityBuffer, 222, 0,     expected);         /* 129-240 */
     }
-    {   XXH128_hash_t const expected = { 0x54135EB88AD8B75EULL, 0xBC45CE6AE50BCF53ULL };
+    {   XXH128_hash_t const expected = { 0xEBD480FA63971D7AULL, 0xB480FB428B4E9260ULL };
         BMK_testXXH128(sanityBuffer, 222, prime, expected);         /* 129-240 */
     }
     {   XXH128_hash_t const expected = { 0xB0C48E6D18E9D084ULL, 0xB16FC17E992FF45DULL };


### PR DESCRIPTION
ensure that each input stripe immediately impacts 128-bit of state
(instead of later at junction stage).