### PR TITLE
Disable autovec, force inline hashLong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
 LIBVER_PATCH := $(shell echo $(LIBVER_PATCH_SCRIPT))
 LIBVER := $(LIBVER_MAJOR).$(LIBVER_MINOR).$(LIBVER_PATCH)
 
-# Shut off autovectorization, it does more harm than goodm
+# Shut off autovectorization, it does more harm than good.
 #
 # We write SIMD when we want SIMD and scalar code when we don't.
 # On 32-bit targets, Clang tends to vectorize 64-bit mutiplies.

--- a/xxh3.h
+++ b/xxh3.h
@@ -962,17 +962,7 @@ XXH3_accumulate(     xxh_u64* XXH_RESTRICT acc,
     }
 }
 
-/* note : clang auto-vectorizes well in SS2 mode _if_ this function is `static`,
- *        and doesn't auto-vectorize it at all if it is `FORCE_INLINE`.
- *        However, it auto-vectorizes better AVX2 if it is `FORCE_INLINE`
- *        Pretty much every other modes and compilers prefer `FORCE_INLINE`.
- */
-
-#if defined(__clang__) && (XXH_VECTOR==0) && !defined(__AVX2__) && !defined(__arm__) && !defined(__thumb__)
-static void
-#else
 XXH_FORCE_INLINE void
-#endif
 XXH3_hashLong_internal_loop( xxh_u64* XXH_RESTRICT acc,
                       const xxh_u8* XXH_RESTRICT input, size_t len,
                       const xxh_u8* XXH_RESTRICT secret, size_t secretSize,


### PR DESCRIPTION
Autovectorization does more harm than good, especially on Clang+ARMv7 NEON where it assumes uint64x2_t multiplies are cheap, but in reality it scalarizes the entire operation.

XXH3_hashLong has also been FORCE_INLINEd - seems to benefit performance, and with the case of autovectorization, our handwritten intrinsics are better than anything GCC or Clang can emit.