### PR TITLE
return non-zero on empty string :

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -593,7 +593,7 @@ XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     {   if (len > 8) return XXH3_len_9to16_64b(input, len, secret, seed);
         if (len >= 4) return XXH3_len_4to8_64b(input, len, secret, seed);
         if (len) return XXH3_len_1to3_64b(input, len, secret, seed);
-        return 0;
+        return XXH3_avalanche((PRIME64_1 + seed) ^ XXH_read64(secret));
     }
 }
 
@@ -1426,7 +1426,9 @@ XXH3_len_0to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
     {   if (len > 8) return XXH3_len_9to16_128b(input, len, secret, seed);
         if (len >= 4) return XXH3_len_4to8_128b(input, len, secret, seed);
         if (len) return XXH3_len_1to3_128b(input, len, secret, seed);
-        {   XXH128_hash_t const h128 = { 0, 0 };
+        {   XXH128_hash_t h128;
+            h128.low64 = XXH3_avalanche((PRIME64_1 + seed) ^ XXH_readLE64(secret));
+            h128.high64 = XXH3_avalanche((PRIME64_2 - seed) ^ XXH_readLE64(secret+8));
             return h128;
     }   }
 }

--- a/xxh3.h
+++ b/xxh3.h
@@ -593,7 +593,7 @@ XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     {   if (len > 8) return XXH3_len_9to16_64b(input, len, secret, seed);
         if (len >= 4) return XXH3_len_4to8_64b(input, len, secret, seed);
         if (len) return XXH3_len_1to3_64b(input, len, secret, seed);
-        return XXH3_avalanche((PRIME64_1 + seed) ^ XXH_read64(secret));
+        return XXH3_avalanche((PRIME64_1 + seed) ^ XXH_readLE64(secret));
     }
 }
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -77,11 +77,11 @@ extern "C" {
  *  INLINE mode
  ******************************/
 /** XXH_INLINE_ALL (and XXH_PRIVATE_API)
- *  Implement requested xxhash functions directly in the unit.
- *  Inlining offers great performance improvement on small inputs,
- *  and dramatic ones when length is expressed as a compile-time constant.
- *  See https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html .
- *  It also removes all symbols from the public list.
+ *  Use these macros to inline xxhash in target unit.
+ *  Inlining improves performance on small inputs,
+ *  up to dramatic levels when length is expressed as a compile-time constant :
+ *  https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html .
+ *  It also keeps xxhash symbols private to the unit (they are not published).
  *  Methodology :
  *     #define XXH_INLINE_ALL
  *     #include "xxhash.h"
@@ -94,7 +94,7 @@ extern "C" {
    /* give access to advanced API, required to compile implementations */
 #  undef XXH_STATIC_LINKING_ONLY   /* avoid macro redef */
 #  define XXH_STATIC_LINKING_ONLY
-   /* make functions private */
+   /* make all functions private */
 #  undef XXH_PUBLIC_API
 #  if defined(__GNUC__)
 #    define XXH_PUBLIC_API static __inline __attribute__((unused))
@@ -107,11 +107,17 @@ extern "C" {
 #    define XXH_PUBLIC_API static
 #  endif
 
-   /* prefix all names, to avoid symbol duplicates with potential library */
+   /* This part deals with the special case where a unit wants to inline xxhash,
+    * but "xxhash.h" has already been included without XXH_INLINE_ALL,
+    * typically as part of another included *.h header file.
+    * Without further action, the new include would be ignored,
+    * and the functions would _not_ be inlined (silent failure).
+    * The following lines avoid this situation by prefixing all names,
+    * avoiding naming collision with previous include. */
 #  ifdef XXH_NAMESPACE
 #    error "XXH_INLINE_ALL with XXH_NAMESPACE is not supported"
 #    /* Note : Alternative is to #undef all symbols (it's a pretty large list).
-      * If doing nothing : it compiles, but functions are actually Not inlined.
+      * Without #error : it compiles, but functions are actually Not inlined.
       * */
 #  endif
 #  define XXH_NAMESPACE XXH_INLINE_
@@ -201,7 +207,7 @@ extern "C" {
 ***************************************/
 #define XXH_VERSION_MAJOR    0
 #define XXH_VERSION_MINOR    7
-#define XXH_VERSION_RELEASE  2
+#define XXH_VERSION_RELEASE  3
 #define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
 XXH_PUBLIC_API unsigned XXH_versionNumber (void);
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -787,8 +787,8 @@ static void BMK_sanityCheck(void)
     BMK_testXXH64(sanityBuffer,222, 0,     0xB641AE8CB691C174ULL);
     BMK_testXXH64(sanityBuffer,222, prime, 0x20CB8AB7AE10C14AULL);
 
-    BMK_testXXH3(NULL,           0, 0,       0);                      /* zero-length hash is always 0 */
-    BMK_testXXH3(NULL,           0, prime64, 0);
+    BMK_testXXH3(NULL,           0, 0,       0x383739D89B1CF3E3ULL);  /* empty string */
+    BMK_testXXH3(NULL,           0, prime64, 0xAA62E4419E745027ULL);
     BMK_testXXH3(sanityBuffer,   1, 0,       0x7198D737CFE7F386ULL);  /*  1 -  3 */
     BMK_testXXH3(sanityBuffer,   1, prime64, 0xB70252DB7161C2BDULL);  /*  1 -  3 */
     BMK_testXXH3(sanityBuffer,   6, 0,       0x22CBF5F3E1F6257CULL);  /*  4 -  8 */
@@ -819,7 +819,7 @@ static void BMK_sanityCheck(void)
 
     {   const void* const secret = sanityBuffer + 7;
         const size_t secretSize = XXH3_SECRET_SIZE_MIN + 11;
-        BMK_testXXH3_withSecret(NULL,           0, secret, secretSize, 0);                      /* zero-length hash is always 0 */
+        BMK_testXXH3_withSecret(NULL,           0, secret, secretSize, 0x367FF684075249CEULL);  /* empty string */
         BMK_testXXH3_withSecret(sanityBuffer,   1, secret, secretSize, 0x7F69735D618DB3F0ULL);  /*  1 -  3 */
         BMK_testXXH3_withSecret(sanityBuffer,   6, secret, secretSize, 0xBFCC7CB1B3554DCEULL);  /*  4 -  8 */
         BMK_testXXH3_withSecret(sanityBuffer,  12, secret, secretSize, 0x8C50DC90AC9206FCULL);  /*  9 - 16 */
@@ -836,10 +836,10 @@ static void BMK_sanityCheck(void)
     }
 
 
-    {   XXH128_hash_t const expected = { 0, 0 };
-        BMK_testXXH128(NULL,           0, 0,     expected);         /* zero-length hash is { seed, -seed } by default */
+    {   XXH128_hash_t const expected = { 0x383739D89B1CF3E3ULL, 0x877994721AD18197ULL };
+        BMK_testXXH128(NULL,           0, 0,     expected);         /* empty string */
     }
-    {   XXH128_hash_t const expected = { 0, 0 };
+    {   XXH128_hash_t const expected = { 0x6614A8A3473C59AFULL, 0xB31E50030E102FBFULL };
         BMK_testXXH128(NULL,           0, prime, expected);
     }
     {   XXH128_hash_t const expected = { 0x7198D737CFE7F386ULL, 0x153C28D2A04DC807ULL };


### PR DESCRIPTION
Following suggestion from @pdillinger, at https://github.com/Cyan4973/xxHash/issues/175#issuecomment-548108921 .

The probability of receiving an empty string is larger than random (> 1 / 2^64),
making its generated hash value "more common".

For some algorithm, it's an issue if this "more common" value is 0.

Maps it instead to an avalanche of an arbitrary start value (prime64).
The start value is blended with the `seed` and the `secret`,
so that the result is dependent on those ones too.

It makes the return value of "empty string" no longer comparable with `0.7.2`.
For this reason, the internal library version number is updated to `0.7.3`.