### PR TITLE
xxh128 len[9-16] : small simplification

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1457,9 +1457,9 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
     {   xxh_u64 const input_lo = XXH_readLE64(input) ^ XXH_readLE64(secret);
         xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret+8) - seed);
         XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
-        m128.low64 += (xxh_u64)(len-1) << 54;
-        m128.high64 += input_hi + XXH_mult32to64(input_hi, PRIME32_2 - 1);
-        m128.low64  ^= m128.high64 >> 32;
+        m128.low64  += (xxh_u64)(len-1) << 54;
+        m128.high64 += input_hi + XXH_mult32to64((xxh_u32)input_hi, PRIME32_2 - 1);
+        m128.low64  ^= XXH_swap64(m128.high64);
 
         {   XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);
             h128.high64 += m128.high64 * PRIME64_2;

--- a/xxh3.h
+++ b/xxh3.h
@@ -1454,45 +1454,11 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
     XXH_ASSERT(input != NULL);
     XXH_ASSERT(secret != NULL);
     XXH_ASSERT(9 <= len && len <= 16);
-#if 0
     {   xxh_u64 const input_lo = XXH_readLE64(input) ^ XXH_readLE64(secret);
         xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret+8) - seed);
         XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
-
-        m128.low64  += len << 54;
-        m128.high64 += (input_hi + XXH_mult32to64(input_hi, PRIME32_2 - 1));
-
-        m128.high64 += (m128.low64 << 1);
-        m128.low64  ^= (m128.high64 >> 3);
-
-        m128.low64   = XXH3_avalanche(m128.low64);
-        m128.high64  = XXH3_avalanche(m128.high64);
-        return m128;
-    }
-#elif 1
-    {   xxh_u64 const input_lo = XXH_readLE64(input) ^ XXH_readLE64(secret);
-        xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret+8) - seed);
-        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
-        m128.low64  += ((len-1) << 54);
+        m128.low64 += (xxh_u64)(len-1) << 54;
         m128.high64 += input_hi + XXH_mult32to64(input_hi, PRIME32_2 - 1);
-
-        m128.low64  ^= m128.high64 >> 3;
-        m128.low64  += XXH_mult32to64(m128.low64, PRIME32_5 - 1);
-
-        m128.high64 += (m128.low64 << 1);
-        m128.high64 += XXH_mult32to64(m128.high64, PRIME32_4 - 1);
-
-        m128.low64   = XXH3_avalanche(m128.low64);
-        m128.high64  = XXH3_avalanche(m128.high64);
-        return m128;
-    }
-#elif 1
-    {   xxh_u64 const input_lo = XXH_readLE64(input) ^ XXH_readLE64(secret);
-        xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret+8) - seed);
-        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
-        m128.low64 += ((len-1) << 54);
-        m128.high64 += input_hi + XXH_mult32to64(input_hi, PRIME32_2 - 1);
-
         m128.low64  ^= m128.high64 >> 32;
 
         {   XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);
@@ -1501,21 +1467,6 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
             h128.high64  = XXH3_avalanche(h128.high64);
             return h128;
     }   }
-#else
-    {   xxh_u64 const input_lo = XXH_readLE64(input) ^ (XXH_readLE64(secret) + seed);
-        xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret+8) - seed);
-        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
-        xxh_u64 const lenContrib = XXH_mult32to64(len, PRIME32_5);
-        m128.low64 += lenContrib;
-        m128.high64 += input_hi * PRIME64_1;
-        m128.low64  ^= (m128.high64 >> 32);
-        {   XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);
-            h128.high64 += m128.high64 * PRIME64_2;
-            h128.low64   = XXH3_avalanche(h128.low64);
-            h128.high64  = XXH3_avalanche(h128.high64);
-            return h128;
-    }   }
-#endif
 }
 
 /* Assumption : `secret` size is >= 16


### PR DESCRIPTION
Insert `secret` from `input_hi` only, to avoid `xor` cancellation,
as suggested by @easyaspi314 .

Also, simplified a bit the next instructions,
resulting in a small improvement to distribution qualities.

Surprisingly, while I tested variants simplifying even more,
replacing the following larger multiplications by 2 smaller `mult32to64` ones,
or even a single one with some additional `xorshift`,
it would not result in any measurable speed benefit.

So I settled on this variant.
Long tests ongoing. No surprise expected, this variant already pass the most difficult ones.