### PR TITLE
Reduce void pointers and evil casts.

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -701,7 +701,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT key)
 
 #elif (XXH_VECTOR == XXH_SSE2)
 
-    {   XXH_ALIGN(16) __m128i* const xaccX = (__m128i*) acc;
+    {   XXH_ALIGN(16) __m128i* const xacc = (__m128i*) acc;
         const         __m128i* const xkey = (const __m128i *) key;   /* not really aligned, just for ptr arithmetic */
         const __m128i prime32 = _mm_set1_epi32((int)PRIME32_1);
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -427,8 +427,8 @@ typedef struct XXH3_state_s XXH3_state_t;
 #define XXH3_INTERNALBUFFER_SIZE 256
 struct XXH3_state_s {
    XXH_ALIGN(64) XXH64_hash_t acc[8];
-   XXH_ALIGN(64) char customSecret[XXH3_SECRET_DEFAULT_SIZE];  /* used to store a custom secret generated from the seed. Makes state larger. Design might change */
-   XXH_ALIGN(64) char buffer[XXH3_INTERNALBUFFER_SIZE];
+   XXH_ALIGN(64) unsigned char customSecret[XXH3_SECRET_DEFAULT_SIZE];  /* used to store a custom secret generated from the seed. Makes state larger. Design might change */
+   XXH_ALIGN(64) unsigned char buffer[XXH3_INTERNALBUFFER_SIZE];
    XXH32_hash_t bufferedSize;
    XXH32_hash_t nbStripesPerBlock;
    XXH32_hash_t nbStripesSoFar;
@@ -438,7 +438,7 @@ struct XXH3_state_s {
    XXH64_hash_t totalLen;
    XXH64_hash_t seed;
    XXH64_hash_t reserved64;
-   const void* secret;    /* note : there is some padding after, due to alignment on 64 bytes */
+   const unsigned char* secret;    /* note : there is some padding after, due to alignment on 64 bytes */
 };   /* typedef'd to XXH3_state_t */
 
 /* Streaming requires state maintenance.


### PR DESCRIPTION
Part of my multipart patch.

This reduces type erasing and casting to wider types.

All unaligned pointers are passed as `BYTE` if possible, with public APIs casting to it immediately instead of after. I'm not sure if we should use it with the SSE2 code because Intel messed up `_mm_loadu_si128`'s prototype.