### PR TITLE
removed cygwin code path

### DIFF
--- a/xxhsum.c
+++ b/xxhsum.c
@@ -93,7 +93,7 @@
  || defined(__MSYS__)
 #  include <unistd.h>   /* isatty */
 #  define IS_CONSOLE(stdStream) isatty(fileno(stdStream))
-#elif defined(MSDOS) || defined(OS2) || defined(__CYGWIN__)
+#elif defined(MSDOS) || defined(OS2)
 #  include <io.h>       /* _isatty */
 #  define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))
 #elif defined(WIN32) || defined(_WIN32)


### PR DESCRIPTION
it's not useful : cygwin already uses the `posix` code path

fix #100