### PR TITLE
Clean up some ugly code, bench improvements, size optimization, bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ they modify libxxhash behavior. They are all disabled by default.
                      with performance improvements observed in the +200% range .
                      See [this article](https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html) for details.
                      Note: there is no need for an `xxhash.o` object file in this case.
-- `XXH_REROLL` : reduce size of generated code. Impact on performance vary, depending on platform and algorithm.
+- `XXH_OPTIMIZE_SIZE` : From a scale of 0-2, how much xxHash will prefer size over speed. This does nothing on its own, it just controls
+                        the defaults for other modifiers (see xxhash.c for the list). 0 means maximum speed, 1 means do some minor tweaksthat usually don't significantly
+                        affect performance, and it is the default when compiling with -Os or -Oz onnGCC and Clang. 2 means to prioritize size
+                        at all costs - even if it means terrible performance.
+- `XXH_REROLL` : Reroll some loops, mainly in XXH32 and XXH64. This can reduce size a lot and can sometimes be faster.
+- `XXH_DISABLE_INLINE_HINTS` : By default, xxHash uses attributes to manually enable or disable inlining. Defining this to 1 will only use `static`, allowing the compiler to decide (and reduce code size).
+- `XXH_STREAM_SINGLE_SHOT` : Use the streaming method for single shot hashes. Reduces size, but also tends to slow down short keys.
 - `XXH_ACCEPT_NULL_INPUT_POINTER` : if set to `1`, when input is a `NULL` pointer,
                                     xxhash result is the same as a zero-length input
                                     (instead of a dereference segfault).
@@ -96,6 +102,9 @@ they modify libxxhash behavior. They are all disabled by default.
                               Incompatible with dynamic linking, due to risks of ABI changes.
 - `XXH_NO_LONG_LONG` : removes support for XXH64,
                        for targets without 64-bit support.
+- `XXH_NO_STREAMING` : Removes support for all streaming hashes, using only the single shot variants.
+                       If you don't plan on using these, code size is roughly halved.
+                       Naturally, this cancels out `XXH_STREAM_SINGLE_SHOT`, and is not ABI-compatible.
 - `XXH_IMPORT` : MSVC specific : should only be defined for dynamic linking, it prevents linkage errors.
 
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -1659,10 +1659,10 @@ XXH_PUBLIC_API int XXH128_cmp(const void* h128_1, const void* h128_2)
 {
     XXH128_hash_t const h1 = *(const XXH128_hash_t*)h128_1;
     XXH128_hash_t const h2 = *(const XXH128_hash_t*)h128_2;
-    int const hcmp = (h1.high64 > h2.high64) - (h2.high64 > h1.high64);
+    int const hcmp = (h1.high64 > h2.high64) - (h1.high64 < h2.high64);
     /* note : bets that, in most cases, hash values are different */
     if (hcmp) return hcmp;
-    return (h1.low64 > h2.low64) - (h2.low64 > h1.low64);
+    return (h1.low64 > h2.low64) - (h1.low64 < h2.low64);
 }
 
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -409,14 +409,14 @@ static XXH64_hash_t XXH3_avalanche(U64 h64)
  * ========================================== */
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_len_1to3_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+XXH3_len_1to3_64b(const BYTE* data, size_t len, const BYTE* keyPtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(data != NULL);
     XXH_ASSERT(1 <= len && len <= 3);
     XXH_ASSERT(keyPtr != NULL);
-    {   BYTE const c1 = ((const BYTE*)data)[0];
-        BYTE const c2 = ((const BYTE*)data)[len >> 1];
-        BYTE const c3 = ((const BYTE*)data)[len - 1];
+    {   BYTE const c1 = data[0];
+        BYTE const c2 = data[len >> 1];
+        BYTE const c3 = data[len - 1];
         U32  const combined = ((U32)c1) + (((U32)c2) << 8) + (((U32)c3) << 16) + (((U32)len) << 24);
         U64  const keyed = (U64)combined ^ (XXH_readLE32(keyPtr) + seed);
         U64  const mixed = keyed * PRIME64_1;
@@ -425,13 +425,13 @@ XXH3_len_1to3_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t
 }
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_len_4to8_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+XXH3_len_4to8_64b(const BYTE* data, size_t len, const BYTE* keyPtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(data != NULL);
     XXH_ASSERT(keyPtr != NULL);
     XXH_ASSERT(4 <= len && len <= 8);
     {   U32 const in1 = XXH_readLE32(data);
-        U32 const in2 = XXH_readLE32((const BYTE*)data + len - 4);
+        U32 const in2 = XXH_readLE32(data + len - 4);
         U64 const in64 = in1 + ((U64)in2 << 32);
         U64 const keyed = in64 ^ (XXH_readLE64(keyPtr) + seed);
         U64 const mix64 = len + ((keyed ^ (keyed >> 51)) * PRIME32_1);
@@ -440,21 +440,21 @@ XXH3_len_4to8_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t
 }
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_len_9to16_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+XXH3_len_9to16_64b(const BYTE* data, size_t len, const BYTE* keyPtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(data != NULL);
     XXH_ASSERT(keyPtr != NULL);
     XXH_ASSERT(9 <= len && len <= 16);
-    {   const U64* const key64 = (const U64*) keyPtr;
-        U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(key64) + seed);
-        U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8) ^ (XXH_readLE64(key64+1) - seed);
+    {
+        U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(keyPtr) + seed);
+        U64 const ll2 = XXH_readLE64(data + len - 8) ^ (XXH_readLE64(keyPtr+8) - seed);
         U64 const acc = len + (ll1 + ll2) + XXH3_mul128_fold64(ll1, ll2);
         return XXH3_avalanche(acc);
     }
 }
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_len_0to16_64b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+XXH3_len_0to16_64b(const BYTE* data, size_t len, const BYTE* keyPtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(len <= 16);
     {   if (len > 8) return XXH3_len_9to16_64b(data, len, keyPtr, seed);
@@ -475,8 +475,8 @@ typedef enum { XXH3_acc_64bits, XXH3_acc_128bits } XXH3_accWidth_e;
 
 XXH_FORCE_INLINE void
 XXH3_accumulate_512(      void* XXH_RESTRICT acc,
-                    const void* XXH_RESTRICT data,
-                    const void* XXH_RESTRICT key,
+                    const BYTE* XXH_RESTRICT data,
+                    const BYTE* XXH_RESTRICT key,
                     XXH3_accWidth_e accWidth)
 {
 #if (XXH_VECTOR == XXH_AVX2)
@@ -530,9 +530,9 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
     XXH_ASSERT((((size_t)acc) & 15) == 0);
     {
         XXH_ALIGN(16) uint64x2_t* const xacc = (uint64x2_t *) acc;
-        /* We don't use a uint32x4_t pointer because it causes bus errors on ARMv7. */
-        uint32_t const* const xdata = (const uint32_t *) data;
-        uint32_t const* const xkey  = (const uint32_t *) key;
+        /* May be unaligned! */
+        uint8_t const* const xdata = (const uint8_t *) data;
+        uint8_t const* const xkey  = (const uint8_t *) key;
 
         size_t i;
         for (i=0; i < STRIPE_LEN / sizeof(uint64x2_t); i++) {
@@ -550,25 +550,25 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
              *    vzip.32 d0, d1               // Interleave high and low bits and overwrite. */
 
             /* data_vec = xdata[i]; */
-            uint32x4_t const data_vec    = vld1q_u32(xdata + (i * 4));
+            uint8x16_t const data_vec    = vld1q_u8(xdata + (i * 16));
             /* key_vec  = xkey[i];  */
-            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));
+            uint8x16_t const key_vec     = vld1q_u8(xkey  + (i * 16));
             /* data_key = data_vec ^ key_vec; */
             uint32x4_t       data_key;
 
             if (accWidth == XXH3_acc_64bits) {
                 /* Add first to prevent register swaps */
                 /* xacc[i] += data_vec; */
-                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u32(data_vec));
+                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u8(data_vec));
             } else {  /* XXH3_acc_128bits */
                 /* xacc[i] += swap(data_vec); */
                 /* can probably be optimized better */
-                uint64x2_t const data64 = vreinterpretq_u64_u32(data_vec);
+                uint64x2_t const data64 = vreinterpretq_u64_u8(data_vec);
                 uint64x2_t const swapped= vextq_u64(data64, data64, 1);
                 xacc[i] = vaddq_u64 (xacc[i], swapped);
             }
 
-            data_key = veorq_u32(data_vec, key_vec);
+            data_key = vreinterpretq_u32_u8(veorq_u8(data_vec, key_vec));
 
             /* Here's the magic. We use the quirkiness of vzip to shuffle data_key in place.
              * shuffle: data_key[0, 1, 2, 3] = data_key[0, 2, 1, 3] */
@@ -580,21 +580,21 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
             /* On aarch64, vshrn/vmovn seems to be equivalent to, if not faster than, the vzip method. */
 
             /* data_vec = xdata[i]; */
-            uint32x4_t const data_vec    = vld1q_u32(xdata + (i * 4));
+            uint8x16_t const data_vec    = vld1q_u8(xdata + (i * 16));
             /* key_vec  = xkey[i];  */
-            uint32x4_t const key_vec     = vld1q_u32(xkey  + (i * 4));
+            uint8x16_t const key_vec     = vld1q_u8(xkey  + (i * 16));
             /* data_key = data_vec ^ key_vec; */
-            uint32x4_t const data_key    = veorq_u32(data_vec, key_vec);
+            uint8x16_t const data_key    = veorq_u8(data_vec, key_vec);
             /* data_key_lo = (uint32x2_t) (data_key & 0xFFFFFFFF); */
-            uint32x2_t const data_key_lo = vmovn_u64  (vreinterpretq_u64_u32(data_key));
+            uint32x2_t const data_key_lo = vmovn_u64  (vreinterpretq_u64_u8(data_key));
             /* data_key_hi = (uint32x2_t) (data_key >> 32); */
-            uint32x2_t const data_key_hi = vshrn_n_u64 (vreinterpretq_u64_u32(data_key), 32);
+            uint32x2_t const data_key_hi = vshrn_n_u64 (vreinterpretq_u64_u8(data_key), 32);
             if (accWidth == XXH3_acc_64bits) {
                 /* xacc[i] += data_vec; */
-                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u32(data_vec));
+                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u8(data_vec));
             } else {  /* XXH3_acc_128bits */
                 /* xacc[i] += swap(data_vec); */
-                uint64x2_t const data64 = vreinterpretq_u64_u32(data_vec);
+                uint64x2_t const data64 = vreinterpretq_u64_u8(data_vec);
                 uint64x2_t const swapped= vextq_u64(data64, data64, 1);
                 xacc[i] = vaddq_u64 (xacc[i], swapped);
             }
@@ -647,32 +647,25 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
 #else   /* scalar variant of Accumulator - universal */
 
     XXH_ALIGN(XXH_ACC_ALIGN) U64* const xacc = (U64*) acc;    /* presumed aligned on 32-bytes boundaries, little hint for the auto-vectorizer */
-    const char* const xdata = (const char*) data;  /* no alignment restriction */
-    const char* const xkey  = (const char*) key;   /* no alignment restriction */
     size_t i;
     XXH_ASSERT(((size_t)acc & (XXH_ACC_ALIGN-1)) == 0);
-    for (i=0; i < ACC_NB; i+=2) {
-        U64 const in1 = XXH_readLE64(xdata + 8*i);
-        U64 const in2 = XXH_readLE64(xdata + 8*(i+1));
-        U64 const key1  = XXH_readLE64(xkey + 8*i);
-        U64 const key2  = XXH_readLE64(xkey + 8*(i+1));
-        U64 const data_key1 = key1 ^ in1;
-        U64 const data_key2 = key2 ^ in2;
-        xacc[i]   += XXH_mult32to64(data_key1 & 0xFFFFFFFF, data_key1 >> 32);
-        xacc[i+1] += XXH_mult32to64(data_key2 & 0xFFFFFFFF, data_key2 >> 32);
-        if (accWidth == XXH3_acc_128bits) {
-            xacc[i]   += in2;
-            xacc[i+1] += in1;
-        } else {  /* XXH3_acc_64bits */
-            xacc[i]   += in1;
-            xacc[i+1] += in2;
+    for (i=0; i < ACC_NB; i++) {
+        U64 data_val = XXH_readLE64(data + 8*i);
+        U64 key_val = XXH_readLE64(key + 8*i);
+        if (accWidth == XXH3_acc_64bits) {
+            xacc[i] += data_val;
+        } else {
+            /* swap even/odd lanes */
+            xacc[i ^ 1] += data_val;
         }
+        key_val ^= data_val;
+        xacc[i] += XXH_mult32to64(key_val & 0xFFFFFFFF, key_val >> 32);
     }
 #endif
 }
 
 XXH_FORCE_INLINE void
-XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
+XXH3_scrambleAcc(void* XXH_RESTRICT acc, const BYTE* XXH_RESTRICT key)
 {
 #if (XXH_VECTOR == XXH_AVX2)
 
@@ -730,7 +723,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
     XXH_ASSERT((((size_t)acc) & 15) == 0);
 
     {   uint64x2_t* const xacc =     (uint64x2_t*) acc;
-        uint32_t const* const xkey = (uint32_t const*) key;
+        uint8_t const* const xkey = (uint8_t const*) key;
         uint32x2_t const prime     = vdup_n_u32 (PRIME32_1);
 
         size_t i;
@@ -741,7 +734,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
             uint64x2_t const   data_vec = veorq_u64   (acc_vec, shifted);
 
             /* key_vec  = xkey[i]; */
-            uint32x4_t const   key_vec  = vld1q_u32   (xkey + (i * 4));
+            uint32x4_t const   key_vec  = vreinterpretq_u32_u8(vld1q_u8(xkey + (i * 16)));
             /* data_key = data_vec ^ key_vec; */
             uint32x4_t const   data_key = veorq_u32   (vreinterpretq_u32_u64(data_vec), key_vec);
             /* shuffled = { data_key[0, 2], data_key[1, 3] }; */
@@ -778,7 +771,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
 #if XXH_VSX_BE
         /* swap bytes words */
         U64x2 const key_raw  = vec_vsx_ld(0, xkey + i);
-	U64x2 const data_key = (U64x2)XXH_vec_permxor((U8x16)data_vec, (U8x16)key_raw, vXorSwap);
+        U64x2 const data_key = (U64x2)XXH_vec_permxor((U8x16)data_vec, (U8x16)key_raw, vXorSwap);
 #else
         U64x2 const key_vec  = vec_vsx_ld(0, xkey + i);
         U64x2 const data_key = data_vec ^ key_vec;
@@ -796,12 +789,11 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
 #else   /* scalar variant of Scrambler - universal */
 
     XXH_ALIGN(XXH_ACC_ALIGN) U64* const xacc = (U64*) acc;   /* presumed aligned on 32-bytes boundaries, little hint for the auto-vectorizer */
-    const char* const xkey = (const char*) key;   /* no alignment restriction */
     int i;
     XXH_ASSERT((((size_t)acc) & (XXH_ACC_ALIGN-1)) == 0);
 
     for (i=0; i < (int)ACC_NB; i++) {
-        U64 const key64 = XXH_readLE64(xkey + 8*i);
+        U64 const key64 = XXH_readLE64(key + 8*i);
         U64 acc64 = xacc[i];
         acc64 ^= acc64 >> 47;
         acc64 ^= key64;
@@ -815,16 +807,16 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
 /* assumption : nbStripes will not overflow secret size */
 XXH_FORCE_INLINE void
 XXH3_accumulate(       U64* XXH_RESTRICT acc,
-                const void* XXH_RESTRICT data,
-                const void* XXH_RESTRICT secret,
+                const BYTE* XXH_RESTRICT data,
+                const BYTE* XXH_RESTRICT secret,
                       size_t nbStripes,
                       XXH3_accWidth_e accWidth)
 {
     size_t n;
     for (n = 0; n < nbStripes; n++ ) {
         XXH3_accumulate_512(acc,
-               (const char*)data   + n*STRIPE_LEN,
-               (const char*)secret + n*XXH_SECRET_CONSUME_RATE,
+                            data   + n*STRIPE_LEN,
+                            secret + n*XXH_SECRET_CONSUME_RATE,
                             accWidth);
     }
 }
@@ -840,8 +832,8 @@ static void
 XXH_FORCE_INLINE void
 #endif
 XXH3_hashLong_internal_loop( U64* XXH_RESTRICT acc,
-                      const void* XXH_RESTRICT data, size_t len,
-                      const void* XXH_RESTRICT secret, size_t secretSize,
+                      const BYTE* XXH_RESTRICT data, size_t len,
+                      const BYTE* XXH_RESTRICT secret, size_t secretSize,
                             XXH3_accWidth_e accWidth)
 {
     size_t const nb_rounds = (secretSize - STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
@@ -853,42 +845,41 @@ XXH3_hashLong_internal_loop( U64* XXH_RESTRICT acc,
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
 
     for (n = 0; n < nb_blocks; n++) {
-        XXH3_accumulate(acc, (const char*)data + n*block_len, secret, nb_rounds, accWidth);
-        XXH3_scrambleAcc(acc, (const char*)secret + secretSize - STRIPE_LEN);
+        XXH3_accumulate(acc, data + n*block_len, secret, nb_rounds, accWidth);
+        XXH3_scrambleAcc(acc, secret + secretSize - STRIPE_LEN);
     }
 
     /* last partial block */
     XXH_ASSERT(len > STRIPE_LEN);
     {   size_t const nbStripes = (len - (block_len * nb_blocks)) / STRIPE_LEN;
         XXH_ASSERT(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
-        XXH3_accumulate(acc, (const char*)data + nb_blocks*block_len, secret, nbStripes, accWidth);
+        XXH3_accumulate(acc, data + nb_blocks*block_len, secret, nbStripes, accWidth);
 
         /* last stripe */
         if (len & (STRIPE_LEN - 1)) {
-            const void* const p = (const char*)data + len - STRIPE_LEN;
+            const BYTE* const p = data + len - STRIPE_LEN;
 #define XXH_SECRET_LASTACC_START 7  /* do not align on 8, so that secret is different from scrambler */
-            XXH3_accumulate_512(acc, p, (const char*)secret + secretSize - STRIPE_LEN - XXH_SECRET_LASTACC_START, accWidth);
+            XXH3_accumulate_512(acc, p, secret + secretSize - STRIPE_LEN - XXH_SECRET_LASTACC_START, accWidth);
     }   }
 }
 
 XXH_FORCE_INLINE U64
-XXH3_mix2Accs(const U64* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+XXH3_mix2Accs(const U64* XXH_RESTRICT acc, const BYTE* XXH_RESTRICT secret)
 {
-    const U64* const key64 = (const U64*)secret;
     return XXH3_mul128_fold64(
-               acc[0] ^ XXH_readLE64(key64),
-               acc[1] ^ XXH_readLE64(key64+1) );
+               acc[0] ^ XXH_readLE64(secret),
+               acc[1] ^ XXH_readLE64(secret + 8) );
 }
 
 static XXH64_hash_t
-XXH3_mergeAccs(const U64* XXH_RESTRICT acc, const void* XXH_RESTRICT secret, U64 start)
+XXH3_mergeAccs(const U64* XXH_RESTRICT acc, const BYTE* XXH_RESTRICT secret, U64 start)
 {
     U64 result64 = start;
 
-    result64 += XXH3_mix2Accs(acc+0, (const char*)secret +  0);
-    result64 += XXH3_mix2Accs(acc+2, (const char*)secret + 16);
-    result64 += XXH3_mix2Accs(acc+4, (const char*)secret + 32);
-    result64 += XXH3_mix2Accs(acc+6, (const char*)secret + 48);
+    result64 += XXH3_mix2Accs(acc+0, secret +  0);
+    result64 += XXH3_mix2Accs(acc+2, secret + 16);
+    result64 += XXH3_mix2Accs(acc+4, secret + 32);
+    result64 += XXH3_mix2Accs(acc+6, secret + 48);
 
     return XXH3_avalanche(result64);
 }
@@ -897,8 +888,8 @@ XXH3_mergeAccs(const U64* XXH_RESTRICT acc, const void* XXH_RESTRICT secret, U64
                         PRIME64_4, PRIME32_2, PRIME64_5, PRIME32_1 };
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_hashLong_internal(const void* XXH_RESTRICT data, size_t len,
-                       const void* XXH_RESTRICT secret, size_t secretSize)
+XXH3_hashLong_internal(const BYTE* XXH_RESTRICT data, size_t len,
+                       const BYTE* XXH_RESTRICT secret, size_t secretSize)
 {
     XXH_ALIGN(XXH_ACC_ALIGN) U64 acc[ACC_NB] = XXH3_INIT_ACC;
 
@@ -908,19 +899,19 @@ XXH3_hashLong_internal(const void* XXH_RESTRICT data, size_t len,
     XXH_STATIC_ASSERT(sizeof(acc) == 64);
 #define XXH_SECRET_MERGEACCS_START 11  /* do not align on 8, so that secret is different from accumulator */
     XXH_ASSERT(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
-    return XXH3_mergeAccs(acc, (const char*)secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
+    return XXH3_mergeAccs(acc, secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
 }
 
 
 XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_64b_defaultSecret(const void* XXH_RESTRICT data, size_t len)
+XXH3_hashLong_64b_defaultSecret(const BYTE* XXH_RESTRICT data, size_t len)
 {
     return XXH3_hashLong_internal(data, len, kSecret, sizeof(kSecret));
 }
 
 XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_64b_withSecret(const void* XXH_RESTRICT data, size_t len,
-                             const void* XXH_RESTRICT secret, size_t secretSize)
+XXH3_hashLong_64b_withSecret(const BYTE* XXH_RESTRICT data, size_t len,
+                             const BYTE* XXH_RESTRICT secret, size_t secretSize)
 {
     return XXH3_hashLong_internal(data, len, secret, secretSize);
 }
@@ -935,18 +926,16 @@ XXH_FORCE_INLINE void XXH_writeLE64(void* dst, U64 v64)
 /* XXH3_initKeySeed() :
  * destination `customSecret` is presumed allocated and same size as `kSecret`.
  */
-XXH_FORCE_INLINE void XXH3_initKeySeed(void* customSecret, U64 seed64)
+XXH_FORCE_INLINE void XXH3_initKeySeed(BYTE* customSecret, U64 seed64)
 {
-          char* const dst = (char*)customSecret;
-    const char* const src = (const char*)kSecret;
     int const nbRounds = XXH_SECRET_DEFAULT_SIZE / 16;
     int i;
 
     XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
 
     for (i=0; i < nbRounds; i++) {
-        XXH_writeLE64(dst + 16*i,     XXH_readLE64(src + 16*i)     + seed64);
-        XXH_writeLE64(dst + 16*i + 8, XXH_readLE64(src + 16*i + 8) - seed64);
+        XXH_writeLE64(customSecret + 16*i,     XXH_readLE64(kSecret + 16*i)     + seed64);
+        XXH_writeLE64(customSecret + 16*i + 8, XXH_readLE64(kSecret + 16*i + 8) - seed64);
     }
 }
 
@@ -959,68 +948,51 @@ XXH_FORCE_INLINE void XXH3_initKeySeed(void* customSecret, U64 seed64)
  * Try to avoid it whenever possible (typically when seed==0).
  */
 XXH_NO_INLINE XXH64_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_64b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+XXH3_hashLong_64b_withSeed(const BYTE* data, size_t len, XXH64_hash_t seed)
 {
-    XXH_ALIGN(8) char secret[XXH_SECRET_DEFAULT_SIZE];
+    XXH_ALIGN(8) BYTE secret[XXH_SECRET_DEFAULT_SIZE];
     if (seed==0) return XXH3_hashLong_64b_defaultSecret(data, len);
     XXH3_initKeySeed(secret, seed);
     return XXH3_hashLong_internal(data, len, secret, sizeof(secret));
 }
 
 
-XXH_FORCE_INLINE U64 XXH3_mix16B(const void* XXH_RESTRICT data,
-                                 const void* XXH_RESTRICT key, U64 seed64)
+XXH_FORCE_INLINE U64 XXH3_mix16B(const BYTE* XXH_RESTRICT data,
+                                 const BYTE* XXH_RESTRICT key, U64 seed64)
 {
-    const U64* const key64 = (const U64*)key;
     U64 const ll1 = XXH_readLE64(data);
-    U64 const ll2 = XXH_readLE64((const BYTE*)data+8);
+    U64 const ll2 = XXH_readLE64(data+8);
     return XXH3_mul128_fold64(
-               ll1 ^ (XXH_readLE64(key64)   + seed64),
-               ll2 ^ (XXH_readLE64(key64+1) - seed64) );
+               ll1 ^ (XXH_readLE64(key)   + seed64),
+               ll2 ^ (XXH_readLE64(key+8) - seed64) );
 }
 
 
 XXH_FORCE_INLINE XXH64_hash_t
-XXH3_len_17to128_64b(const void* XXH_RESTRICT data, size_t len,
-                     const void* XXH_RESTRICT secret, size_t secretSize,
+XXH3_len_17to128_64b(const BYTE* XXH_RESTRICT input, size_t len,
+                     const BYTE* XXH_RESTRICT secret, size_t secretSize,
                      XXH64_hash_t seed)
 {
-    const BYTE* const p = (const BYTE*)data;
-    const char* const key = (const char*)secret;
+    int i = (int)((len - 1) / 32);
+    U64 acc = len * PRIME64_1;
 
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     XXH_ASSERT(16 < len && len <= 128);
 
-    {   U64 acc = len * PRIME64_1;
-        if (len > 32) {
-            if (len > 64) {
-                if (len > 96) {
-                    acc += XXH3_mix16B(p+48, key+96, seed);
-                    acc += XXH3_mix16B(p+len-64, key+112, seed);
-                }
-                acc += XXH3_mix16B(p+32, key+64, seed);
-                acc += XXH3_mix16B(p+len-48, key+80, seed);
-            }
-            acc += XXH3_mix16B(p+16, key+32, seed);
-            acc += XXH3_mix16B(p+len-32, key+48, seed);
-        }
-        acc += XXH3_mix16B(p+0, key+0, seed);
-        acc += XXH3_mix16B(p+len-16, key+16, seed);
-
-        return XXH3_avalanche(acc);
+    for (; i >= 0; --i) {
+        acc += XXH3_mix16B(input + (16*i),               secret + (16 * (2 * i)),      seed);
+        acc += XXH3_mix16B(input + len - (16 * (i + 1)), secret + (16 * ((2 * i) + 1)), seed);
     }
+    return XXH3_avalanche(acc);
 }
 
 #define XXH3_MIDSIZE_MAX 240
 
 XXH_NO_INLINE XXH64_hash_t
-XXH3_len_129to240_64b(const void* XXH_RESTRICT data, size_t len,
-                      const void* XXH_RESTRICT secret, size_t secretSize,
+XXH3_len_129to240_64b(const BYTE* XXH_RESTRICT input, size_t len,
+                      const BYTE* XXH_RESTRICT secret, size_t secretSize,
                       XXH64_hash_t seed)
 {
-    const BYTE* const p = (const BYTE*)data;
-    const char* const key = (const char*)secret;
-
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
 
@@ -1031,15 +1003,15 @@ XXH3_len_129to240_64b(const void* XXH_RESTRICT data, size_t len,
         int const nbRounds = (int)len / 16;
         int i;
         for (i=0; i<8; i++) {
-            acc += XXH3_mix16B(p+(16*i), key+(16*i), seed);
+            acc += XXH3_mix16B(input+(16*i), secret+(16*i), seed);
         }
         acc = XXH3_avalanche(acc);
         XXH_ASSERT(nbRounds >= 8);
         for (i=8 ; i < nbRounds; i++) {
-            acc += XXH3_mix16B(p+(16*i), key+(16*(i-8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
+            acc += XXH3_mix16B(input+(16*i), secret+(16*(i-8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
         }
         /* last bytes */
-        acc += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
+        acc += XXH3_mix16B(input + len - 16, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
         return XXH3_avalanche(acc);
     }
 }
@@ -1048,10 +1020,10 @@ XXH3_len_129to240_64b(const void* XXH_RESTRICT data, size_t len,
 
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len)
 {
-    if (len <= 16) return XXH3_len_0to16_64b(data, len, kSecret, 0);
-    if (len <= 128) return XXH3_len_17to128_64b(data, len, kSecret, sizeof(kSecret), 0);
-    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b(data, len, kSecret, sizeof(kSecret), 0);
-    return XXH3_hashLong_64b_defaultSecret(data, len);
+    if (len <= 16) return XXH3_len_0to16_64b((const BYTE*)data, len, kSecret, 0);
+    if (len <= 128) return XXH3_len_17to128_64b((const BYTE*)data, len, kSecret, sizeof(kSecret), 0);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b((const BYTE*)data, len, kSecret, sizeof(kSecret), 0);
+    return XXH3_hashLong_64b_defaultSecret((const BYTE*)data, len);
 }
 
 XXH_PUBLIC_API XXH64_hash_t
@@ -1062,19 +1034,19 @@ XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t 
      * it should be done here.
      * For now, it's a contract pre-condition.
      * Adding a check and a branch here would cost performance at every hash */
-     if (len <= 16) return XXH3_len_0to16_64b(data, len, secret, 0);
-     if (len <= 128) return XXH3_len_17to128_64b(data, len, secret, secretSize, 0);
-     if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b(data, len, secret, secretSize, 0);
-     return XXH3_hashLong_64b_withSecret(data, len, secret, secretSize);
+     if (len <= 16) return XXH3_len_0to16_64b((const BYTE*)data, len, (const BYTE*)secret, 0);
+     if (len <= 128) return XXH3_len_17to128_64b((const BYTE*)data, len, (const BYTE*)secret, secretSize, 0);
+     if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b((const BYTE*)data, len, (const BYTE*)secret, secretSize, 0);
+     return XXH3_hashLong_64b_withSecret((const BYTE*)data, len, (const BYTE*)secret, secretSize);
 }
 
 XXH_PUBLIC_API XXH64_hash_t
 XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
 {
-    if (len <= 16) return XXH3_len_0to16_64b(data, len, kSecret, seed);
-    if (len <= 128) return XXH3_len_17to128_64b(data, len, kSecret, sizeof(kSecret), seed);
-    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b(data, len, kSecret, sizeof(kSecret), seed);
-    return XXH3_hashLong_64b_withSeed(data, len, seed);
+    if (len <= 16) return XXH3_len_0to16_64b((const BYTE*)data, len, kSecret, seed);
+    if (len <= 128) return XXH3_len_17to128_64b((const BYTE*)data, len, kSecret, sizeof(kSecret), seed);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b((const BYTE*)data, len, kSecret, sizeof(kSecret), seed);
+    return XXH3_hashLong_64b_withSeed((const BYTE*)data, len, seed);
 }
 
 /* ===   XXH3 streaming   === */
@@ -1099,7 +1071,7 @@ XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state)
 static void
 XXH3_64bits_reset_internal(XXH3_state_t* statePtr,
                            XXH64_hash_t seed,
-                           const void* secret, size_t secretSize)
+                           const BYTE* secret, size_t secretSize)
 {
     XXH_ASSERT(statePtr != NULL);
     memset(statePtr, 0, sizeof(*statePtr));
@@ -1131,7 +1103,7 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
 {
     if (statePtr == NULL) return XXH_ERROR;
-    XXH3_64bits_reset_internal(statePtr, 0, secret, secretSize);
+    XXH3_64bits_reset_internal(statePtr, 0, (const BYTE*)secret, secretSize);
     if (secret == NULL) return XXH_ERROR;
     if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
     return XXH_OK;
@@ -1150,26 +1122,26 @@ XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
 XXH_FORCE_INLINE void
 XXH3_consumeStripes( U64* acc,
                             XXH32_hash_t* nbStripesSoFarPtr, XXH32_hash_t nbStripesPerBlock,
-                            const void* data, size_t totalStripes,
-                            const void* secret, size_t secretLimit,
+                            const BYTE* data, size_t totalStripes,
+                            const BYTE* secret, size_t secretLimit,
                             XXH3_accWidth_e accWidth)
 {
     XXH_ASSERT(*nbStripesSoFarPtr < nbStripesPerBlock);
     if (nbStripesPerBlock - *nbStripesSoFarPtr <= totalStripes) {
         /* need a scrambling operation */
         size_t const nbStripes = nbStripesPerBlock - *nbStripesSoFarPtr;
-        XXH3_accumulate(acc, data, (const char*)secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, accWidth);
-        XXH3_scrambleAcc(acc, (const char*)secret + secretLimit);
-        XXH3_accumulate(acc, (const char*)data + nbStripes * STRIPE_LEN, secret, totalStripes - nbStripes, accWidth);
+        XXH3_accumulate(acc, data, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, accWidth);
+        XXH3_scrambleAcc(acc, secret + secretLimit);
+        XXH3_accumulate(acc, data + nbStripes * STRIPE_LEN, secret, totalStripes - nbStripes, accWidth);
         *nbStripesSoFarPtr = (XXH32_hash_t)(totalStripes - nbStripes);
     } else {
-        XXH3_accumulate(acc, data, (const char*)secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, totalStripes, accWidth);
+        XXH3_accumulate(acc, data, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, totalStripes, accWidth);
         *nbStripesSoFarPtr += (XXH32_hash_t)totalStripes;
     }
 }
 
 XXH_FORCE_INLINE XXH_errorcode
-XXH3_update(XXH3_state_t* state, const void* input, size_t len, XXH3_accWidth_e accWidth)
+XXH3_update(XXH3_state_t* state, const BYTE* input, size_t len, XXH3_accWidth_e accWidth)
 {
     if (input==NULL)
 #if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
@@ -1178,8 +1150,7 @@ XXH3_update(XXH3_state_t* state, const void* input, size_t len, XXH3_accWidth_e 
         return XXH_ERROR;
 #endif
 
-    {   const BYTE* p = (const BYTE*)input;
-        const BYTE* const bEnd = p + len;
+    {   const BYTE* const bEnd = input + len;
 
         state->totalLen += len;
 
@@ -1196,7 +1167,7 @@ XXH3_update(XXH3_state_t* state, const void* input, size_t len, XXH3_accWidth_e 
         if (state->bufferedSize) {   /* some data within internal buffer: fill then consume it */
             size_t const loadSize = XXH3_INTERNALBUFFER_SIZE - state->bufferedSize;
             XXH_memcpy(state->buffer + state->bufferedSize, input, loadSize);
-            p += loadSize;
+            input += loadSize;
             XXH3_consumeStripes(state->acc,
                                &state->nbStripesSoFar, state->nbStripesPerBlock,
                                 state->buffer, XXH3_INTERNALBUFFER_STRIPES,
@@ -1206,21 +1177,21 @@ XXH3_update(XXH3_state_t* state, const void* input, size_t len, XXH3_accWidth_e 
         }
 
         /* consume input by full buffer quantities */
-        if (p+XXH3_INTERNALBUFFER_SIZE <= bEnd) {
+        if (input + XXH3_INTERNALBUFFER_SIZE <= bEnd) {
             const BYTE* const limit = bEnd - XXH3_INTERNALBUFFER_SIZE;
             do {
                 XXH3_consumeStripes(state->acc,
                                    &state->nbStripesSoFar, state->nbStripesPerBlock,
-                                    p, XXH3_INTERNALBUFFER_STRIPES,
+                                    input, XXH3_INTERNALBUFFER_STRIPES,
                                     state->secret, state->secretLimit,
                                     accWidth);
-                p += XXH3_INTERNALBUFFER_SIZE;
-            } while (p<=limit);
+                input += XXH3_INTERNALBUFFER_SIZE;
+            } while (input<=limit);
         }
 
-        if (p < bEnd) { /* some remaining input data : buffer it */
-            XXH_memcpy(state->buffer, p, (size_t)(bEnd-p));
-            state->bufferedSize = (XXH32_hash_t)(bEnd-p);
+        if (input < bEnd) { /* some remaining input data : buffer it */
+            XXH_memcpy(state->buffer, input, (size_t)(bEnd-input));
+            state->bufferedSize = (XXH32_hash_t)(bEnd-input);
         }
     }
 
@@ -1230,7 +1201,7 @@ XXH3_update(XXH3_state_t* state, const void* input, size_t len, XXH3_accWidth_e 
 XXH_PUBLIC_API XXH_errorcode
 XXH3_64bits_update(XXH3_state_t* state, const void* input, size_t len)
 {
-    return XXH3_update(state, input, len, XXH3_acc_64bits);
+    return XXH3_update(state, (const BYTE*)input, len, XXH3_acc_64bits);
 }
 
 
@@ -1249,18 +1220,18 @@ XXH3_digest_long (XXH64_hash_t* acc, const XXH3_state_t* state, XXH3_accWidth_e 
         if (state->bufferedSize % STRIPE_LEN) {  /* one last partial stripe */
             XXH3_accumulate_512(acc,
                                 state->buffer + state->bufferedSize - STRIPE_LEN,
-                   (const char*)state->secret + state->secretLimit - XXH_SECRET_LASTACC_START,
+                                state->secret + state->secretLimit - XXH_SECRET_LASTACC_START,
                                 accWidth);
         }
     } else {  /* bufferedSize < STRIPE_LEN */
         if (state->bufferedSize) { /* one last stripe */
-            char lastStripe[STRIPE_LEN];
+            BYTE lastStripe[STRIPE_LEN];
             size_t const catchupSize = STRIPE_LEN - state->bufferedSize;
-            memcpy(lastStripe, (const char*)state->buffer + sizeof(state->buffer) - catchupSize, catchupSize);
+            memcpy(lastStripe, state->buffer + sizeof(state->buffer) - catchupSize, catchupSize);
             memcpy(lastStripe + catchupSize, state->buffer, state->bufferedSize);
             XXH3_accumulate_512(acc,
                                 lastStripe,
-                   (const char*)state->secret + state->secretLimit - XXH_SECRET_LASTACC_START,
+                                state->secret + state->secretLimit - XXH_SECRET_LASTACC_START,
                                 accWidth);
     }   }
 }
@@ -1270,7 +1241,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
     if (state->totalLen > XXH3_MIDSIZE_MAX) {
         XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[ACC_NB];
         XXH3_digest_long(acc, state, XXH3_acc_64bits);
-        return XXH3_mergeAccs(acc, (const char*)state->secret + XXH_SECRET_MERGEACCS_START, (U64)state->totalLen * PRIME64_1);
+        return XXH3_mergeAccs(acc, state->secret + XXH_SECRET_MERGEACCS_START, (U64)state->totalLen * PRIME64_1);
     }
     /* len <= XXH3_MIDSIZE_MAX : short code */
     if (state->seed)
@@ -1283,19 +1254,18 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
  * ========================================== */
 
 XXH_FORCE_INLINE XXH128_hash_t
-XXH3_len_1to3_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+XXH3_len_1to3_128b(const BYTE* data, size_t len, const BYTE* keyPtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(data != NULL);
     XXH_ASSERT(1 <= len && len <= 3);
     XXH_ASSERT(keyPtr != NULL);
-    {   const U32* const key32 = (const U32*) keyPtr;
-        BYTE const c1 = ((const BYTE*)data)[0];
-        BYTE const c2 = ((const BYTE*)data)[len >> 1];
-        BYTE const c3 = ((const BYTE*)data)[len - 1];
+    {   BYTE const c1 = data[0];
+        BYTE const c2 = data[len >> 1];
+        BYTE const c3 = data[len - 1];
         U32  const combinedl = ((U32)c1) + (((U32)c2) << 8) + (((U32)c3) << 16) + (((U32)len) << 24);
         U32  const combinedh = XXH_swap32(combinedl);
-        U64  const keyedl = (U64)combinedl ^ (XXH_readLE32(key32)   + seed);
-        U64  const keyedh = (U64)combinedh ^ (XXH_readLE32(key32+1) - seed);
+        U64  const keyedl = (U64)combinedl ^ (XXH_readLE32(keyPtr)   + seed);
+        U64  const keyedh = (U64)combinedh ^ (XXH_readLE32(keyPtr+4) - seed);
         U64  const mixedl = keyedl * PRIME64_1;
         U64  const mixedh = keyedh * PRIME64_5;
         XXH128_hash_t const h128 = { XXH3_avalanche(mixedl) /*low64*/, XXH3_avalanche(mixedh) /*high64*/ };
@@ -1305,17 +1275,17 @@ XXH3_len_1to3_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_
 
 
 XXH_FORCE_INLINE XXH128_hash_t
-XXH3_len_4to8_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+XXH3_len_4to8_128b(const BYTE* data, size_t len, const BYTE* keyPtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(data != NULL);
     XXH_ASSERT(keyPtr != NULL);
     XXH_ASSERT(4 <= len && len <= 8);
     {   U32 const in1 = XXH_readLE32(data);
-        U32 const in2 = XXH_readLE32((const BYTE*)data + len - 4);
+        U32 const in2 = XXH_readLE32(data + len - 4);
         U64 const in64l = in1 + ((U64)in2 << 32);
         U64 const in64h = XXH_swap64(in64l);
         U64 const keyedl = in64l ^ (XXH_readLE64(keyPtr) + seed);
-        U64 const keyedh = in64h ^ (XXH_readLE64((const char*)keyPtr + 8) - seed);
+        U64 const keyedh = in64h ^ (XXH_readLE64(keyPtr + 8) - seed);
         U64 const mix64l1 = len + ((keyedl ^ (keyedl >> 51)) * PRIME32_1);
         U64 const mix64l2 = (mix64l1 ^ (mix64l1 >> 47)) * PRIME64_2;
         U64 const mix64h1 = ((keyedh ^ (keyedh >> 47)) * PRIME64_1) - len;
@@ -1326,14 +1296,13 @@ XXH3_len_4to8_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_
 }
 
 XXH_FORCE_INLINE XXH128_hash_t
-XXH3_len_9to16_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash_t seed)
+XXH3_len_9to16_128b(const BYTE* data, size_t len, const BYTE* keyPtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(data != NULL);
     XXH_ASSERT(keyPtr != NULL);
     XXH_ASSERT(9 <= len && len <= 16);
-    {   const U64* const key64 = (const U64*) keyPtr;
-        U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(key64) + seed);
-        U64 const ll2 = XXH_readLE64((const BYTE*)data + len - 8) ^ (XXH_readLE64(key64+1) - seed);
+    {   U64 const ll1 = XXH_readLE64(data) ^ (XXH_readLE64(keyPtr) + seed);
+        U64 const ll2 = XXH_readLE64(data + len - 8) ^ (XXH_readLE64(keyPtr+8) - seed);
         U64 const inlow = ll1 ^ ll2;
         XXH128_hash_t m128 = XXH_mult64to128(inlow, PRIME64_1);
         U64 const lenContrib = (U64)(U32)len * (U64)PRIME32_5; m128.low64 += lenContrib;
@@ -1350,7 +1319,7 @@ XXH3_len_9to16_128b(const void* data, size_t len, const void* keyPtr, XXH64_hash
 /* Assumption : `secret` size is >= 16
  * Note : it should be >= XXH3_SECRET_SIZE_MIN anyway */
 XXH_FORCE_INLINE XXH128_hash_t
-XXH3_len_0to16_128b(const void* data, size_t len, const void* secret, XXH64_hash_t seed)
+XXH3_len_0to16_128b(const BYTE* data, size_t len, const BYTE* secret, XXH64_hash_t seed)
 {
     XXH_ASSERT(len <= 16);
     {   if (len > 8) return XXH3_len_9to16_128b(data, len, secret, seed);
@@ -1362,8 +1331,8 @@ XXH3_len_0to16_128b(const void* data, size_t len, const void* secret, XXH64_hash
 }
 
 XXH_FORCE_INLINE XXH128_hash_t
-XXH3_hashLong_128b_internal(const void* XXH_RESTRICT data, size_t len,
-                            const void* XXH_RESTRICT secret, size_t secretSize)
+XXH3_hashLong_128b_internal(const BYTE* XXH_RESTRICT data, size_t len,
+                            const BYTE* XXH_RESTRICT secret, size_t secretSize)
 {
     XXH_ALIGN(XXH_ACC_ALIGN) U64 acc[ACC_NB] = XXH3_INIT_ACC;
 
@@ -1372,115 +1341,102 @@ XXH3_hashLong_128b_internal(const void* XXH_RESTRICT data, size_t len,
     /* converge into final hash */
     XXH_STATIC_ASSERT(sizeof(acc) == 64);
     XXH_ASSERT(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
-    {   U64 const low64 = XXH3_mergeAccs(acc, (const char*)secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
-        U64 const high64 = XXH3_mergeAccs(acc, (const char*)secret + secretSize - sizeof(acc) - XXH_SECRET_MERGEACCS_START, ~((U64)len * PRIME64_2));
+    {   U64 const low64 = XXH3_mergeAccs(acc, secret + XXH_SECRET_MERGEACCS_START, (U64)len * PRIME64_1);
+        U64 const high64 = XXH3_mergeAccs(acc, secret + secretSize - sizeof(acc) - XXH_SECRET_MERGEACCS_START, ~((U64)len * PRIME64_2));
         XXH128_hash_t const h128 = { low64, high64 };
         return h128;
     }
 }
 
 XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_128b_defaultSecret(const void* data, size_t len)
+XXH3_hashLong_128b_defaultSecret(const BYTE* data, size_t len)
 {
     return XXH3_hashLong_128b_internal(data, len, kSecret, sizeof(kSecret));
 }
 
 XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_128b_withSecret(const void* data, size_t len,
-                              const void* secret, size_t secretSize)
+XXH3_hashLong_128b_withSecret(const BYTE* data, size_t len,
+                              const BYTE* secret, size_t secretSize)
 {
     return XXH3_hashLong_128b_internal(data, len, secret, secretSize);
 }
 
 XXH_NO_INLINE XXH128_hash_t    /* It's important for performance that XXH3_hashLong is not inlined. Not sure why (uop cache maybe ?), but difference is large and easily measurable */
-XXH3_hashLong_128b_withSeed(const void* data, size_t len, XXH64_hash_t seed)
+XXH3_hashLong_128b_withSeed(const BYTE* data, size_t len, XXH64_hash_t seed)
 {
-    XXH_ALIGN(8) char secret[XXH_SECRET_DEFAULT_SIZE];
+    XXH_ALIGN(8) BYTE secret[XXH_SECRET_DEFAULT_SIZE];
     if (seed == 0) return XXH3_hashLong_128b_defaultSecret(data, len);
     XXH3_initKeySeed(secret, seed);
     return XXH3_hashLong_128b_internal(data, len, secret, sizeof(secret));
 }
 
 XXH_NO_INLINE XXH128_hash_t
-XXH3_len_129to240_128b(const void* XXH_RESTRICT data, size_t len,
-                      const void* XXH_RESTRICT secret, size_t secretSize,
-                      XXH64_hash_t seed)
+XXH3_len_129to240_128b(const BYTE* XXH_RESTRICT input, size_t len,
+                       const BYTE* XXH_RESTRICT secret, size_t secretSize, XXH64_hash_t seed)
 {
-    const BYTE* const p = (const BYTE*)data;
-    const char* const key = (const char*)secret;
+
+    U64 acc1 = len * PRIME64_1;
+    U64 acc2 = 0;
+    int const nbRounds = (int)(len / 32);
+    int i;
 
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
 
-    {   U64 acc1 = len * PRIME64_1;
-        U64 acc2 = 0;
-        int const nbRounds = (int)len / 32;
-        int i;
-        for (i=0; i<4; i++) {
-            acc1 += XXH3_mix16B(p+(32*i),    key+(32*i),         seed);
-            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*i)+16, 0ULL-seed);
-        }
-        acc1 = XXH3_avalanche(acc1);
-        acc2 = XXH3_avalanche(acc2);
-        XXH_ASSERT(nbRounds >= 4);
-        for (i=4 ; i < nbRounds; i++) {
-            acc1 += XXH3_mix16B(p+(32*i)   , key+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,      seed);
-            acc2 += XXH3_mix16B(p+(32*i)+16, key+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, 0ULL-seed);
-        }
-        /* last bytes */
-        acc1 += XXH3_mix16B(p + len - 16, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,      seed);
-        acc2 += XXH3_mix16B(p + len - 32, key + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL-seed);
+    for (i = 0; i < 4; i++) {
+        acc1 += XXH3_mix16B(input+(32*i),    secret+(32*i),         seed);
+        acc2 += XXH3_mix16B(input+(32*i)+16, secret+(32*i)+16, 0ULL-seed);
+    }
+    acc1 = XXH3_avalanche(acc1);
+    acc2 = XXH3_avalanche(acc2);
 
-        {   U64 const low64 = acc1 + acc2;
-            U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
-            XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
-            return h128;
-        }
+    for (i=4 ; i < nbRounds; i++) {
+        acc1 += XXH3_mix16B(input+(32*i)   , secret+(32*(i-4))    + XXH3_MIDSIZE_STARTOFFSET,      seed);
+        acc2 += XXH3_mix16B(input+(32*i)+16, secret+(32*(i-4))+16 + XXH3_MIDSIZE_STARTOFFSET, 0ULL-seed);
+    }
+    /* last bytes */
+    acc1 += XXH3_mix16B(input + len - 16, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET     ,      seed);
+    acc2 += XXH3_mix16B(input + len - 32, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL-seed);
+
+    {   U64 const low64 = acc1 + acc2;
+        U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
+        XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
+        return h128;
     }
 }
 
 XXH_FORCE_INLINE XXH128_hash_t
-XXH3_len_17to128_128b(const void* XXH_RESTRICT data, size_t len,
-                     const void* XXH_RESTRICT secret, size_t secretSize,
+XXH3_len_17to128_128b(const BYTE* XXH_RESTRICT input,
+                     size_t len,
+                     const BYTE* XXH_RESTRICT secret, size_t secretSize,
                      XXH64_hash_t seed)
 {
-    const BYTE* const p = (const BYTE*)data;
-    const char* const key = (const char*)secret;
+    int i = (int)((len - 1) / 32);
+
+    U64 acc1 = len * PRIME64_1;
+    U64 acc2 = 0;
 
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     XXH_ASSERT(16 < len && len <= 128);
 
-    {   U64 acc1 = len * PRIME64_1;
-        U64 acc2 = 0;
-        if (len > 32) {
-            if (len > 64) {
-                if (len > 96) {
-                    acc1 += XXH3_mix16B(p+48, key+96, seed);
-                    acc2 += XXH3_mix16B(p+len-64, key+112, seed);
-                }
-                acc1 += XXH3_mix16B(p+32, key+64, seed);
-                acc2 += XXH3_mix16B(p+len-48, key+80, seed);
-            }
-            acc1 += XXH3_mix16B(p+16, key+32, seed);
-            acc2 += XXH3_mix16B(p+len-32, key+48, seed);
-        }
-        acc1 += XXH3_mix16B(p+0, key+0, seed);
-        acc2 += XXH3_mix16B(p+len-16, key+16, seed);
+    for (; i >= 0; --i) {
+        acc1 += XXH3_mix16B(input + (16 * i),             secret + (16 * (2 * i)),      seed);
+        acc2 += XXH3_mix16B(input + len - (16 * (i + 1)), secret + (16 * ((2 * i) + 1)), seed);
+    }
 
-        {   U64 const low64 = acc1 + acc2;
-            U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
-            XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
-            return h128;
-        }
+    {   U64 const low64 = acc1 + acc2;
+        U64 const high64 = (acc1 * PRIME64_1) + (acc2 * PRIME64_4) + ((len - seed) * PRIME64_2);
+        XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
+        return h128;
     }
 }
 
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* data, size_t len)
 {
-    if (len <= 16) return XXH3_len_0to16_128b(data, len, kSecret, 0);
-    if (len <= 128) return XXH3_len_17to128_128b(data, len, kSecret, sizeof(kSecret), 0);
-    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b(data, len, kSecret, sizeof(kSecret), 0);
-    return XXH3_hashLong_128b_defaultSecret(data, len);
+    if (len <= 16) return XXH3_len_0to16_128b((const BYTE*)data, len, kSecret, 0);
+    if (len <= 128) return XXH3_len_17to128_128b((const BYTE*)data, len, kSecret, sizeof(kSecret), 0);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b((const BYTE*)data, len, kSecret, sizeof(kSecret), 0);
+    return XXH3_hashLong_128b_defaultSecret((const BYTE*)data, len);
 }
 
 XXH_PUBLIC_API XXH128_hash_t
@@ -1491,19 +1447,19 @@ XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t
      * it should be done here.
      * For now, it's a contract pre-condition.
      * Adding a check and a branch here would cost performance at every hash */
-     if (len <= 16) return XXH3_len_0to16_128b(data, len, secret, 0);
-     if (len <= 128) return XXH3_len_17to128_128b(data, len, secret, secretSize, 0);
-     if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b(data, len, secret, secretSize, 0);
-     return XXH3_hashLong_128b_withSecret(data, len, secret, secretSize);
+     if (len <= 16) return XXH3_len_0to16_128b((const BYTE*)data, len, (const BYTE*)secret, 0);
+     if (len <= 128) return XXH3_len_17to128_128b((const BYTE*)data, len, (const BYTE*)secret, secretSize, 0);
+     if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b((const BYTE*)data, len, (const BYTE*)secret, secretSize, 0);
+     return XXH3_hashLong_128b_withSecret((const BYTE*)data, len, (const BYTE*)secret, secretSize);
 }
 
 XXH_PUBLIC_API XXH128_hash_t
 XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed)
 {
-    if (len <= 16) return XXH3_len_0to16_128b(data, len, kSecret, seed);
-    if (len <= 128) return XXH3_len_17to128_128b(data, len, kSecret, sizeof(kSecret), seed);
-    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b(data, len, kSecret, sizeof(kSecret), seed);
-    return XXH3_hashLong_128b_withSeed(data, len, seed);
+    if (len <= 16) return XXH3_len_0to16_128b((const BYTE*)data, len, kSecret, seed);
+    if (len <= 128) return XXH3_len_17to128_128b((const BYTE*)data, len, kSecret, sizeof(kSecret), seed);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_128b((const BYTE*)data, len, kSecret, sizeof(kSecret), seed);
+    return XXH3_hashLong_128b_withSeed((const BYTE*)data, len, seed);
 }
 
 XXH_PUBLIC_API XXH128_hash_t
@@ -1522,7 +1478,7 @@ XXH128(const void* data, size_t len, XXH64_hash_t seed)
 static void
 XXH3_128bits_reset_internal(XXH3_state_t* statePtr,
                            XXH64_hash_t seed,
-                           const void* secret, size_t secretSize)
+                           const BYTE* secret, size_t secretSize)
 {
     XXH3_64bits_reset_internal(statePtr, seed, secret, secretSize);
 }
@@ -1539,7 +1495,7 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
 {
     if (statePtr == NULL) return XXH_ERROR;
-    XXH3_128bits_reset_internal(statePtr, 0, secret, secretSize);
+    XXH3_128bits_reset_internal(statePtr, 0, (const BYTE*)secret, secretSize);
     if (secret == NULL) return XXH_ERROR;
     if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
     return XXH_OK;
@@ -1558,7 +1514,7 @@ XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
 XXH_PUBLIC_API XXH_errorcode
 XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len)
 {
-    return XXH3_update(state, input, len, XXH3_acc_128bits);
+    return XXH3_update(state, (const BYTE*)input, len, XXH3_acc_128bits);
 }
 
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
@@ -1567,8 +1523,8 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
         XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[ACC_NB];
         XXH3_digest_long(acc, state, XXH3_acc_128bits);
         XXH_ASSERT(state->secretLimit + STRIPE_LEN >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
-        {   U64 const low64 = XXH3_mergeAccs(acc, (const char*)state->secret + XXH_SECRET_MERGEACCS_START, (U64)state->totalLen * PRIME64_1);
-            U64 const high64 = XXH3_mergeAccs(acc, (const char*)state->secret + state->secretLimit + STRIPE_LEN - sizeof(acc) - XXH_SECRET_MERGEACCS_START, ~((U64)state->totalLen * PRIME64_2));
+        {   U64 const low64 = XXH3_mergeAccs(acc, state->secret + XXH_SECRET_MERGEACCS_START, (U64)state->totalLen * PRIME64_1);
+            U64 const high64 = XXH3_mergeAccs(acc, state->secret + state->secretLimit + STRIPE_LEN - sizeof(acc) - XXH_SECRET_MERGEACCS_START, ~((U64)state->totalLen * PRIME64_2));
             XXH128_hash_t const h128 = { low64, high64 };
             return h128;
         }

--- a/xxh3.h
+++ b/xxh3.h
@@ -1491,36 +1491,31 @@ XXH3_len_129to240_128b(const BYTE* XXH_RESTRICT input, size_t len,
                        const BYTE* XXH_RESTRICT secret, size_t secretSize, XXH64_hash_t seed)
 {
 
-    U64 acc1 = len * PRIME64_1;
-    U64 acc2 = 0;
     int const nbRounds = (int)(len / 32);
     int i;
+    XXH128_hash_t acc;
+    acc.low64 = len * PRIME64_1;
+    acc.high64 = 0;
 
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
 
-    {   XXH128_hash_t acc;
-        int const nbRounds = (int)len / 32;
-        int i;
-        acc.low64 = len * PRIME64_1;
-        acc.high64 = 0;
-        for (i=0; i<4; i++) {
-            acc = XXH128_mix32B(acc, input+(32*i), input+(32*i)+16, secret+(32*i), seed);
-        }
-        acc.low64 = XXH3_avalanche(acc.low64);
-        acc.high64 = XXH3_avalanche(acc.high64);
-        XXH_ASSERT(nbRounds >= 4);
-        for (i=4 ; i < nbRounds; i++) {
-            acc = XXH128_mix32B(acc, input+(32*i), input+(32*i)+16, secret+XXH3_MIDSIZE_STARTOFFSET+(32*(i-4)), seed);
-        }
-        /* last bytes */
-        acc = XXH128_mix32B(acc, input + len - 16, input + len - 32, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL - seed);
+    for (i=0; i<4; i++) {
+        acc = XXH128_mix32B(acc, input+(32*i), input+(32*i)+16, secret+(32*i), seed);
+    }
+    acc.low64 = XXH3_avalanche(acc.low64);
+    acc.high64 = XXH3_avalanche(acc.high64);
+    XXH_ASSERT(nbRounds >= 4);
+    for (i=4 ; i < nbRounds; i++) {
+        acc = XXH128_mix32B(acc, input+(32*i), input+(32*i)+16, secret+XXH3_MIDSIZE_STARTOFFSET+(32*(i-4)), seed);
+    }
+    /* last bytes */
+    acc = XXH128_mix32B(acc, input + len - 16, input + len - 32, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0ULL - seed);
 
-        {   U64 const low64 = acc.low64 + acc.high64;
-            U64 const high64 = (acc.low64 * PRIME64_1) + (acc.high64 * PRIME64_4) + ((len - seed) * PRIME64_2);
-            XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
-            return h128;
-        }
+    {   U64 const low64 = acc.low64 + acc.high64;
+        U64 const high64 = (acc.low64 * PRIME64_1) + (acc.high64 * PRIME64_4) + ((len - seed) * PRIME64_2);
+        XXH128_hash_t const h128 = { XXH3_avalanche(low64), (XXH64_hash_t)0 - XXH3_avalanche(high64) };
+        return h128;
     }
 }
 
@@ -1533,8 +1528,6 @@ XXH3_len_17to128_128b(const BYTE* XXH_RESTRICT input,
 {
     int i = (int)((len - 1) / 32);
 
-    U64 acc1 = len * PRIME64_1;
-    U64 acc2 = 0;
     XXH128_hash_t acc;
     acc.low64 = len * PRIME64_1;
     acc.high64 = 0;

--- a/xxhash.c
+++ b/xxhash.c
@@ -365,17 +365,16 @@ static U32 XXH32_avalanche(U32 h32)
 #define XXH_get32bits(p) XXH_readLE32_align(p, align)
 
 static U32
-XXH32_finalize(U32 h32, const void* ptr, size_t len, XXH_alignment align)
+XXH32_finalize(U32 h32, const BYTE* ptr, size_t len, XXH_alignment align)
 {
-    const BYTE* p = (const BYTE*)ptr;
 
 #define PROCESS1               \
-    h32 += (*p++) * PRIME32_5; \
+    h32 += (*ptr++) * PRIME32_5; \
     h32 = XXH_rotl32(h32, 11) * PRIME32_1 ;
 
 #define PROCESS4                         \
-    h32 += XXH_get32bits(p) * PRIME32_3; \
-    p+=4;                                \
+    h32 += XXH_get32bits(ptr) * PRIME32_3; \
+    ptr+=4;                                \
     h32  = XXH_rotl32(h32, 17) * PRIME32_4 ;
 
     /* Compact rerolled version */
@@ -436,16 +435,15 @@ XXH32_finalize(U32 h32, const void* ptr, size_t len, XXH_alignment align)
 }
 
 XXH_FORCE_INLINE U32
-XXH32_endian_align(const void* input, size_t len, U32 seed, XXH_alignment align)
+XXH32_endian_align(const BYTE* input, size_t len, U32 seed, XXH_alignment align)
 {
-    const BYTE* p = (const BYTE*)input;
-    const BYTE* bEnd = p + len;
+    const BYTE* bEnd = input + len;
     U32 h32;
 
 #if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
-    if (p==NULL) {
+    if (input==NULL) {
         len=0;
-        bEnd=p=(const BYTE*)(size_t)16;
+        bEnd=input=(const BYTE*)(size_t)16;
     }
 #endif
 
@@ -457,11 +455,11 @@ XXH32_endian_align(const void* input, size_t len, U32 seed, XXH_alignment align)
         U32 v4 = seed - PRIME32_1;
 
         do {
-            v1 = XXH32_round(v1, XXH_get32bits(p)); p+=4;
-            v2 = XXH32_round(v2, XXH_get32bits(p)); p+=4;
-            v3 = XXH32_round(v3, XXH_get32bits(p)); p+=4;
-            v4 = XXH32_round(v4, XXH_get32bits(p)); p+=4;
-        } while (p < limit);
+            v1 = XXH32_round(v1, XXH_get32bits(input)); input+=4;
+            v2 = XXH32_round(v2, XXH_get32bits(input)); input+=4;
+            v3 = XXH32_round(v3, XXH_get32bits(input)); input+=4;
+            v4 = XXH32_round(v4, XXH_get32bits(input)); input+=4;
+        } while (input < limit);
 
         h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
             + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
@@ -471,7 +469,7 @@ XXH32_endian_align(const void* input, size_t len, U32 seed, XXH_alignment align)
 
     h32 += (U32)len;
 
-    return XXH32_finalize(h32, p, len&15, align);
+    return XXH32_finalize(h32, input, len&15, align);
 }
 
 
@@ -488,10 +486,10 @@ XXH_PUBLIC_API XXH32_hash_t XXH32 (const void* input, size_t len, unsigned int s
 
     if (XXH_FORCE_ALIGN_CHECK) {
         if ((((size_t)input) & 3) == 0) {   /* Input is 4-bytes aligned, leverage the speed benefit */
-            return XXH32_endian_align(input, len, seed, XXH_aligned);
+            return XXH32_endian_align((const BYTE*)input, len, seed, XXH_aligned);
     }   }
 
-    return XXH32_endian_align(input, len, seed, XXH_unaligned);
+    return XXH32_endian_align((const BYTE*)input, len, seed, XXH_unaligned);
 #endif
 }
 
@@ -607,7 +605,7 @@ XXH_PUBLIC_API XXH32_hash_t XXH32_digest (const XXH32_state_t* state)
 
     h32 += state->total_len_32;
 
-    return XXH32_finalize(h32, state->mem32, state->memsize, XXH_aligned);
+    return XXH32_finalize(h32, (const BYTE*)state->mem32, state->memsize, XXH_aligned);
 }
 
 
@@ -782,22 +780,21 @@ static U64 XXH64_avalanche(U64 h64)
 #define XXH_get64bits(p) XXH_readLE64_align(p, align)
 
 static U64
-XXH64_finalize(U64 h64, const void* ptr, size_t len, XXH_alignment align)
+XXH64_finalize(U64 h64, const BYTE* ptr, size_t len, XXH_alignment align)
 {
-    const BYTE* p = (const BYTE*)ptr;
 
 #define PROCESS1_64            \
-    h64 ^= (*p++) * PRIME64_5; \
+    h64 ^= (*ptr++) * PRIME64_5; \
     h64 = XXH_rotl64(h64, 11) * PRIME64_1;
 
 #define PROCESS4_64          \
-    h64 ^= (U64)(XXH_get32bits(p)) * PRIME64_1; \
-    p+=4;                    \
+    h64 ^= (U64)(XXH_get32bits(ptr)) * PRIME64_1; \
+    ptr+=4;                    \
     h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
 
 #define PROCESS8_64 {        \
-    U64 const k1 = XXH64_round(0, XXH_get64bits(p)); \
-    p+=8;                    \
+    U64 const k1 = XXH64_round(0, XXH_get64bits(ptr)); \
+    ptr+=8;                    \
     h64 ^= k1;               \
     h64  = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4; \
 }
@@ -907,16 +904,15 @@ XXH64_finalize(U64 h64, const void* ptr, size_t len, XXH_alignment align)
 }
 
 XXH_FORCE_INLINE U64
-XXH64_endian_align(const void* input, size_t len, U64 seed, XXH_alignment align)
+XXH64_endian_align(const BYTE* input, size_t len, U64 seed, XXH_alignment align)
 {
-    const BYTE* p = (const BYTE*)input;
-    const BYTE* bEnd = p + len;
+    const BYTE* bEnd = input + len;
     U64 h64;
 
 #if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
-    if (p==NULL) {
+    if (input==NULL) {
         len=0;
-        bEnd=p=(const BYTE*)(size_t)32;
+        bEnd=input=(const BYTE*)(size_t)32;
     }
 #endif
 
@@ -928,11 +924,11 @@ XXH64_endian_align(const void* input, size_t len, U64 seed, XXH_alignment align)
         U64 v4 = seed - PRIME64_1;
 
         do {
-            v1 = XXH64_round(v1, XXH_get64bits(p)); p+=8;
-            v2 = XXH64_round(v2, XXH_get64bits(p)); p+=8;
-            v3 = XXH64_round(v3, XXH_get64bits(p)); p+=8;
-            v4 = XXH64_round(v4, XXH_get64bits(p)); p+=8;
-        } while (p<=limit);
+            v1 = XXH64_round(v1, XXH_get64bits(input)); input+=8;
+            v2 = XXH64_round(v2, XXH_get64bits(input)); input+=8;
+            v3 = XXH64_round(v3, XXH_get64bits(input)); input+=8;
+            v4 = XXH64_round(v4, XXH_get64bits(input)); input+=8;
+        } while (input<=limit);
 
         h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
         h64 = XXH64_mergeRound(h64, v1);
@@ -946,7 +942,7 @@ XXH64_endian_align(const void* input, size_t len, U64 seed, XXH_alignment align)
 
     h64 += (U64) len;
 
-    return XXH64_finalize(h64, p, len, align);
+    return XXH64_finalize(h64, input, len, align);
 }
 
 
@@ -963,10 +959,10 @@ XXH_PUBLIC_API XXH64_hash_t XXH64 (const void* input, size_t len, unsigned long 
 
     if (XXH_FORCE_ALIGN_CHECK) {
         if ((((size_t)input) & 7)==0) {  /* Input is aligned, let's leverage the speed advantage */
-            return XXH64_endian_align(input, len, seed, XXH_aligned);
+            return XXH64_endian_align((const BYTE*)input, len, seed, XXH_aligned);
     }   }
 
-    return XXH64_endian_align(input, len, seed, XXH_unaligned);
+    return XXH64_endian_align((const BYTE*)input, len, seed, XXH_unaligned);
 
 #endif
 }
@@ -1083,7 +1079,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_digest (const XXH64_state_t* state)
 
     h64 += (U64) state->total_len;
 
-    return XXH64_finalize(h64, state->mem64, (size_t)state->total_len, XXH_aligned);
+    return XXH64_finalize(h64, (const BYTE*)state->mem64, (size_t)state->total_len, XXH_aligned);
 }
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -427,8 +427,8 @@ typedef struct XXH3_state_s XXH3_state_t;
 #define XXH3_INTERNALBUFFER_SIZE 256
 struct XXH3_state_s {
    XXH_ALIGN(64) XXH64_hash_t acc[8];
-   XXH_ALIGN(64) char customSecret[XXH3_SECRET_DEFAULT_SIZE];  /* used to store a custom secret generated from the seed. Makes state larger. Design might change */
-   XXH_ALIGN(64) char buffer[XXH3_INTERNALBUFFER_SIZE];
+   XXH_ALIGN(64) unsigned char customSecret[XXH3_SECRET_DEFAULT_SIZE];  /* used to store a custom secret generated from the seed. Makes state larger. Design might change */
+   XXH_ALIGN(64) unsigned char buffer[XXH3_INTERNALBUFFER_SIZE];
    XXH32_hash_t bufferedSize;
    XXH32_hash_t nbStripesPerBlock;
    XXH32_hash_t nbStripesSoFar;
@@ -438,7 +438,7 @@ struct XXH3_state_s {
    XXH64_hash_t totalLen;
    XXH64_hash_t seed;
    XXH64_hash_t reserved64;
-   const void* secret;    /* note : there is some padding after, due to alignment on 64 bytes */
+   const unsigned char* secret;    /* note : there is some padding after, due to alignment on 64 bytes */
 };   /* typedef'd to XXH3_state_t */
 
 /* Streaming requires state maintenance.

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -429,15 +429,13 @@ static void BMK_dummy(volatile hashFunction h, const char* hName, const void* bu
     cStart = clock();
     while (clock() == cStart);   /* starts clock() at its exact beginning */
     cStart = clock();
-
     {   U32 u;
         for (u=0; u<nbh_perIteration; u++)
             r += h(buffer, bufferSize, u);
     }
-    if (r==0) DISPLAYLEVEL(3,"");  /* do something with r to defeat compiler "optimizing" away hash */
-
-    clock_t const end = clock();
-    g_overhead = end - cStart;
+    if (r==0) DISPLAYLEVEL(3,"%d",r);  /* do something with r to defeat compiler "optimizing" away hash */
+    { clock_t const end = clock();
+      g_overhead = end - cStart; }
 }
 
 /* BMK_benchMem():


### PR DESCRIPTION
* Unified SSE2 and AVX2 with macros expanding to either SSE2 or AVX2 intrinsics
* Used a macro to abstract the vzip hack on neon
* Synchronize the comments, names, and order of the SSE2/AVX2 code with the NEON code to highlight similarities.
* Replace most void pointers with BYTE pointers
* Fix most casting issues (I need to double check VSX)
* Prefer "secret" and "input" over "data" and "key" (except in accumulate - it looks better)
* Document the code more in the main loop
* Use `(x > y) - (x < y)` instead of `(x > y) - (y > x)` in XXH28_cmp - the former is more idiomatic
* Use a new form for XXH_accumulate_512's scalar loop. This allows better size optimizations
* Reroll a few loops that were confusing to readers and compilers
* Fix endian detection on GCC
* Fix vector conversion issue on GCC
* Add multiple options to significantly improve size optimizations (could go further but that's pretty good for now)
  * The main issue, force inlining, is fixed
  * `aarch64-linux-android-clang -Oz -DXXH_OPTIMIZE_SIZE=2 -c xxhash.c`: less than half the size of default options + XXH_REROLL