### PR TITLE
Simplify len [4,8] for xxh128

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1437,7 +1437,7 @@ XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
         xxh_u64 const input_64 = input_hi + ((xxh_u64)input_lo << 32);
         xxh_u64 const keyed = input_64 ^ (XXH_readLE64(secret) + seed);
 
-        XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1 + len);
+        XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1 + (len << 2));
 
         // alternative more "classical" insertion of len
         // The one above is slightly faster (135->138)

--- a/xxh3.h
+++ b/xxh3.h
@@ -1439,14 +1439,8 @@ XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
 
         XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1 + (len << 2));
 
-        // alternative more "classical" insertion of len
-        // The one above is slightly faster (135->138)
-        //XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1);
-        //m128.low64  += len;
-        //m128.high64 -= len;
-
-        m128.low64  ^= (m128.high64 >> 5);
-        m128.high64 += (m128.low64 << 3);
+        m128.high64 += (m128.low64 << 1);
+        m128.low64  ^= (m128.high64 >> 3);
 
         m128.low64   = XXH3_avalanche(m128.low64);
         m128.high64  = XXH3_avalanche(m128.high64);

--- a/xxh3.h
+++ b/xxh3.h
@@ -1408,8 +1408,8 @@ XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     {   xxh_u8 const c1 = input[0];
         xxh_u8 const c2 = input[len >> 1];
         xxh_u8 const c3 = input[len - 1];
-        xxh_u32  const combinedl = ((xxh_u32)c1) + (((xxh_u32)c2) << 8) + (((xxh_u32)c3) << 16) + (((xxh_u32)len) << 24);
-        xxh_u32  const combinedh = XXH_swap32(combinedl);
+        xxh_u32  const combinedl = ((xxh_u32)c1<<16) | (((xxh_u32)c2) << 24) | (((xxh_u32)c3) << 0) | (((xxh_u32)len) << 8);
+        xxh_u32  const combinedh = XXH_rotl32(XXH_swap32(combinedl), 13);
         xxh_u64  const keyed_lo = (xxh_u64)combinedl ^ (XXH_readLE32(secret)   + seed);
         xxh_u64  const keyed_hi = (xxh_u64)combinedh ^ (XXH_readLE32(secret+4) - seed);
         xxh_u64  const mixedl = keyed_lo * PRIME64_1;

--- a/xxh3.h
+++ b/xxh3.h
@@ -570,11 +570,17 @@ XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs)
 }
 
 
+XXH_FORCE_INLINE xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift)
+{
+    XXH_ASSERT(0 <= shift && shift < 64);
+    return v64 ^ (v64 >> shift);
+}
+
 static XXH64_hash_t XXH3_avalanche(xxh_u64 h64)
 {
-    h64 ^= h64 >> 37;
+    h64 = XXH_xorshift64(h64, 37);
     h64 *= 0x165667919E3779F9ULL;
-    h64 ^= h64 >> 32;
+    h64 = XXH_xorshift64(h64, 32);
     return h64;
 }
 
@@ -614,7 +620,7 @@ XXH3_len_4to8_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_h
                           + ((xxh_u64)input1 << 32)
                           + ((xxh_u64)(XXH_rotl32(input2,23)) << 32)
                           + len;
-        return XXH3_avalanche(mix ^ (mix >> 59));
+        return XXH3_avalanche(XXH_xorshift64(mix, 59));
     }
 }
 
@@ -926,7 +932,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
     for (i=0; i < ACC_NB; i++) {
         xxh_u64 const key64 = XXH_readLE64(xsecret + 8*i);
         xxh_u64 acc64 = xacc[i];
-        acc64 ^= acc64 >> 47;
+        acc64 = XXH_xorshift64(acc64, 47);
         acc64 ^= key64;
         acc64 *= PRIME32_1;
         xacc[i] = acc64;
@@ -1419,26 +1425,31 @@ XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     }
 }
 
-
 XXH_FORCE_INLINE XXH128_hash_t
 XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
 {
     XXH_ASSERT(input != NULL);
     XXH_ASSERT(secret != NULL);
     XXH_ASSERT(4 <= len && len <= 8);
+    seed ^= (xxh_u64)XXH_swap32((xxh_u32)seed) << 32;
     {   xxh_u32 const input_lo = XXH_readLE32(input);
         xxh_u32 const input_hi = XXH_readLE32(input + len - 4);
-        xxh_u64 const input_64_lo = input_lo + ((xxh_u64)input_hi << 32);
-        xxh_u64 const input_64_hi = XXH_swap64(input_64_lo);
-        xxh_u64 const keyed_lo = input_64_lo ^ (XXH_readLE64(secret) + seed);
-        xxh_u64 const keyed_hi = input_64_hi ^ (XXH_readLE64(secret + 8) - seed);
-        xxh_u64 const mix64l1 = len + ((keyed_lo ^ (keyed_lo >> 51)) * PRIME32_1);
-        xxh_u64 const mix64l2 = (mix64l1 ^ (mix64l1 >> 47)) * PRIME64_2;
-        xxh_u64 const mix64h1 = ((keyed_hi ^ (keyed_hi >> 47)) * PRIME64_1) - len;
-        xxh_u64 const mix64h2 = (mix64h1 ^ (mix64h1 >> 43)) * PRIME64_4;
-        {   XXH128_hash_t const h128 = { XXH3_avalanche(mix64l2) /*low64*/, XXH3_avalanche(mix64h2) /*high64*/ };
-            return h128;
-    }   }
+        xxh_u64 const input_64 = input_hi + ((xxh_u64)input_lo << 32);
+        xxh_u64 const keyed = input_64 ^ (XXH_readLE64(secret) + seed);
+        XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1);
+        m128.low64  += len;
+        m128.high64 -= len;
+        m128.low64  ^= (m128.high64 >> 5);
+        m128.high64 += (m128.low64 << 3);
+
+        // optional, quality seems good enough without it
+        //m128.low64   = XXH_xorshift64(m128.low64, 47);
+        //m128.high64  = XXH_xorshift64(m128.high64, 51);
+
+        m128.low64   = XXH3_avalanche(m128.low64);
+        m128.high64  = XXH3_avalanche(m128.high64);
+        return m128;
+    }
 }
 
 XXH_FORCE_INLINE XXH128_hash_t

--- a/xxh3.h
+++ b/xxh3.h
@@ -1436,15 +1436,17 @@ XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
         xxh_u32 const input_hi = XXH_readLE32(input + len - 4);
         xxh_u64 const input_64 = input_hi + ((xxh_u64)input_lo << 32);
         xxh_u64 const keyed = input_64 ^ (XXH_readLE64(secret) + seed);
-        XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1);
-        m128.low64  += len;
-        m128.high64 -= len;
+
+        XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1 + len);
+
+        // alternative more "classical" insertion of len
+        // The one above is slightly faster (135->138)
+        //XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1);
+        //m128.low64  += len;
+        //m128.high64 -= len;
+
         m128.low64  ^= (m128.high64 >> 5);
         m128.high64 += (m128.low64 << 3);
-
-        // optional, quality seems good enough without it
-        //m128.low64   = XXH_xorshift64(m128.low64, 47);
-        //m128.high64  = XXH_xorshift64(m128.high64, 51);
 
         m128.low64   = XXH3_avalanche(m128.low64);
         m128.high64  = XXH3_avalanche(m128.high64);


### PR DESCRIPTION
This new version is much simpler than `v0.7.2` for len [4,8].
It replaces most of the multiplications by a 64x64->128 one, which feels adequate for a 128-bit hash.
As a consequence, it runs faster on `x64` systems. Even `aarch64` prefers it.

Note however that speed on 32-bit `x86` is negatively impacted.
In the context of `xxh128`, I'm not sure though if this is a relevant platform to optimize for.

Latency test, fixed size inputs [4-8] , performance reported in Millions of Hashes per Second (MH/s) :

| arch | cpu | compiler | v0.7.2 | this PR | 
| --- | --- | --- | --- | --- | 
| `x64` | i7-8559U | Apple clang 11.0 |  130 |  161 | 
| `x64` | i7-9700K | gcc v9.2.1 | 114 | 137 | 
| `x86` | i7-9700K | gcc v9.2.1 | 83 | 73 | 
| `aarch64` | snapdragon 855 | clang v9.0.1 | 89 | 94 |  
| `armv7ve` | snapdragon 855 | clang v9.0.1 | 25 | 71 |
| `armv6t2` | snapdragon 855 | clang v9.0.1 | 62 | 72 |

This new variant features 2 minor `DiffDist` warnings, at `x2.15` and `x2.33` (limit is `x2.0`) at bits `8` and `9`.

And last issue is the usual one : the `prng` test doesn't pass, although the score is not that bad (100 with 32-bit inputs, 40 with 64-bit inputs).

Fixing this last one requires an additional rotation in the critical path, slowing down the hash noticeably.
Haven't arbitrated yet if that's worthwhile ...

