### PR TITLE
Improve documentation of internals

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -595,6 +595,11 @@ XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_h
     XXH_ASSERT(input != NULL);
     XXH_ASSERT(1 <= len && len <= 3);
     XXH_ASSERT(secret != NULL);
+    /*
+     * len = 1: combined = { input[0], 0x01, input[0], input[0] }
+     * len = 2: combined = { input[1], 0x02, input[0], input[0] }
+     * len = 3: combined = { input[2], 0x03, input[0], input[1] }
+     */
     {   xxh_u8 const c1 = input[0];
         xxh_u8 const c2 = input[len >> 1];
         xxh_u8 const c3 = input[len - 1];
@@ -1411,6 +1416,11 @@ XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     XXH_ASSERT(input != NULL);
     XXH_ASSERT(1 <= len && len <= 3);
     XXH_ASSERT(secret != NULL);
+    /*
+     * len = 1: combinedl = { input[0], 0x01, input[0], input[0] }
+     * len = 2: combinedl = { input[1], 0x02, input[0], input[0] }
+     * len = 3: combinedl = { input[2], 0x03, input[0], input[1] }
+     */
     {   xxh_u8 const c1 = input[0];
         xxh_u8 const c2 = input[len >> 1];
         xxh_u8 const c3 = input[len - 1];

--- a/xxh3.h
+++ b/xxh3.h
@@ -1456,6 +1456,15 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
     XXH_ASSERT(9 <= len && len <= 16);
     {   xxh_u64 const input_lo = XXH_readLE64(input) ^ (XXH_readLE64(secret) + seed);
         xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret+8) - seed);
+        /*
+         * xxh_u128 m128 = input_lo | ((xxh_u128)input_hi << 64);
+         * m128 ^= (m128 >> 64);
+         * m128 *= PRIME64_1;
+         * m128 += ((xxh_u128)XXH_mult32to64(len, PRIME32_5) << 64);
+         * m128 ^= (m128 >> 96);
+         * m128 *= PRIME64_2;
+         * return XXH3_avalanche((xxh_u64)m128) | ((xxh_u128)XXH3_avalanche(m128 >> 64) << 64);
+         */
         XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
         xxh_u64 const lenContrib = XXH_mult32to64(len, PRIME32_5);
         m128.low64 += lenContrib;

--- a/xxh3.h
+++ b/xxh3.h
@@ -111,8 +111,8 @@
  * shift is larger than 32. This means:
  *  - All the bits we need are in the upper 32 bits, so we can ignore the lower
  *    32 bits in the shift.
- *  - The result will always fit in one 32-bit register, and therefore,
- *    we can ignore the high 32 bits with the xor.
+ *  - The shift result will always fit in the lower 32 bits, and therefore,
+ *    we can ignore the upper 32 bits in the xor.
  *
  * Therefore, XXH3 only requires these features to be efficient:
  *

--- a/xxh3.h
+++ b/xxh3.h
@@ -613,7 +613,7 @@ XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_h
     XXH_ASSERT(secret != NULL);
     /*
      * len = 1: combined = { input[0], 0x01, input[0], input[0] }
-     * len = 2: combined = { input[1], 0x02, input[0], input[0] }
+     * len = 2: combined = { input[1], 0x02, input[0], input[1] }
      * len = 3: combined = { input[2], 0x03, input[0], input[1] }
      */
     {   xxh_u8 const c1 = input[0];
@@ -1520,7 +1520,7 @@ XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     XXH_ASSERT(secret != NULL);
     /*
      * len = 1: combinedl = { input[0], 0x01, input[0], input[0] }
-     * len = 2: combinedl = { input[1], 0x02, input[0], input[0] }
+     * len = 2: combinedl = { input[1], 0x02, input[0], input[1] }
      * len = 3: combinedl = { input[2], 0x03, input[0], input[1] }
      */
     {   xxh_u8 const c1 = input[0];

--- a/xxh3.h
+++ b/xxh3.h
@@ -1187,7 +1187,7 @@ XXH3_hashLong_64b_withSeed(const xxh_u8* input, size_t len, XXH64_hash_t seed)
 
 /*
  * DISCLAIMER: There are known *seed-dependent* multicollisions here due to multiplication
- * by zero, affecting hashes of lengths 17 to 240, however, they are very unlilely.
+ * by zero, affecting hashes of lengths 17 to 240, however, they are very unlikely.
  *
  * Keep this in mind when using the unseeded XXH3_64bits() variant: As with all unseeded
  * non-cryptographic hashes, it does not attempt to defend itself against specially crafted

--- a/xxh3.h
+++ b/xxh3.h
@@ -780,6 +780,8 @@ typedef enum { XXH3_acc_64bits, XXH3_acc_128bits } XXH3_accWidth_e;
  * On 128-bit inputs, we swap the 128-bit lane pairs to improve cross-pollination (otherwise the
  * upper and lower halves would be essentially independent), but since this doesn't matter on
  * 64-bit hashes (they all get merged together in the end), we avoid the extra steps.
+ *
+ * Both XXH3_64bits and XXH3_128bits use this subroutine.
  */
 XXH_FORCE_INLINE void
 XXH3_accumulate_512(      void* XXH_RESTRICT acc,
@@ -967,6 +969,8 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
  * need to (or want to) mix as often or as much as HighwayHash does.
  *
  * This isn't as tight as XXH3_accumulate, but still written in SIMD to avoid extraction.
+ *
+ * Both XXH3_64bits and XXH3_128bits use this subroutine.
  */
 XXH_FORCE_INLINE void
 XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
@@ -1399,6 +1403,9 @@ XXH3_consumeStripes( xxh_u64* acc,
     }
 }
 
+/*
+ * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
+ */
 XXH_FORCE_INLINE XXH_errorcode
 XXH3_update(XXH3_state_t* state, const xxh_u8* input, size_t len, XXH3_accWidth_e accWidth)
 {

--- a/xxh3.h
+++ b/xxh3.h
@@ -711,7 +711,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
         size_t i;
         for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
             /* data_vec    = xinput[i]; */
-            __m256i const data_vec   = _mm256_loadu_si256    (xinput+i);
+            __m256i const data_vec    = _mm256_loadu_si256    (xinput+i);
             /* key_vec     = xsecret[i]; */
             __m256i const key_vec     = _mm256_loadu_si256   (xsecret+i);
             /* data_key    = data_vec ^ key_vec; */
@@ -725,7 +725,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
                 __m256i const data_swap = _mm256_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i const sum       = _mm256_add_epi64(xacc[i], data_swap);
                 /* xacc[i] += product; */
-                xacc[i] = _mm_add_epi64(product, sum);
+                xacc[i] = _mm256_add_epi64(product, sum);
             } else {  /* XXH3_acc_64bits */
                 /* xacc[i] += data_vec; */
                 __m256i const sum = _mm256_add_epi64(xacc[i], data_vec);

--- a/xxh3.h
+++ b/xxh3.h
@@ -1437,6 +1437,7 @@ XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
         xxh_u64 const input_64 = input_lo + ((xxh_u64)input_hi << 32);
         xxh_u64 const keyed = input_64 ^ (XXH_readLE64(secret) + seed);
 
+        /* Shift len to the left to ensure it is even, this avoids even multiplies. */
         XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1 + (len << 2));
 
         m128.high64 += (m128.low64 << 1);


### PR DESCRIPTION
 - Add some explanations of the algorithms
   - show 128-bit arithmetic in `9to16_128b`
   - show pieced together inputs in `1to3`
   - Mention the mum/farsh/umac influence
   - Add Google's comment about 32->64 multiply mixing quality in `XXH3_scrambleAcc`
   - Mention the switch from iterative to single shot in short hashes
 - Make the SIMD comments match and look cleaner
   - remove ancient farsh comments
   - move `_mm_shuffle_epi32` to its own line
   - no `_mm_shuffle_epi32` magic numbers
 - Minor typo fixes
 - Be transparent about the mid range collisions (unless we want to fix it which AFAIK is not planned)
   - don't see any reason to deny its existence, nothing is perfect
   - explain the unlikely probability compared to umac collisions
   - note that XXH128 isn't affected
 - use `xxh_` prefix on VSX typedefs to match scalar types
 - move 17to128 and 129to240 to a more logical location