### PR TITLE
Unified VSX and S390X code path, remove vpermxor 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,11 @@ matrix:
         - CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" make check
 
     - name: IBM s390x compilation and consistency checks
+      dist: bionic
       arch: s390x
       script:
+        # for info
+        - cat /proc/cpuinfo
         # Scalar (universal) code path
         - CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static make check
         # s390x code path (64-bit)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: c
 
+# Dump CPU info before start
+before_install:
+  - cat /proc/cpuinfo
+
 matrix:
   fast_finish: true
   include:
@@ -93,8 +97,6 @@ matrix:
       dist: bionic
       arch: s390x
       script:
-        # for info
-        - cat /proc/cpuinfo
         # Scalar (universal) code path
         - CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static make check
         # s390x code path (64-bit)
@@ -108,3 +110,4 @@ matrix:
         - cd build
         - cmake ..
         - make
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,9 @@ matrix:
       script:
         # Scalar (universal) code path
         - CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static make check
+        # s390x code path (64-bit)
+        - make clean
+        - CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" make check
 
     - name: cmake build test
       script:

--- a/xxh3.h
+++ b/xxh3.h
@@ -194,7 +194,7 @@ __extension__({ \
 /* We need some helpers for big endian mode. */
 #if XXH_VSX_BE
 /* A wrapper for POWER9's vec_revb. */
-#  if defined(__POWER9_VECTOR__) || defined(__s390x__)
+#  if defined(__POWER9_VECTOR__) || (defined(__clang__) && defined(__s390x__))
 #    define XXH_vec_revb vec_revb
 #  else
 XXH_FORCE_INLINE U64x2 XXH_vec_revb(U64x2 val)

--- a/xxh3.h
+++ b/xxh3.h
@@ -234,7 +234,7 @@ XXH_FORCE_INLINE U64x2 XXH_vec_xor_revb(U64x2 acc, U64x2 input)
 {
     U8x16 const vXorSwap  = { 0x07, 0x16, 0x25, 0x34, 0x43, 0x52, 0x61, 0x70,
                               0x8F, 0x9E, 0xAD, 0xBC, 0xCB, 0xDA, 0xE9, 0xF8 };
-    return (U64x2)XXH_vec_permxor((U8x16)val, (U8x16)input, vXorSwap);
+    return (U64x2)XXH_vec_permxor((U8x16)acc, (U8x16)input, vXorSwap);
 }
 #  else
 XXH_FORCE_INLINE U64x2 XXH_vec_xor_revb(U64x2 acc, U64x2 input)

--- a/xxh3.h
+++ b/xxh3.h
@@ -190,7 +190,7 @@ typedef __vector unsigned U32x4;
 #  endif
 #endif
 
-#if XXH_VEC_BE
+#if XXH_VSX_BE
 /* A wrapper for POWER9's vec_revb. */
 #  if defined(__POWER9_VECTOR__) || (defined(__clang__) && defined(__s390x__))
 #    define XXH_vec_revb vec_revb
@@ -202,7 +202,7 @@ XXH_FORCE_INLINE U64x2 XXH_vec_revb(U64x2 val)
     return vec_perm(val, val, vByteSwap);
 }
 #  endif
-#endif /* XXH_VEC_BE */
+#endif /* XXH_VSX_BE */
 
 /*
  * Performs an unaligned load and byte swaps it on big endian.

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -241,6 +241,10 @@ static unsigned BMK_isLittleEndian(void)
 #  define ARCH "mips64"
 #elif defined(__mips)
 #  define ARCH "mips"
+#elif defined(__s390x__)
+#  define ARCH "s390x"
+#elif defined(__s390__)
+#  define ARCH "s390"
 #else
 #  define ARCH "unknown"
 #endif


### PR DESCRIPTION
~~This is not ready to merge, it has only been tested for compile errors at the moment. I don't have an s390x toolchain, just Clang's cross compiler.~~

 - Add s390x support to xxhsum
 - Reuse the VSX path for s390x, they both use similar APIs
 - Replace vec_vsx_ld with memcpy
 - Remove vpermxor hack, it makes things too messy
 - Improve Travis tests, dump CPUID info