### PR TITLE
Use Travis CI Arm64 and PPC64le arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,19 @@ matrix:
 
     - name: General linux tests (Xenial)
       dist: xenial
-      before_install:
-        - sudo apt-get update  -qq
-        - sudo apt-get install -qq clang
-        - sudo apt-get install -qq g++-multilib
-        - sudo apt-get install -qq gcc-multilib
-        - sudo apt-get install -qq cppcheck
+      arch: amd64
+      addons:
+        apt:
+          packages:
+            - clang
+            - g++-multilib
+            - gcc-multilib
+            - cppcheck
       script:
         - make -B test-all
 
     - name: Check results consistency on x64
+      arch: amd64
       script:
         - CPPFLAGS=-DXXH_VECTOR=0 make check   # Scalar code path
         - make clean
@@ -26,42 +29,47 @@ matrix:
         - CPPFLAGS=-DXXH_REROLL=1 make check   # reroll code path (#240)
         - make -C tests/bench
 
-    - name: ARM + aarch64 compilation and consistency checks
+    - name: ARM compilation and consistency checks
       dist: xenial
-      install:
-        - sudo apt-get install -qq
-            qemu-system-arm
-            qemu-user-static
-            gcc-arm-linux-gnueabi
-            libc6-dev-armel-cross
-            gcc-aarch64-linux-gnu
-            libc6-dev-arm64-cross
+      arch: amd64
+      addons:
+        apt:
+          packages:
+            - qemu-system-arm
+            - qemu-user-static
+            - gcc-arm-linux-gnueabi
+            - libc6-dev-armel-cross
       script:
         # arm (32-bit)
         - CC=arm-linux-gnueabi-gcc CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static RUN_ENV=qemu-arm-static make check   # Scalar code path
         - make clean
         # NEON (32-bit)
         - CC=arm-linux-gnueabi-gcc CPPFLAGS=-DXXH_VECTOR=3 CFLAGS="-O3 -march=armv7-a -fPIC -mfloat-abi=softfp -mfpu=neon-vfpv4" LDFLAGS=-static RUN_ENV=qemu-arm-static make check   # NEON code path
-        - make clean
+
+    - name: aarch64 compilation and consistency checks
+      dist: xenial
+      arch: arm64
+      script:
         # aarch64
-        - CC=aarch64-linux-gnu-gcc CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static RUN_ENV=qemu-aarch64-static make check   # Scalar code path
+        - CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static make check   # Scalar code path
+        # NEON (64-bit)
         - make clean
-        - CC=aarch64-linux-gnu-gcc CPPFLAGS=-DXXH_VECTOR=3 LDFLAGS=-static RUN_ENV=qemu-aarch64-static make check   # NEON code path
-        - make clean
+        - CPPFLAGS=-DXXH_VECTOR=3 LDFLAGS=-static make check   # NEON code path
+          
     # We need Bionic here because the QEMU versions shipped in the older repos
     # do not support POWER8 emulation, and compiling QEMU from source is a pain.
     - name: PowerPC + PPC64 compilation and consistency checks (Bionic)
       dist: bionic
-      install:
-        - sudo apt-get install -qq
-            qemu-system-ppc
-            qemu-user-static
-            gcc-powerpc-linux-gnu
-            gcc-powerpc64-linux-gnu
-            libc6-dev-powerpc-cross
-            libc6-dev-ppc64-cross
-            gcc-powerpc64le-linux-gnu
-            libc6-dev-ppc64el-cross
+      arch: amd64
+      addons:
+        apt:
+          packages:
+            - qemu-system-ppc
+            - qemu-user-static
+            - gcc-powerpc-linux-gnu
+            - gcc-powerpc64-linux-gnu
+            - libc6-dev-powerpc-cross
+            - libc6-dev-ppc64-cross
       script:
         - CC=powerpc-linux-gnu-gcc RUN_ENV=qemu-ppc-static LDFLAGS=-static make check   # Scalar code path
         - make clean
@@ -70,8 +78,12 @@ matrix:
         # VSX code
         - CC=powerpc64-linux-gnu-gcc RUN_ENV="qemu-ppc64-static -cpu power8" CFLAGS="-O3 -maltivec -mvsx -mcpu=power8 -mpower8-vector" LDFLAGS="-static -m64" make check   # Auto code path
         - make clean
-        - CC=powerpc64le-linux-gnu-gcc RUN_ENV="qemu-ppc64le-static -cpu power8" CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" make check   # VSX code path
-        - make clean
+
+    - name: PPC64LE compilation and consistency checks
+      dist: xenial
+      arch: ppc64le
+      script:
+        - CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" make check   # VSX code path
 
     - name: cmake
       script:


### PR DESCRIPTION
This offloads the Arm64 and PPC64le builds and tests to real hardware that is now available on Travis CI.