### PR TITLE
xxhash can be inlined even when previously included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,9 +282,13 @@ preview-man: man
 test: DEBUGFLAGS += -DDEBUGLEVEL=1
 test: all namespaceTest check test-xxhsum-c c90test test-tools
 
+.PHONY: test-inline
+test-inline:
+	$(MAKE) -C tests test
+
 .PHONY: test-all
 test-all: CFLAGS += -Werror
-test-all: test test32 clangtest cxxtest usan listL120 trailingWhitespace staticAnalyze
+test-all: test test32 clangtest cxxtest usan test-inline listL120 trailingWhitespace staticAnalyze
 
 .PHONY: test-tools
 test-tools:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,45 @@
+CFLAGS += -Wall -Wextra -g
+
+NM = nm
+GREP = grep
+
+.PHONY: default
+default: all
+
+.PHONY: all
+all: test
+
+.PHONY: test
+test: test_multiinclude
+
+.PHONY: test_multiinclude
+test_multiinclude:
+	@$(MAKE) clean
+	# compile without xxhash.o, ensure symbols exist within target
+	# note : built using only default rules
+	$(MAKE) multiInclude
+	@$(MAKE) clean
+	# compile with xxhash.o, to detect duplicated symbols
+	$(MAKE) multiInclude_withxxhash
+	@$(MAKE) clean
+	# Note : XXH_INLINE_ALL with XXH_NAMESPACE is currently disabled
+	# compile with XXH_NAMESPACE
+	# CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude_withxxhash
+	# no symbol prefixed TESTN_ should exist
+	# ! $(NM) multiInclude_withxxhash | $(GREP) TESTN_
+	#$(MAKE) clean
+	# compile with XXH_NAMESPACE and without xxhash.o
+	# CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude
+	# no symbol prefixed TESTN_ should exist
+	# ! $(NM) multiInclude | $(GREP) TESTN_
+	#@$(MAKE) clean
+
+xxhash.o: ../xxhash.c ../xxhash.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -c -o $@ $<
+
+multiInclude_withxxhash: multiInclude.o xxhash.o
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
+
+clean:
+	@$(RM) *.o
+	@$(RM) multiInclude multiInclude_withxxhash

--- a/tests/multiInclude.c
+++ b/tests/multiInclude.c
@@ -1,6 +1,6 @@
 /*
-*  test_multiinclude
-*  test program, just to validate including multiple times in any order
+*  multiinclude test program
+*  validate that xxhash.h can be included multiple times and in any order
 *
 *  Copyright (C) Yann Collet 2013-present
 *
@@ -25,26 +25,29 @@
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 
-#include <stdio.h>  // printf
+#include <stdio.h>   /* printf */
 
 /* normal include, gives access to public symbols */
 #include "../xxhash.h"
 
-/* advanced include, gives access to experimental symbols */
-/* note : without specific effort, experimental symbols might be unavailable */
+/* advanced include, gives access to experimental symbols
+ * This test ensure that xxhash.h can be included multiple times
+ * and in any order. This order is more difficult :
+ * without care, declaration of experimental symbols could be skipped */
 #define XXH_STATIC_LINKING_ONLY
 #include "../xxhash.h"
 
-/* inlining : re-define all symbols, keep them private to the unit.
- * note : without specific efforts, symbol names will collide
- * note 2 : no linking to xxhash.o, so that link stage will fail if inline is ignored */
+/* inlining : re-define all identifiers, keep them private to the unit.
+ * note : without specific efforts, identifier names would collide
+ * To be linked with and withouy xxhash.o,
+ * to test symbol's presence and naming collisions */
 #define XXH_INLINE_ALL
 #include "../xxhash.h"
 
 
 int main(void)
 {
-    XXH3_state_t state;   /* part of experimental */
+    XXH3_state_t state;   /* part of experimental API */
 
     XXH3_64bits_reset(&state);
     const char input[] = "Hello World !";

--- a/tests/multiInclude.c
+++ b/tests/multiInclude.c
@@ -1,0 +1,58 @@
+/*
+*  test_multiinclude
+*  test program, just to validate including multiple times in any order
+*
+*  Copyright (C) Yann Collet 2013-present
+*
+*  GPL v2 License
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+*  You can contact the author at :
+*  - xxHash homepage : http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+#include <stdio.h>  // printf
+
+/* normal include, gives access to public symbols */
+#include "../xxhash.h"
+
+/* advanced include, gives access to experimental symbols */
+/* note : without specific effort, experimental symbols might be unavailable */
+#define XXH_STATIC_LINKING_ONLY
+#include "../xxhash.h"
+
+/* inlining : re-define all symbols, keep them private to the unit.
+ * note : without specific efforts, symbol names will collide
+ * note 2 : no linking to xxhash.o, so that link stage will fail if inline is ignored */
+#define XXH_INLINE_ALL
+#include "../xxhash.h"
+
+
+int main(void)
+{
+    XXH3_state_t state;   /* part of experimental */
+
+    XXH3_64bits_reset(&state);
+    const char input[] = "Hello World !";
+
+    XXH3_64bits_update(&state, input, sizeof(input));
+
+    XXH64_hash_t const h = XXH3_64bits_digest(&state);
+    printf("hash '%s' : %0llx \n", input, (unsigned long long)h);
+
+    return 0;
+}

--- a/xxh3.h
+++ b/xxh3.h
@@ -40,11 +40,12 @@
 #ifndef XXH3_H_1397135465
 #define XXH3_H_1397135465
 
-
 /* ===   Dependencies   === */
-
-#undef XXH_INLINE_ALL   /* in case it's already defined */
-#define XXH_INLINE_ALL
+#ifndef XXHASH_H_5627135585666179
+/* special : when including `xxh3.h` directly, turn on XXH_INLINE_ALL */
+#  undef XXH_INLINE_ALL   /* avoid redefinition */
+#  define XXH_INLINE_ALL
+#endif
 #include "xxhash.h"
 
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -1654,7 +1654,7 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
 
 /* 128-bit utility functions */
 
-#include <string.h>   /* memcmp */
+#include <string.h>   /* memcmp, memcpy */
 
 /* return : 1 is equal, 0 if different */
 XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)

--- a/xxhash.c
+++ b/xxhash.c
@@ -33,7 +33,7 @@
 */
 
 
-/* xxhash.c only instantiates functions defined in xxhash.h
+/* xxhash.c instantiates functions defined in xxhash.h
  */
 
 #define XXH_STATIC_LINKING_ONLY   /* access advanced declarations */

--- a/xxhash.h
+++ b/xxhash.h
@@ -74,7 +74,7 @@ extern "C" {
 #endif
 
 /* ****************************
- *  API modifier
+ *  INLINE mode
  ******************************/
 /** XXH_INLINE_ALL (and XXH_PRIVATE_API)
  *  Implement requested xxhash functions directly in the unit.
@@ -140,6 +140,10 @@ extern "C" {
 #endif /* XXH_INLINE_ALL || XXH_PRIVATE_API */
 
 
+
+/* ****************************************************************
+ *  Stable API
+ *****************************************************************/
 #ifndef XXHASH_H_5627135585666179
 #define XXHASH_H_5627135585666179 1
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -54,11 +54,8 @@
 #include <assert.h>     /* assert */
 #include <errno.h>      /* errno */
 
-#include "xxhash.h"
-
 #define XXH_STATIC_LINKING_ONLY   /* *_state_t */
-#include "xxhash.h"    /* note : intentional double include, for validation.
-                        * this test ensures that xxhash.h can be included in any order. */
+#include "xxhash.h"
 
 
 /* ************************************


### PR DESCRIPTION
Inlining hash functions is generally beneficial for performance. The benefit becomes critically important whenever input size can be defined as a compile-time constant.

To inline xxhash functions, one just needs to include it this way :

```
   #define XXH_INLINE_ALL
   #include "xxhash.h"
```

One potential issue is that `xxhash.h` may have already been included previously,
typically as part of another included `*.h` .
In which case, the second `#include` statement will have no effect : the content of `xxhash.h`, having already been parsed, would be skipped.

This patch fixes this situation :
now, when `XXH_INLINE_ALL` is defined, all identifiers are renamed,
in order to avoid naming collisions and confusion with already included identifiers.

The renaming process uses `XXH_NAMESPACE`.
For this to work correctly, `XXH_NAMESPACE` must be available (i.e. not already used).

A test has been added in `tests/` to ensure this scenario works correctly.