### PR TITLE
Comments + 32-bit path for 9to16_128b, improve arch detection

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1615,24 +1615,63 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
     XXH_ASSERT(input != NULL);
     XXH_ASSERT(secret != NULL);
     XXH_ASSERT(9 <= len && len <= 16);
-    {   xxh_u64 const input_lo = XXH_readLE64(input) ^ XXH_readLE64(secret);
-        xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret+8) - seed);
-        /*
-         * xxh_u128 m128 = input_lo | ((xxh_u128)input_hi << 64);
-         * m128 ^= (m128 >> 64);
-         * m128 *= PRIME64_1;
-         * m128 += ((xxh_u128)XXH_mult32to64(len, PRIME32_5) << 64);
-         * m128 ^= (m128 >> 96);
-         * m128 *= PRIME64_2;
-         * return XXH3_avalanche((xxh_u64)m128) | ((xxh_u128)XXH3_avalanche(m128 >> 64) << 64);
-         */
+    {   xxh_u64 const input_lo = XXH_readLE64(input)           ^ (XXH_readLE64(secret));
+        xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ (XXH_readLE64(secret + 8) - seed);
         XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
-        m128.low64  += (xxh_u64)(len-1) << 54;
-        m128.high64 += input_hi + XXH_mult32to64((xxh_u32)input_hi, PRIME32_2 - 1);
+        /*
+         * Put len in the middle of m128 to ensure that the length gets mixed to both the low
+         * and high bits in the 128x64 multiply below.
+         */
+        m128.low64  += (xxh_u64)(len - 1) << 54;
+        /*
+         * Add the high 32 bits of input_hi to the high 32 bits of m128, then
+         * add the long product of the low 32 bits of input_hi and PRIME32_2 to
+         * the high 64 bits of m128.
+         *
+         * The best approach to this operation is different on 32-bit and 64-bit.
+         */
+        if (sizeof(void *) < sizeof(xxh_u64)) { /* 32-bit */
+            /*
+             * 32-bit optimized version, which is more readable.
+             *
+             * On 32-bit, it removes an ADC and delays a dependency between the two
+             * halves of m128.high64, but it generates an extra mask on 64-bit.
+             */
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64((xxh_u32)input_hi, PRIME32_2);
+        } else {
+            /*
+             * 64-bit optimized (albeit more confusing) version.
+             *
+             * Uses some properties of addition and multiplication to remove the mask:
+             *
+             * Let:
+             *    a = input_hi.lo = (input_hi & 0x00000000FFFFFFFF)
+             *    b = input_hi.hi = (input_hi & 0xFFFFFFFF00000000)
+             *    c = PRIME32_2
+             *
+             *    a + (b * c)
+             * Inverse Property: x + y - x == y
+             *    a + (b * (1 + c - 1))
+             * Distributive Property: x * (y + z) == (x * y) + (x * z)
+             *    a + (b * 1) + (b * (c - 1))
+             * Identity Property: x * 1 == x
+             *    a + b + (b * (c - 1))
+             *
+             * Substitute a, b, and c:
+             *    input_hi.hi + input_hi.lo + ((xxh_u64)input_hi.lo * (PRIME32_2 - 1))
+             *
+             * Since input_hi.hi + input_hi.lo == input_hi, we get this:
+             *    input_hi + ((xxh_u64)input_hi.lo * (PRIME32_2 - 1))
+             */
+            m128.high64 += input_hi + XXH_mult32to64((xxh_u32)input_hi, PRIME32_2 - 1);
+        }
+        /* m128 ^= XXH_swap64(m128 >> 64); */
         m128.low64  ^= XXH_swap64(m128.high64);
 
-        {   XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);
+        {   /* 128x64 multiply: h128 = m128 * PRIME64_2; */
+            XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);
             h128.high64 += m128.high64 * PRIME64_2;
+
             h128.low64   = XXH3_avalanche(h128.low64);
             h128.high64  = XXH3_avalanche(h128.high64);
             return h128;


### PR DESCRIPTION
Just some minor fixups.

Arch detection:
- MSVC x86 no longer shows up as `unknown`
- x86_64 and aarch64 always show `SSE2` and `NEON` respectively
- ARM gives more detail:
   - unaligned access
   - arch version (only number though)
   - thumb/thumb-2
   - example:
      - `ARMv6 + unaligned`
      - `ARMv4 + Thumb-1`
      - would previously show up as `arm` despite being entirely different

`9to16_128b`:
- Comments updated, switched to line-by-line because the whole thing isn't 128-bit arithmetic
- The `input_hi + XXH_mult32to64((xxh_u32)input_hi, PRIME32_2 - 1)` line is documented in detail
  - shows the usage of distributive property etc
- Add a second 32-bit path for said multiply
  - Saves a data dependency and an `adc` on 32-bit
  - Adds a mask on 64-bit
  - More reflective of the actual arithmetic