### PR TITLE
Collision tester

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,8 @@ test-all: test test32 clangtest cxxtest usan test-inline listL120 trailingWhites
 
 .PHONY: test-tools
 test-tools:
-	MOREFLAGS=-Werror $(MAKE) -C tests/bench
+	CFLAGS=-Werror $(MAKE) -C tests/bench
+	CFLAGS=-Werror $(MAKE) -C tests/collisions
 
 .PHONY: listL120
 listL120:  # extract lines >= 120 characters in *.{c,h}, by Takayuki Matsuoka (note : $$, for Makefile compatibility)

--- a/README.md
+++ b/README.md
@@ -62,17 +62,27 @@ thanks to [Takayuki Matsuoka](https://github.com/t-mat) contributions.
 The library files `xxhash.c` and `xxhash.h` are BSD licensed.
 The utility `xxhsum` is GPL licensed.
 
-### Building xxHash - Using vcpkg
 
-You can download and install xxHash using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+### New hash algorithms
 
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install xxhash
+Starting with `v0.7.0`, the library includes a new algorithm, named `XXH3`,
+able to generate 64 and 128-bits hashes.
 
-The xxHash port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The new algorithm is much faster than its predecessors,
+for both long and small inputs,
+as can be observed in following graphs :
+
+![XXH3, bargraph](https://user-images.githubusercontent.com/750081/61976096-b3a35f00-af9f-11e9-8229-e0afc506c6ec.png)
+
+![XXH3, latency, random size](https://user-images.githubusercontent.com/750081/61976089-aedeab00-af9f-11e9-9239-e5375d6c080f.png)
+
+To access these new prototypes, one needs to unlock their declaration, using build macro `XXH_STATIC_LINKING_ONLY`.
+
+The algorithm is currently in development, meaning its return values might still change in future versions.
+However, the implementation is stable, and can be used in production,
+typically for ephemeral data (produced and consumed in same session).
+`XXH3` return values will be finalized on reaching `v0.8.0`.
+
 
 ### Build modifiers
 
@@ -84,7 +94,7 @@ they modify libxxhash behavior. They are all disabled by default.
                      It's _extremely effective_ when key length is expressed as _a compile time constant_,
                      with performance improvements observed in the +200% range .
                      See [this article](https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html) for details.
-                     Note: there is no need for an `xxhash.o` object file in this case.
+                     Note: there is no need to compile an `xxhash.o` object file in this case.
 - `XXH_NO_INLINE_HINTS` : By default, xxHash uses tricks like `__attribute__((always_inline))` and `__forceinline` to try and improve performance at the cost of code size. Defining this to 1 will mark all internal functions as `static`, allowing the compiler to decide whether to inline a function or not. This is very useful when optimizing for the smallest binary size, and it is automatically defined when compiling with `-O0`, `-Os`, `-Oz`, or `-fno-inline` on GCC and Clang. This may also increase performance depending on the compiler and the architecture.
 - `XXH_REROLL` : reduce size of generated code. Impact on performance vary, depending on platform and algorithm.
 - `XXH_ACCEPT_NULL_INPUT_POINTER` : if set to `1`, when input is a `NULL` pointer,
@@ -110,6 +120,19 @@ they modify libxxhash behavior. They are all disabled by default.
 - `XXH_NO_LONG_LONG` : removes support for XXH64,
                        for targets without 64-bit support.
 - `XXH_IMPORT` : MSVC specific : should only be defined for dynamic linking, it prevents linkage errors.
+
+
+### Building xxHash - Using vcpkg
+
+You can download and install xxHash using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install xxhash
+
+The xxHash port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 
 ### Example
@@ -164,31 +187,11 @@ XXH64_hash_t calcul_hash_streaming(FileHandler fh)
 }
 ```
 
-### New experimental hash algorithm
-
-Starting with `v0.7.0`, the library includes a new algorithm, named `XXH3`,
-able to generate 64 and 128-bits hashes.
-
-The new algorithm is much faster than its predecessors,
-for both long and small inputs,
-as can be observed in following graphs :
-
-![XXH3, bargraph](https://user-images.githubusercontent.com/750081/61976096-b3a35f00-af9f-11e9-8229-e0afc506c6ec.png)
-
-![XXH3, latency, random size](https://user-images.githubusercontent.com/750081/61976089-aedeab00-af9f-11e9-9239-e5375d6c080f.png)
-
-The algorithm is currently labeled experimental, its return values can still change in future versions.
-It can already be used for ephemeral data, and for tests, but avoid storing long-term hash values yet.
-
-To access experimental prototypes, one need to unlock their declaration using macro `XXH_STATIC_LINKING_ONLY`.
-`XXH3` will be stabilized in a future version.
-This period is used to collect users' feedback.
-
 
 ### Other programming languages
 
 Beyond the C reference version,
-xxHash is also available on many programming languages,
+xxHash is also available in many programming languages,
 thanks to great contributors.
 They are [listed here](http://www.xxhash.com/#other-languages).
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ able to generate 64 and 128-bits hashes.
 
 The new algorithm is much faster than its predecessors,
 for both long and small inputs,
-as can be observed in following graphs :
+which can be observed in the following graphs :
 
 ![XXH3, bargraph](https://user-images.githubusercontent.com/750081/61976096-b3a35f00-af9f-11e9-8229-e0afc506c6ec.png)
 
 ![XXH3, latency, random size](https://user-images.githubusercontent.com/750081/61976089-aedeab00-af9f-11e9-9239-e5375d6c080f.png)
 
-To access these new prototypes, one needs to unlock their declaration, using build macro `XXH_STATIC_LINKING_ONLY`.
+To access these new prototypes, one needs to unlock their declaration, using build the macro `XXH_STATIC_LINKING_ONLY`.
 
 The algorithm is currently in development, meaning its return values might still change in future versions.
 However, the implementation is stable, and can be used in production,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,7 @@ build_script:
       make -v &&
       echo ----- &&
       if not [%PLATFORM%]==[clang] (
+        if [%PLATFORM%]==[mingw32] SET CPPFLAGS=-DPOOL_MT=0
         make -B clean test MOREFLAGS=-Werror
       ) ELSE (
         make -B clean test CC=clang CXX=clang++ MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wno-pass-failed" NO_C90_TEST=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,15 +71,17 @@ build_script:
       make -v &&
       echo ----- &&
       if not [%PLATFORM%]==[clang] (
-        if [%PLATFORM%]==[mingw32] SET CPPFLAGS=-DPOOL_MT=0
+        if [%PLATFORM%]==[mingw32] ( SET CPPFLAGS=-DPOOL_MT=0 ) &&
         make -B clean test MOREFLAGS=-Werror
       ) ELSE (
+        SET CXXFLAGS=--std=c++14 &&
         make -B clean test CC=clang CXX=clang++ MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wno-pass-failed" NO_C90_TEST=true
       ) &&
       make -C tests/bench
     )
-    # note : strict c90 tests with clang fail, due to (erroneous) presence on `inline` keyword in some included system file
-    # -Dinline= is a way to disable this keyword
+    # note 1 : strict c90 tests with clang fail, due to (erroneous) presence on `inline` keyword in some included system file
+    # note 2 : multi-threading code doesn't work with mingw32, disabled through POOL_MT=0
+    # note 3 : clang requires C++14 to compile sort because its own code contains c++14-only code
 
   - if [%COMPILER%]==[visual] (
       cd cmake_unofficial &&

--- a/tests/bench/LICENSE
+++ b/tests/bench/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/tests/bench/benchHash.c
+++ b/tests/bench/benchHash.c
@@ -3,33 +3,24 @@
 *  Part of xxHash project
 *  Copyright (C) 2019-present, Yann Collet
 *
-*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*  GPL v2 License
 *
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions are
-*  met:
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
 *
-*  * Redistributions of source code must retain the above copyright
-*  notice, this list of conditions and the following disclaimer.
-*  * Redistributions in binary form must reproduce the above
-*  copyright notice, this list of conditions and the following disclaimer
-*  in the documentation and/or other materials provided with the
-*  distribution.
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
 *
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 *
 *  You can contact the author at :
-*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash homepage : http://www.xxhash.com
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 

--- a/tests/bench/benchHash.h
+++ b/tests/bench/benchHash.h
@@ -3,33 +3,24 @@
 *  Part of xxHash project
 *  Copyright (C) 2019-present, Yann Collet
 *
-*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*  GPL v2 License
 *
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions are
-*  met:
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
 *
-*  * Redistributions of source code must retain the above copyright
-*  notice, this list of conditions and the following disclaimer.
-*  * Redistributions in binary form must reproduce the above
-*  copyright notice, this list of conditions and the following disclaimer
-*  in the documentation and/or other materials provided with the
-*  distribution.
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
 *
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 *
 *  You can contact the author at :
-*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash homepage : http://www.xxhash.com
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 

--- a/tests/bench/bhDisplay.c
+++ b/tests/bench/bhDisplay.c
@@ -3,33 +3,24 @@
 *  Part of xxHash project
 *  Copyright (C) 2019-present, Yann Collet
 *
-*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*  GPL v2 License
 *
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions are
-*  met:
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
 *
-*  * Redistributions of source code must retain the above copyright
-*  notice, this list of conditions and the following disclaimer.
-*  * Redistributions in binary form must reproduce the above
-*  copyright notice, this list of conditions and the following disclaimer
-*  in the documentation and/or other materials provided with the
-*  distribution.
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
 *
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 *
 *  You can contact the author at :
-*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash homepage : http://www.xxhash.com
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 

--- a/tests/bench/bhDisplay.h
+++ b/tests/bench/bhDisplay.h
@@ -3,33 +3,24 @@
 *  Part of xxHash project
 *  Copyright (C) 2019-present, Yann Collet
 *
-*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*  GPL v2 License
 *
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions are
-*  met:
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
 *
-*  * Redistributions of source code must retain the above copyright
-*  notice, this list of conditions and the following disclaimer.
-*  * Redistributions in binary form must reproduce the above
-*  copyright notice, this list of conditions and the following disclaimer
-*  in the documentation and/or other materials provided with the
-*  distribution.
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
 *
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 *
 *  You can contact the author at :
-*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash homepage : http://www.xxhash.com
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 

--- a/tests/bench/hashes.h
+++ b/tests/bench/hashes.h
@@ -3,33 +3,24 @@
 *  Part of xxHash project
 *  Copyright (C) 2019-present, Yann Collet
 *
-*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*  GPL v2 License
 *
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions are
-*  met:
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
 *
-*  * Redistributions of source code must retain the above copyright
-*  notice, this list of conditions and the following disclaimer.
-*  * Redistributions in binary form must reproduce the above
-*  copyright notice, this list of conditions and the following disclaimer
-*  in the documentation and/or other materials provided with the
-*  distribution.
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
 *
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 *
 *  You can contact the author at :
-*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash homepage : http://www.xxhash.com
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 

--- a/tests/bench/main.c
+++ b/tests/bench/main.c
@@ -2,34 +2,24 @@
 *  Main program to benchmark hash functions
 *  Part of xxHash project
 *  Copyright (C) 2019-present, Yann Collet
+*  GPL v2 License
 *
-*  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
 *
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions are
-*  met:
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
 *
-*  * Redistributions of source code must retain the above copyright
-*  notice, this list of conditions and the following disclaimer.
-*  * Redistributions in binary form must reproduce the above
-*  copyright notice, this list of conditions and the following disclaimer
-*  in the documentation and/or other materials provided with the
-*  distribution.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 *
 *  You can contact the author at :
-*  - xxHash homepage: http://www.xxhash.com
+*  - xxHash homepage : http://www.xxhash.com
 *  - xxHash source repository : https://github.com/Cyan4973/xxHash
 */
 

--- a/tests/collisions/.gitignore
+++ b/tests/collisions/.gitignore
@@ -1,0 +1,2 @@
+#build artefacts
+collisionsTest

--- a/tests/collisions/LICENSE
+++ b/tests/collisions/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -1,0 +1,72 @@
+#  Brute force collision tester for 64-bit hashes
+#  Part of xxHash project
+#  Copyright (C) 2012-present, Yann Collet
+#
+# GPL v2 License
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#  You can contact the author at :
+#  - xxHash homepage: http://www.xxhash.com
+#  - xxHash source repository : https://github.com/Cyan4973/xxHash
+#
+
+SRC_DIRS = ./ ../../ allcodecs/
+VPATH = $(SRC_DIRS)
+CPPFLAGS += $(addprefix -I ,$(SRC_DIRS))
+CFLAGS   ?= -std=c99 \
+            -Wall -Wextra -Wconversion
+CFLAGS   += -maes -mavx2
+CXXFLAGS ?= -Wall -Wextra -Wconversion --std=c++11
+LDFLAGS  += -pthread
+LDFLAGS  += -maes -mavx2
+TESTHASHES = 110000000
+
+.PHONY: default
+default: release
+
+.PHONY: all
+all: release
+
+collisionsTest: main.o pool.o threading.o sort.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ $(LDFLAGS) -o $@
+
+main.o: hashes.h xxh3.h xxhash.h
+
+release: CXXFLAGS += -O3
+release: CFLAGS += -O3
+release: collisionsTest
+
+debug: CXXFLAGS += -g3 -O0 -DDEBUG
+debug: CFLAGS += -g3 -O0 -DDEBUG
+debug: collisionsTest
+
+.PHONY: check
+check: test
+
+.PHONY: test
+test: debug
+	@echo ""
+	@echo "## $(TESTHASHES) hashes with original and 0 threads"
+	@time ./collisionsTest --nbh=$(TESTHASHES)
+	@echo ""
+	@echo "## $(TESTHASHES) hashes with original and 4 threads"
+	@time ./collisionsTest --nbh=$(TESTHASHES) --threadlog=2
+	@echo ""
+
+.PHONY: clean
+clean:
+	$(RM) *.o
+	$(RM) collisionsTest

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -34,13 +34,17 @@ LDFLAGS  += -pthread
 LDFLAGS  += -maes -mavx2
 TESTHASHES = 110000000
 
+HASH_SRC := $(sort $(wildcard allcodecs/*.c allcodecs/*.cc))
+HASH_OBJ := $(patsubst %.c,%.o,$(HASH_SRC))
+
+
 .PHONY: default
 default: release
 
 .PHONY: all
 all: release
 
-collisionsTest: main.o pool.o threading.o sort.o
+collisionsTest: main.o pool.o threading.o sort.o $(HASH_OBJ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ $(LDFLAGS) -o $@
 
 main.o: hashes.h xxh3.h xxhash.h
@@ -68,5 +72,5 @@ test: debug
 
 .PHONY: clean
 clean:
-	$(RM) *.o
+	$(RM) *.o allcodecs/*.o
 	$(RM) collisionsTest

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -34,7 +34,8 @@ For the default test, the expected "optimal" collision rate for a 64-bit hash fu
 
 #### Build modifier
 
-- `SLAB5` : use alternative pattern generator, more friendly to weak algorithms
+- `SLAB5` : use alternative pattern generator, friendlier for weak hash algorithms
+- `POOL_MT` : if  `=0`, disable multi-treading code (enabled by default)
 
 #### How to integrate any hash in the tester
 

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -8,7 +8,7 @@ The test requires a very large amount of memory.
 By default, it will generate 24 billion of 64-bit hashes,
 requiring __192 GB of RAM__ for their storage.
 The number of hashes can be modified using command `--nbh=`.
-be aware that testing the collision ratio of 64-bit hashes
+Be aware that testing the collision ratio of 64-bit hashes
 requires a very large amount of hashes (several billions) for meaningful measurements.
 
 To reduce RAM usage, an optional filter can be requested, with `--filter`.
@@ -47,9 +47,9 @@ it's not compatible with a C90-only compiler.
 
 #### How to integrate any hash in the tester
 
-The build script is expecting to compile files in `./allcodecs`.
+The build script is expecting to compile files found in `./allcodecs`.
 Put the source code here.
-This also works if the hash is a single `*.h` files.
+This also works if the hash is a single `*.h` file.
 
 The glue happens in `hashes.h`.
 In this file, there are 2 sections :
@@ -64,6 +64,17 @@ it should be listed.
 
 #### Usage
 
+```
+usage: ./collisionsTest [hashName] [opt]
+
+list of hashNames : (...)
+
+Optional parameters:
+--nbh=#  : select nb of hashes to generate (25769803776 by default)
+--filter : activated the filter. Reduce memory usage for same nb of hashes. Slower.
+--threadlog=# : use 2^# threads
+--len=#  : select length of input (255 bytes by default)
+```
 
 #### Some advises on how to setup a collisions test
 

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -32,6 +32,10 @@ but storage must allocate an upper bound.
 
 For the default test, the expected "optimal" collision rate for a 64-bit hash function is ~18 collisions.
 
+#### Build modifier
+
+- `SLAB5` : use alternative pattern generator, more friendly to weak algorithms
+
 #### How to integrate any hash in the tester
 
 The build script is expecting to compile files in `./allcodecs`.

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -32,6 +32,14 @@ but storage must allocate an upper bound.
 
 For the default test, the expected "optimal" collision rate for a 64-bit hash function is ~18 collisions.
 
+#### How to build
+```
+make
+```
+
+Note : the code is a mix of C99 and C++14,
+it's not compatible with a C90-only compiler.
+
 #### Build modifier
 
 - `SLAB5` : use alternative pattern generator, friendlier for weak hash algorithms
@@ -52,6 +60,9 @@ to the table, at the end of `hashed.h`
 
 Build with `make`. Locate your new hash with `./collisionsTest -h`,
 it should be listed.
+
+
+#### Usage
 
 
 #### Some advises on how to setup a collisions test

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -1,0 +1,38 @@
+
+__collisionsTest__ is a brute force hash analyzer
+which will measure a 64-bit hash algorithm's collision rate
+by generating billions of hashes,
+and comparing the result to an "ideal" target.
+
+The test requires a very large amount of memory.
+By default, it will generate 24 billion of 64-bit hashes,
+requiring 192 GB of RAM for their storage.
+The number of hashes can be modified using command `--nbh=`,
+but beware that requiring too few hashes will not provide meaningful information on the algorithm's collision performance.
+
+To reduce RAM usage, an optional filter can be requested, with `--filter`.
+It reduces the nb of candidates to analyze, hence associated RAM budget.
+Be aware that the filter also requires RAM
+(32 GB by default, can be modified using `--filterlog=`,
+a too small filter will not be efficient, aim at ~2 bytes per hash),
+and that managing the filter costs a significant CPU budget.
+
+The RAM budget will be completed by a list of candidates,
+which will be a fraction of original hash list.
+Using default settings (24 billions hashes, 32 GB filter),
+the number of potential candidates should be reduced to less than 2 billions,
+requiring ~14 GB for their storage.
+Such a result also depends on hash algorithm's efficiency.
+The number of effective candidates is likely to be lower, at ~ 1 billion,
+but storage must allocate an upper bound.
+
+For the default test, the expected "optimal" collision rate for a 64-bit hash function is ~18 collisions.
+
+Here are a few results produced with this tester :
+
+| Name        | nb Collisions | Notes |
+| ---         | ---           | ---   |
+| XXH3_64bits |   |   |
+| XXH64       |   |   |
+| XXH32       |   |   |
+| badsum      |   |   |

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -38,7 +38,7 @@ The build script is expecting to compile files in `./allcodecs`.
 Put the source code here.
 This also works if the hash is a single `*.h` files.
 
-The flue happens in `hashes.h`.
+The glue happens in `hashes.h`.
 In this file, there are 2 sections :
 - Add the required `#include "header.h"`, and create a wrapper,
 to respect the format expected by the function pointer.
@@ -51,7 +51,7 @@ it should be listed.
 
 #### Some advises on how to setup a collisions test
 
-The test is primarily driven by the amount of RAM available.
+Most tests are primarily driven by the amount of RAM available.
 Here's a method to decide the size of the test.
 
 Presuming that RAM budget is not plentiful, for this example 32 GB,
@@ -73,9 +73,21 @@ The command line becomes :
 
 Here are a few results produced with this tester :
 
-| Name        | nb Collisions | Notes |
-| ---         | ---           | ---   |
-| XXH3_64bits |   |   |
-| XXH64       |   |   |
-| XXH32       |   |   |
-| badsum      |   |   |
+| Algorithm | Input Len | Nb Hashes | Expected | Nb Collisions | Notes |
+| --- | --- | --- | --- | --- | --- |
+| __XXH3__ | 256 | 100 Gi | 312.5 | 326 |  |
+| __XXH64__ | 256 | 100 Gi | 312.5 | 294 |  |
+| __XXH128__ | 256 | 100 Gi | 0.0 | 0 | As a 128-bit hash, we expect XXH128 to generate 0 hash |
+| __XXH128__ low 64-bit | 512 | 100 Gi | 312.5 | 321 |  |
+| __XXH128__ high 64-bit | 512 | 100 Gi | 312.5 | 325 |  |
+
+Test on small inputs :
+
+| Algorithm | Input Len | Nb Hashes | Expected | Nb Collisions | Notes |
+| --- | --- | --- | --- | --- | --- |
+| __XXH3__ | 8 |  |  |  | To be restarted |
+| __XXH64__ | 8 | 100 Gi | 312.5 | __0__ | `XXH64` is bijective for `len==8` |
+| __XXH128__ | 16 | 25 Gi | 0.0 | 0 | test range 9-16 |
+| __XXH128__ | 32 | 25 Gi | 0.0 | 0 | test range 17-128 |
+| __XXH128__ | 100 | 13 Gi | 0.0 | 0 | test range 17-128 |
+| __XXH128__ | 200 | 13 Gi | 0.0 | 0 | test range 129-240 |

--- a/tests/collisions/allcodecs/README.md
+++ b/tests/collisions/allcodecs/README.md
@@ -1,0 +1,1 @@
+Put in this directory all hash algorithms to test

--- a/tests/collisions/allcodecs/dummy.c
+++ b/tests/collisions/allcodecs/dummy.c
@@ -1,0 +1,38 @@
+/* dummy.c,
+*  a fake hash algorithm, just to test integration capabilities.
+*  Part of xxHash project
+*  Copyright (C) 2012-present, Yann Collet
+*
+*  GPL v2 License
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+*  You can contact the author at :
+*  - xxHash homepage : http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+
+#include <dummy.h>
+
+unsigned badsum32(const void* input, size_t len, unsigned seed)
+{
+    unsigned sum = seed;
+    const unsigned char* in8 = input;
+    size_t c;
+    for (c=0; c<len; c++)
+        sum += in8[c];
+    return sum;
+}

--- a/tests/collisions/allcodecs/dummy.h
+++ b/tests/collisions/allcodecs/dummy.h
@@ -1,0 +1,44 @@
+/* dummy.c,
+*  a fake hash algorithm, just to test integration capabilities.
+*  Part of xxHash project
+*  Copyright (C) 2012-present, Yann Collet
+*
+*  GPL v2 License
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+*  You can contact the author at :
+*  - xxHash homepage : http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+#ifndef DUMMY_H_987987
+#define DUMMY_H_987987
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+
+#include <stddef.h> /* size_t */
+
+unsigned badsum32(const void* input, size_t len, unsigned seed);
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif  /* DUMMY_H_987987 */

--- a/tests/collisions/hashes.h
+++ b/tests/collisions/hashes.h
@@ -39,6 +39,12 @@ typedef union {
     XXH128_hash_t h128;
 } UniHash;
 
+UniHash uniHash32(uint64_t v32)
+{   UniHash unih;
+    unih.h64 = v32;
+    return unih;
+}
+
 UniHash uniHash64(uint64_t v64)
 {   UniHash unih;
     unih.h64 = v64;
@@ -81,7 +87,16 @@ UniHash XXH64_wrapper (const void* data, size_t size)
 
 UniHash XXH32_wrapper (const void* data, size_t size)
 {
-    return uniHash64( XXH32(data, size, 0) );
+    return uniHash32( XXH32(data, size, 0) );
+}
+
+/* ===  Dummy integration example  === */
+
+#include "dummy.h"
+
+UniHash badsum32_wrapper (const void* data, size_t size)
+{
+    return uniHash32( badsum32(data, size, 0) );
 }
 
 
@@ -96,7 +111,7 @@ typedef struct {
     int bits;
 } hashDescription;
 
-#define HASH_FN_TOTAL 6
+#define HASH_FN_TOTAL 7
 
 hashDescription hashfnTable[HASH_FN_TOTAL] = {
     { "xxh3"  ,  XXH3_wrapper,     64 },
@@ -105,6 +120,7 @@ hashDescription hashfnTable[HASH_FN_TOTAL] = {
     { "xxh128l", XXH128l_wrapper,  64 },
     { "xxh128h", XXH128h_wrapper,  64 },
     { "xxh32" ,  XXH32_wrapper,    32 },
+    { "badsum32",badsum32_wrapper, 32 },
 };
 
 #endif   /* HASHES_H_1235465 */

--- a/tests/collisions/hashes.h
+++ b/tests/collisions/hashes.h
@@ -1,0 +1,110 @@
+/* List of hashes for the brute force collision tester
+*  Part of xxHash project
+*  Copyright (C) 2019-present, Yann Collet
+*
+*  GPL v2 License
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+*  You can contact the author at :
+*  - xxHash homepage : http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+#ifndef HASHES_H_1235465
+#define HASHES_H_1235465
+
+#include <stddef.h>   /* size_t */
+#include <stdint.h>   /* uint64_t */
+#define XXH_INLINE_ALL   /* XXH128_hash_t */
+#include "xxhash.h"
+
+
+/* return type */
+
+typedef union {
+    uint64_t       h64;
+    XXH128_hash_t h128;
+} UniHash;
+
+UniHash uniHash64(uint64_t v64)
+{   UniHash unih;
+    unih.h64 = v64;
+    return unih;
+}
+
+UniHash uniHash128(XXH128_hash_t v128)
+{   UniHash unih;
+    unih.h128 = v128;
+    return unih;
+}
+
+
+/* ===  xxHash  === */
+
+UniHash XXH3_wrapper (const void* data, size_t size)
+{
+    return uniHash64( XXH3_64bits(data, size) );
+}
+
+UniHash XXH128_wrapper (const void* data, size_t size)
+{
+    return uniHash128( XXH3_128bits(data, size) );
+}
+
+UniHash XXH128l_wrapper (const void* data, size_t size)
+{
+    return uniHash64( XXH3_128bits(data, size).low64 );
+}
+
+UniHash XXH128h_wrapper (const void* data, size_t size)
+{
+    return uniHash64( XXH3_128bits(data, size).high64 );
+}
+
+UniHash XXH64_wrapper (const void* data, size_t size)
+{
+    return uniHash64 ( XXH64(data, size, 0) );
+}
+
+UniHash XXH32_wrapper (const void* data, size_t size)
+{
+    return uniHash64( XXH32(data, size, 0) );
+}
+
+
+
+/* ===  Table  === */
+
+typedef UniHash (*hashfn) (const void* data, size_t size);
+
+typedef struct {
+    const char* name;
+    hashfn fn;
+    int bits;
+} hashDescription;
+
+#define HASH_FN_TOTAL 6
+
+hashDescription hashfnTable[HASH_FN_TOTAL] = {
+    { "xxh3"  ,  XXH3_wrapper,     64 },
+    { "xxh64" ,  XXH64_wrapper,    64 },
+    { "xxh128",  XXH128_wrapper,  128 },
+    { "xxh128l", XXH128l_wrapper,  64 },
+    { "xxh128h", XXH128h_wrapper,  64 },
+    { "xxh32" ,  XXH32_wrapper,    32 },
+};
+
+#endif   /* HASHES_H_1235465 */

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -204,19 +204,30 @@ static inline void update_sampleFactory(sampleFactory* sf)
 
 #define SPARSE_LEVEL_MAX 15
 
+/* Nb of combinations of m bits in a register of n bits */
+static double Cnm(int n, int m)
+{
+    assert(n > 0);
+    assert(m > 0);
+    assert(m <= m);
+    double acc = 1;
+    for (int i=0; i<m; i++) {
+        acc *= n - i;
+        acc /= 1 + i;
+    }
+    return acc;
+}
+
 static int enoughCombos(size_t size, uint64_t htotal)
 {
     if (size < 2) return 0;   /* ensure no multiplication by negative */
-    uint64_t possible = 0;
-    uint64_t acc = 1;
-    uint64_t const srcBits = size * 8;
-    uint64_t nbBits = 0;
-    while (possible < htotal) {
-        acc *= srcBits - nbBits;
-        acc /= nbBits + 1;
-        possible += acc;
-        nbBits++;
-        if (nbBits >= SPARSE_LEVEL_MAX) return 0;
+    uint64_t acc = 0;
+    uint64_t const srcBits = size * 8; assert(srcBits < INT_MAX);
+    int nbBitsSet = 0;
+    while (acc < htotal) {
+        nbBitsSet++;
+        if (nbBitsSet >= SPARSE_LEVEL_MAX) return 0;
+        acc += (uint64_t)Cnm((int)srcBits, nbBitsSet);
     }
     return 1;
 }

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -1,0 +1,1040 @@
+/* Brute force collision tester for 64-bit hashes
+*  Part of xxHash project
+*  Copyright (C) 2012-present, Yann Collet
+*
+*  GPL v2 License
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+*  You can contact the author at :
+*  - xxHash homepage : http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/*
+ * The collision tester will generate 24 billions hashes (by default),
+ * and count how many collisions were produced by the 64-bit hash algorithm.
+ * The optimal amount of collisions for 64-bit is ~18 collisions.
+ * A good hash should be close to this figure.
+ *
+ * This program requires a lot of memory :
+ * - Either store hash values directly => 192 GB
+ * - Either use a filter :
+ *   -  32 GB (by default) for the filter itself
+ *   -  + ~14 GB for the list of hashes (depending on filter outcome)
+ * Due to these memory constraints, it requires a 64-bit system.
+ */
+
+
+ /* ===  Dependencies  === */
+
+#include <stdint.h>   /* uint64_t */
+#include <stdlib.h>   /* malloc, free, qsort, exit */
+#include <string.h>   /* memset */
+#include <stdio.h>    /* printf, fflush */
+
+#undef NDEBUG   /* ensure assert is _not_ disabled */
+#include <assert.h>
+
+#include "hashes.h"   /* UniHash, hashfn, hashfnTable */
+
+#include "sort.hh"    /* sort64 */
+
+
+
+typedef enum { ht64, ht128 } Htype_e;
+
+/* ===  Debug  === */
+
+#define EXIT(...) { printf(__VA_ARGS__); printf("\n"); exit(1); }
+
+static void hexRaw(const void* buffer, size_t size)
+{
+    const unsigned char* p = (const unsigned char*)buffer;
+    for (size_t i=0; i<size; i++) {
+        printf("%02X", p[i]);
+    }
+}
+
+void hexDisp(const void* buffer, size_t size)
+{
+    hexRaw(buffer, size);
+    printf("\n");
+}
+
+static void printHash(const void* table, size_t n, Htype_e htype)
+{
+    if (htype == ht64) {
+        uint64_t const h64 = ((const uint64_t*)table)[n];
+        hexRaw(&h64, sizeof(h64));
+    } else {
+        assert(htype == ht128);
+        XXH128_hash_t const h128 = ((const XXH128_hash_t*)table)[n];
+        hexRaw(&h128, sizeof(h128));
+    }
+}
+
+/* ===  Generate Random unique Samples to hash  === */
+
+/* These functions will generate and update a sample to hash.
+ * initSample() will fill a buffer with random bytes,
+ * updateSample() will modify one slab in the input buffer.
+ * updateSample() guarantees it will produce unique samples,
+ * but it needs to know the total number of samples.
+ */
+
+
+static const uint64_t prime64_1 = 11400714785074694791ULL;   /* 0b1001111000110111011110011011000110000101111010111100101010000111 */
+static const uint64_t prime64_2 = 14029467366897019727ULL;   /* 0b1100001010110010101011100011110100100111110101001110101101001111 */
+static const uint64_t prime64_3 =  1609587929392839161ULL;   /* 0b0001011001010110011001111011000110011110001101110111100111111001 */
+
+static uint64_t avalanche64(uint64_t h64)
+{
+    h64 ^= h64 >> 33;
+    h64 *= prime64_2;
+    h64 ^= h64 >> 29;
+    h64 *= prime64_3;
+    h64 ^= h64 >> 32;
+    return h64;
+}
+
+unsigned char randomByte(size_t n)
+{
+    uint64_t n64 = avalanche64(n+1);
+    n64 *= prime64_1;
+    return (unsigned char)(n64 >> 56);
+}
+
+
+#if 0
+
+/* Slab5 sample generation.
+ * It is generally more friendly to hash algorithms,
+ * because it flips many bits per update,
+ * without fitting common per4 or per8 ingestion patterns.
+ */
+
+#define SLAB_SIZE 5
+void initSample(void* buffer, size_t size, uint64_t htotal)
+{
+    uint64_t const minNbSlabs = ((htotal-1) >> 32) + 1;
+    uint64_t const minSize = minNbSlabs * SLAB_SIZE;
+    if (size < minSize)
+        EXIT("sample size must be >= %i bytes for this amount of hashes",
+            (int)minSize);
+
+    unsigned char* const p = (unsigned char*)buffer;
+    for (size_t n=0; n<size; n++)
+        p[n] = randomByte(n);
+}
+
+static inline void updateSample(void* buffer, size_t size, uint64_t hnb)
+{
+    size_t const nbSlabs = size / SLAB_SIZE;
+    size_t const SlabNb = hnb % nbSlabs;
+
+    char* const ptr = (char*)buffer;
+    size_t const start = (SlabNb * SLAB_SIZE) + 1;
+    uint32_t val32;
+    memcpy(&val32, ptr+start, sizeof(val32));
+    static const uint32_t prime32_5 = 374761393U;
+    val32 += prime32_5;
+    memcpy(ptr+start, &val32, sizeof(val32));
+}
+
+#else
+
+/* Sparse sample generation.
+ * This pattern only flips one bit most of the time.
+ * It's supposed to be more difficult for weak hash algorithms,
+ * for both collisions rate and bias detection.
+ * Note there is no bias analysis yet in this test tool.
+ */
+
+#define SPARSE_LEVEL_MAX 15
+
+static int enoughCombos(size_t size, uint64_t htotal)
+{
+    if (size < 2) return 0;   /* ensure no multiplication by negative */
+    uint64_t possible = 0;
+    uint64_t acc = 1;
+    uint64_t const srcBits = size * 8;
+    uint64_t nbBits = 0;
+    while (possible < htotal) {
+        acc *= srcBits - nbBits;
+        acc /= nbBits + 1;
+        possible += acc;
+        nbBits++;
+        if (nbBits >= SPARSE_LEVEL_MAX) return 0;
+    }
+    return 1;
+}
+
+typedef enum { sf_slab5, sf_sparse } sf_genMode;
+
+typedef struct {
+    void* buffer;
+    size_t size;
+    sf_genMode mode;
+    /* sparse */
+    size_t bitIdx[SPARSE_LEVEL_MAX];
+    int level;
+    size_t maxBitIdx;
+    /* slab5 */
+    size_t nbSlabs;
+    size_t current;
+    size_t prngSeed;
+} sampleFactory;
+
+static void init_sampleFactory(sampleFactory* sf, uint64_t htotal)
+{
+    if (!enoughCombos(sf->size, htotal)) {
+        EXIT("sample size must be larger for this amount of hashes");
+    }
+
+    memset(sf->bitIdx, 0, sizeof(sf->bitIdx));
+    sf->level = 0;
+
+    unsigned char* const p = (unsigned char*)sf->buffer;
+    for (size_t n=0; n<sf->size; n++)
+        p[n] = randomByte(sf->prngSeed + n);
+}
+
+static sampleFactory*
+create_sampleFactory(size_t size, uint64_t htotal, uint64_t seed)
+{
+    sampleFactory* const sf = malloc(sizeof(sampleFactory));
+    if (!sf) EXIT("not enough memory");
+    void* const buffer = malloc(size);
+    if (!buffer) EXIT("not enough memory");
+    sf->buffer = buffer;
+    sf->size = size;
+    sf->mode = sf_sparse;
+    sf->maxBitIdx = size * 8;
+    sf->prngSeed = seed;
+    init_sampleFactory(sf, htotal);
+    return sf;
+}
+
+static void free_sampleFactory(sampleFactory* sf)
+{
+    if (!sf) return;
+    free(sf->buffer);
+    free(sf);
+}
+
+static void flipbit(void* buffer, uint64_t bitID)
+{
+    size_t const pos = bitID >> 3;
+    unsigned char const mask = (unsigned char)(1 << (bitID & 7));
+    unsigned char* const p = (unsigned char*)buffer;
+    p[pos] ^= mask;
+}
+
+static int updateBit(void* buffer, size_t* bitIdx, int level, size_t max)
+{
+    if (level==0) return 0;   /* can't progress further */
+
+    flipbit(buffer, bitIdx[level]); /* erase previous bits */
+
+    if (bitIdx[level] < max-1) { /* simple case : go to next bit */
+        bitIdx[level]++;
+        flipbit(buffer, bitIdx[level]); /* set new bit */
+        return 1;
+    }
+
+    /* reached last bit : need to update a bit from lower level */
+    if (!updateBit(buffer, bitIdx, level-1, max-1)) return 0;
+    bitIdx[level] = bitIdx[level-1] + 1;
+    flipbit(buffer, bitIdx[level]); /* set new bit */
+    return 1;
+}
+
+static inline void update_sampleFactory(sampleFactory* sf)
+{
+    if (!updateBit(sf->buffer, sf->bitIdx, sf->level, sf->maxBitIdx)) {
+        /* no more room => move to next level */
+        sf->level++;
+        assert(sf->level < SPARSE_LEVEL_MAX);
+
+        /* set new bits */
+        for (int i=1; i <= sf->level; i++) {
+            sf->bitIdx[i] = (size_t)(i-1);
+            flipbit(sf->buffer, sf->bitIdx[i]);
+        }
+    }
+}
+
+#endif /* pattern generator selection */
+
+
+/* ===  Candidate Filter  === */
+
+typedef unsigned char Filter;
+
+Filter* create_Filter(int bflog)
+{
+    assert(bflog < 64 && bflog > 1);
+    size_t bfsize = (size_t)1 << bflog;
+    Filter* bf = malloc(bfsize);
+    assert(((void)"Filter creation failed", bf));
+    memset(bf, 0, bfsize);
+    return bf;
+}
+
+void free_Filter(Filter* bf)
+{
+    free(bf);
+}
+
+#ifdef FILTER_1_PROBE
+
+/* Attach hash to a slot
+ * return : Nb of potential collision candidates detected
+ *          0 : position not yet occupied
+ *          2 : position previously occupied by a single candidate
+ *          1 : position already occupied by multiple candidates
+ */
+inline int Filter_insert(Filter* bf, int bflog, uint64_t hash)
+{
+    int const slotNb = hash & 3;
+    int const shift = slotNb * 2 ;
+
+    size_t const bfmask = ((size_t)1 << bflog) - 1;
+    size_t const pos = (hash >> 2) & bfmask;
+
+    int const existingCandidates = ((((unsigned char*)bf)[pos]) >> shift) & 3;
+
+    static const int addCandidates[4] = { 0, 2, 1, 1 };
+    static const int nextValue[4] = { 1, 2, 3, 3 };
+
+    ((unsigned char*)bf)[pos] |= (unsigned char)(nextValue[existingCandidates] << shift);
+    return addCandidates[existingCandidates];
+}
+
+/* Check if provided 64-bit hash is a collision candidate
+ * Requires the slot to be occupied by at least 2 candidates.
+ * return >0 if hash is collision candidate
+ *         0 otherwise (slot unoccupied, or only one candidate)
+ * note: slot unoccupied should not happen in this algorithm,
+ *       since all hashes are supposed to have been inserted at least once.
+ */
+inline int Filter_check(const Filter* bf, int bflog, uint64_t hash)
+{
+    int const slotNb = hash & 3;
+    int const shift = slotNb * 2;
+
+    size_t const bfmask = ((size_t)1 << bflog) - 1;
+    size_t const pos = (hash >> 2) & bfmask;
+
+    return (((const unsigned char*)bf)[pos]) >> (shift+1) & 1;
+}
+
+#else
+
+/* 2-probes strategy,
+ * more efficient at filtering candidates,
+ * requires filter size to be > nb of hashes */
+
+#define MIN(a,b)   ((a) < (b) ? (a) : (b))
+#define MAX(a,b)   ((a) > (b) ? (a) : (b))
+
+ /* Attach hash to 2 slots
+  * return : Nb of potential candidates detected
+  *          0 : position not yet occupied
+  *          2 : position previously occupied by a single candidate (at most)
+  *          1 : position already occupied by multiple candidates
+  */
+static inline int Filter_insert(Filter* bf, int bflog, uint64_t hash)
+ {
+     hash = avalanche64(hash);
+     unsigned const slot1 = hash & 255;
+     hash >>= 8;
+     unsigned const slot2 = hash & 255;
+     hash >>= 8;
+
+     size_t const fclmask = ((size_t)1 << (bflog-6)) - 1;
+     size_t const cacheLineNb = hash & fclmask;
+
+     size_t const pos1 = (cacheLineNb << 6) + (slot1 >> 2);
+     unsigned const shift1 = (slot1 & 3) * 2;
+     unsigned const ex1 = (bf[pos1] >> shift1) & 3;
+
+     size_t const pos2 = (cacheLineNb << 6) + (slot2 >> 2);
+     unsigned const shift2 = (slot2 & 3) * 2;
+     unsigned const ex2 = (bf[pos2] >> shift2) & 3;
+
+     unsigned const existing = MIN(ex1, ex2);
+
+     static const int addCandidates[4] = { 0, 2, 1, 1 };
+     static const unsigned nextValue[4] = { 1, 2, 3, 3 };
+
+     bf[pos1] &= (Filter)(~(3 << shift1)); /* erase previous value */
+     bf[pos1] |= (Filter)(MAX(ex1, nextValue[existing]) << shift1);
+     bf[pos2] |= (Filter)(MAX(ex2, nextValue[existing]) << shift2);
+
+     return addCandidates[existing];
+ }
+
+
+ /* Check if provided 64-bit hash is a collision candidate
+  * Requires the slot to be occupied by at least 2 candidates.
+  * return >0 if hash is collision candidate
+  *         0 otherwise (slot unoccupied, or only one candidate)
+  * note: slot unoccupied should not happen in this algorithm,
+  *       since all hashes are supposed to have been inserted at least once.
+  */
+static inline int Filter_check(const Filter* bf, int bflog, uint64_t hash)
+ {
+     hash = avalanche64(hash);
+     unsigned const slot1 = hash & 255;
+     hash >>= 8;
+     unsigned const slot2 = hash & 255;
+     hash >>= 8;
+
+     size_t const fclmask = ((size_t)1 << (bflog-6)) - 1;
+     size_t const cacheLineNb = hash & fclmask;
+
+     size_t const pos1 = (cacheLineNb << 6) + (slot1 >> 2);
+     unsigned const shift1 = (slot1 & 3) * 2;
+     unsigned const ex1 = (bf[pos1] >> shift1) & 3;
+
+     size_t const pos2 = (cacheLineNb << 6) + (slot2 >> 2);
+     unsigned const shift2 = (slot2 & 3) * 2;
+     unsigned const ex2 = (bf[pos2] >> shift2) & 3;
+
+     return (ex1 >= 2) && (ex2 >= 2);
+ }
+
+#endif // FILTER_1_PROBE
+
+
+/* ===  Display  === */
+
+#include <time.h>   /* clock_t, clock, time_t, time, difftime */
+
+void update_indicator(uint64_t v, uint64_t total)
+{
+    static clock_t start = 0;
+    if (start==0) start = clock();
+    clock_t const updateRate = CLOCKS_PER_SEC / 2;
+
+    clock_t const clockSpan = (clock_t)(clock() - start);
+    if (clockSpan > updateRate) {
+        start = clock();
+        assert(v <= total);
+        assert(total > 0);
+        double share = ((double)v / (double)total) * 100;
+        printf("%6.2f%% (%llu)  \r", share, (unsigned long long)v);
+        fflush(NULL);
+    }
+}
+
+/* note : not thread safe */
+const char* displayDelay(double delay_s)
+{
+    static char delayString[50];
+    memset(delayString, 0, sizeof(delayString));
+
+    int const mn = ((int)delay_s / 60) % 60;
+    int const h = (int)delay_s / 3600;
+    int const sec = (int)delay_s % 60;
+
+    char* p = delayString;
+    if (h) sprintf(p, "%i h ", h);
+    if (mn || h) {
+        p = delayString + strlen(delayString);
+        sprintf(p, "%i mn ", mn);
+    }
+    p = delayString + strlen(delayString);
+    sprintf(p, "%is ", sec);
+
+    return delayString;
+}
+
+
+/* ===  Math  === */
+
+static double power(uint64_t base, int p)
+{
+    double value = 1;
+    assert(p>=0);
+    for (int i=0; i<p; i++) {
+        value *= (double)base;
+    }
+    return value;
+}
+
+static double estimateNbCollisions(uint64_t nbH, int nbBits)
+{
+    return ((double)nbH * (double)(nbH-1)) / power(2, nbBits+1);
+}
+
+static int highestBitSet(uint64_t v)
+{
+    assert(v!=0);
+    int bitId = 0;
+    while (v >>= 1) bitId++;
+    return bitId;
+}
+
+
+/* ===  Filter and search collisions  === */
+
+#undef NDEBUG   /* ensure assert is not disabled */
+#include <assert.h>
+
+/* will recommend 24 billion samples for 64-bit hashes,
+ * expecting 18 collisions for a good 64-bit hash */
+#define NB_BITS_MAX 64   /* can't store nor analyze hash wider than 64-bits for the time being */
+uint64_t select_nbh(int nbBits)
+{
+    assert(nbBits > 0);
+    if (nbBits > NB_BITS_MAX) nbBits = NB_BITS_MAX;
+    double targetColls = (double)((128 + 17) - (nbBits * 2));
+    uint64_t nbH = 24;
+    while (estimateNbCollisions(nbH, nbBits) < targetColls) nbH *= 2;
+    return nbH;
+}
+
+
+typedef struct {
+    uint64_t nbCollisions;
+} searchCollisions_results;
+
+typedef struct {
+    uint64_t nbH;
+    uint64_t mask;
+    uint64_t maskSelector;
+    size_t sampleSize;
+    uint64_t prngSeed;
+    int filterLog;      /* <0 = disable filter;  0= auto-size; */
+    int hashID;
+    int display;
+    int nbThreads;
+    searchCollisions_results* resultPtr;
+} searchCollisions_parameters;
+
+#define DISPLAY(...) { if (display) printf(__VA_ARGS__); }
+
+static int isEqual(void* hTablePtr, size_t index1, size_t index2, Htype_e htype)
+{
+    if (htype == ht64) {
+        uint64_t const h1 = ((const uint64_t*)hTablePtr)[index1];
+        uint64_t const h2 = ((const uint64_t*)hTablePtr)[index2];
+        return (h1 == h2);
+    } else {
+        assert(htype == ht128);
+        XXH128_hash_t const h1 = ((const XXH128_hash_t*)hTablePtr)[index1];
+        XXH128_hash_t const h2 = ((const XXH128_hash_t*)hTablePtr)[index2];
+        return XXH128_isEqual(h1, h2);
+    }
+}
+
+static int isHighEqual(void* hTablePtr, size_t index1, size_t index2, Htype_e htype, int rShift)
+{
+    uint64_t h1, h2;
+    if (htype == ht64) {
+        h1 = ((const uint64_t*)hTablePtr)[index1];
+        h2 = ((const uint64_t*)hTablePtr)[index2];
+    } else {
+        assert(htype == ht128);
+        h1 = ((const XXH128_hash_t*)hTablePtr)[index1].high64;
+        h2 = ((const XXH128_hash_t*)hTablePtr)[index2].high64;
+        assert(rShift >= 64);
+        rShift -= 64;
+    }
+    assert(0 <= rShift && rShift < 64);
+    return (h1 >> rShift) == (h2 >> rShift);
+}
+
+/* assumption : (htype*)hTablePtr[index] is valid */
+static void addHashCandidate(void* hTablePtr, UniHash h, Htype_e htype, size_t index)
+{
+    if (htype == ht64) {
+        ((uint64_t*)hTablePtr)[index] = h.h64;
+    } else {
+        assert(htype == ht128);
+        ((XXH128_hash_t*)hTablePtr)[index] = h.h128;
+    }
+}
+
+static size_t search_collisions(
+    searchCollisions_parameters param)
+{
+    uint64_t totalH = param.nbH;
+    const uint64_t hMask = param.mask;
+    const uint64_t hSelector = param.maskSelector;
+    int bflog = param.filterLog;
+    const int filter = (param.filterLog >= 0);
+    const size_t sampleSize = param.sampleSize;
+    const int hashID = param.hashID;
+    const Htype_e htype = (hashfnTable[hashID].bits == 64) ? ht64 : ht128;
+    const int display = param.display;
+    /* init */
+    sampleFactory* const sf = create_sampleFactory(sampleSize, totalH, param.prngSeed);
+    if (!sf) EXIT("not enough memory");
+
+    //const char* const hname = hashfnTable[hashID].name;
+    hashfn const hfunction = hashfnTable[hashID].fn;
+    int const hwidth = hashfnTable[hashID].bits;
+    if (totalH == 0) totalH = select_nbh(hwidth);
+    if (bflog == 0) bflog = highestBitSet(totalH) + 1;   /* auto-size filter */
+    uint64_t const bfsize = (1ULL << bflog);
+
+
+    /* ===  filter hashes (optional)  === */
+
+    Filter* bf = NULL;
+    uint64_t nbPresents = totalH;
+
+    if (filter) {
+        time_t const filterTBegin = time(NULL);
+        DISPLAY(" create filter (%i GB) \n", (int)(bfsize >> 30));
+        bf = create_Filter(bflog);
+        if (!bf) EXIT("not enough memory for filter");
+
+
+        DISPLAY(" generate %llu hashes from samples of %u bytes \n",
+                (unsigned long long)totalH, (unsigned)sampleSize);
+        nbPresents = 0;
+
+        for (uint64_t n=0; n < totalH; n++) {
+            if (display && ((n&0xFFFFF) == 1) )
+                update_indicator(n, totalH);
+            update_sampleFactory(sf);
+
+            UniHash const h = hfunction(sf->buffer, sampleSize);
+            if ((h.h64 & hMask) != hSelector) continue;
+
+            nbPresents += (uint64_t)Filter_insert(bf, bflog, h.h64);
+        }
+
+        if (nbPresents==0) {
+            DISPLAY(" analysis completed : no collision detected \n");
+            if (param.resultPtr) param.resultPtr->nbCollisions = 0;
+            free_Filter(bf);
+            free_sampleFactory(sf);
+            return 0;
+        }
+
+        {   double const filterDelay = difftime(time(NULL), filterTBegin);
+            DISPLAY(" generation and filter completed in %s, detected up to %llu candidates \n",
+                    displayDelay(filterDelay), (unsigned long long) nbPresents);
+    }   }
+
+
+    /* === store hash candidates : duplicates will be present here === */
+
+    time_t const storeTBegin = time(NULL);
+    size_t const hashByteSize = (htype == ht64) ? 8 : 16; assert(htype == ht64 || (htype == ht128));
+    size_t const tableSize = (nbPresents+1) * hashByteSize;
+    assert(tableSize > nbPresents);  /* check tableSize calculation overflow */
+    DISPLAY(" store hash candidates (%i MB) \n", (int)(tableSize >> 20));
+
+    /* Generate and store hashes */
+    void* const hashCandidates = malloc(tableSize);
+    if (!hashCandidates) EXIT("not enough memory to store candidates");
+    init_sampleFactory(sf, totalH);
+    size_t nbCandidates = 0;
+    for (uint64_t n=0; n < totalH; n++) {
+        if (display && ((n&0xFFFFF) == 1) ) update_indicator(n, totalH);
+        update_sampleFactory(sf);
+
+        UniHash const h = hfunction(sf->buffer, sampleSize);
+        if ((h.h64 & hMask) != hSelector) continue;
+
+        if (filter) {
+            if (Filter_check(bf, bflog, h.h64)) {
+                assert(nbCandidates < nbPresents);
+                addHashCandidate(hashCandidates, h, htype, nbCandidates++);
+            }
+        } else {
+            assert(nbCandidates < nbPresents);
+            addHashCandidate(hashCandidates, h, htype, nbCandidates++);
+        }
+    }
+    if (nbCandidates < nbPresents) {
+        /* try to mitigate gnuc_quicksort behavior, by reducing allocated memory,
+         * since gnuc_quicksort uses a lot of additional memory for mergesort */
+        void* const checkPtr = realloc(hashCandidates, nbCandidates * hashByteSize);
+        assert(checkPtr != NULL);
+        assert(checkPtr == hashCandidates);  /* simplification : since we are reducing size,
+                                              * we hope to keep the same ptr position.
+                                              * Otherwise, hashCandidates must be mutable */
+        DISPLAY(" list of hash reduced to %u MB from %u MB (saved %u MB) \n",
+                (unsigned)((nbCandidates * hashByteSize) >> 20),
+                (unsigned)(tableSize >> 20),
+                (unsigned)((tableSize - (nbCandidates * hashByteSize)) >> 20) );
+    }
+    double const storeTDelay = difftime(time(NULL), storeTBegin);
+    DISPLAY(" stored %llu hash candidates in %s \n",
+            (unsigned long long) nbCandidates, displayDelay(storeTDelay));
+    free_Filter(bf);
+    free_sampleFactory(sf);
+
+
+    /* === step 3 : look for duplicates === */
+    time_t const sortTBegin = time(NULL);
+    DISPLAY(" sorting candidates... ");
+    fflush(NULL);
+    if (htype == ht64) {
+        sort64(hashCandidates, nbCandidates); /* using C++ sort, as it's faster than C stdlib's qsort,
+                                               * and doesn't suffer from gnuc_libsort memory expansion */
+    } else {
+        assert(htype == ht128);
+        sort128(hashCandidates, nbCandidates); /* sort with custom comparator */
+    }
+    double const sortTDelay = difftime(time(NULL), sortTBegin);
+    DISPLAY(" completed in %s \n", displayDelay(sortTDelay));
+
+    /* scan and count duplicates */
+    time_t const countBegin = time(NULL);
+    DISPLAY(" looking for duplicates : ");
+    fflush(NULL);
+    size_t collisions = 0;
+    for (size_t n=1; n<nbCandidates; n++) {
+        if (isEqual(hashCandidates, n, n-1, htype)) {
+            printf("collision : ");
+            printHash(hashCandidates, n, htype);
+            printf(" / ");
+            printHash(hashCandidates, n-1, htype);
+            printf(" \n");
+            collisions++;
+    }   }
+
+    if (!filter /* all candidates */ && display /*single thead*/ ) {
+        /* check partial bitfields (high bits) */
+        DISPLAY(" \n");
+        int const hashBits = (htype == ht64) ? 64 : 128;
+        double worstRatio = 0.;
+        int worstNbHBits = 0;
+        for (int nbHBits = 1; nbHBits < hashBits; nbHBits++) {
+            uint64_t const nbSlots = (uint64_t)1 << nbHBits;
+            double const expectedCollisions = estimateNbCollisions(nbCandidates, nbHBits);
+            if ( (nbSlots > nbCandidates * 100)  /* within range for meaningfull collision analysis results */
+              && (expectedCollisions > 18.0) ) {
+                int const rShift = hashBits - nbHBits;
+                size_t HBits_collisions = 0;
+                for (size_t n=1; n<nbCandidates; n++) {
+                    if (isHighEqual(hashCandidates, n, n-1, htype, rShift)) {
+                        HBits_collisions++;
+                }   }
+                double const collisionRatio = (double)HBits_collisions / expectedCollisions;
+                if (collisionRatio > 2.0) DISPLAY("WARNING !!!  ===> ");
+                DISPLAY(" high %i bits : %zu collision (%.1f expected) : x%.2f \n",
+                        nbHBits, HBits_collisions, expectedCollisions, collisionRatio);
+                if (collisionRatio > worstRatio) {
+                    worstNbHBits = nbHBits;
+                    worstRatio = collisionRatio;
+        }   }   }
+        DISPLAY("Worst collision ratio at %i high bits : x%.2f \n",
+                worstNbHBits, worstRatio);
+    }
+    double const countDelay = difftime(time(NULL), countBegin);
+    DISPLAY(" completed in %s \n", displayDelay(countDelay));
+
+    /* clean and exit */
+    free (hashCandidates);
+
+#if 0  /* debug */
+    for (size_t n=0; n<nbCandidates; n++)
+        printf("0x%016llx \n", (unsigned long long)hashCandidates[n]);
+#endif
+
+    if (param.resultPtr) param.resultPtr->nbCollisions = collisions;
+    return collisions;
+}
+
+
+
+#if defined(__MACH__) || defined(__linux__)
+#include <sys/resource.h>
+static size_t getProcessMemUsage(int children)
+{
+    struct rusage stats;
+    if (getrusage(children ? RUSAGE_CHILDREN : RUSAGE_SELF, &stats) == 0)
+      return (size_t)stats.ru_maxrss;
+    return 0;
+}
+#else
+static size_t getProcessMemUsage(int ignore) { return 0; }
+#endif
+
+void time_collisions(searchCollisions_parameters param)
+{
+    uint64_t totalH = param.nbH;
+    int hashID = param.hashID;
+    int display = param.display;
+
+    /* init */
+    assert(0 <= hashID && hashID < HASH_FN_TOTAL);
+    //const char* const hname = hashfnTable[hashID].name;
+    int const hwidth = hashfnTable[hashID].bits;
+    if (totalH == 0) totalH = select_nbh(hwidth);
+    double const targetColls = estimateNbCollisions(totalH, hwidth);
+
+    /* Start the timer to measure start/end of hashing + collision detection. */
+    time_t const programTBegin = time(NULL);
+
+    /* Generate hashes, and count collisions */
+    size_t const collisions = search_collisions(param);
+
+    /* display results */
+    double const programTDelay = difftime(time(NULL), programTBegin);
+    size_t const programBytesSelf = getProcessMemUsage(0);
+    size_t const programBytesChildren = getProcessMemUsage(1);
+    DISPLAY("\n\n");
+    DISPLAY("===>   found  %llu collisions (x%.2f, %.1f expected) in %s\n",
+            (unsigned long long)collisions,
+            (double)collisions / targetColls,
+            targetColls,
+            displayDelay(programTDelay));
+    if (programBytesSelf)
+      DISPLAY("===>   MaxRSS(self) %zuMB, MaxRSS(children) %zuMB\n",
+              programBytesSelf>>20,
+              programBytesChildren>>20);
+    DISPLAY("------------------------------------------ \n");
+}
+
+void MT_searchCollisions(void* payload)
+{
+    searchCollisions_parameters* const paramsPtr = (searchCollisions_parameters*) payload;
+    search_collisions(*paramsPtr);
+}
+
+/* ===  Command Line  === */
+
+/*! readU64FromChar() :
+ *  allows and interprets K, KB, KiB, M, MB and MiB suffix.
+ *  Will also modify `*stringPtr`, advancing it to position where it stopped reading.
+ */
+static uint64_t readU64FromChar(const char** stringPtr)
+{
+    static uint64_t const max = (((uint64_t)(-1)) / 10) - 1;
+    uint64_t result = 0;
+    while ((**stringPtr >='0') && (**stringPtr <='9')) {
+        assert(result < max);
+        result *= 10;
+        result += (unsigned)(**stringPtr - '0');
+        (*stringPtr)++ ;
+    }
+    if ((**stringPtr=='K') || (**stringPtr=='M') || (**stringPtr=='G')) {
+        uint64_t const maxK = ((uint64_t)(-1)) >> 10;
+        assert(result < maxK);
+        result <<= 10;
+        if ((**stringPtr=='M') || (**stringPtr=='G')) {
+            assert(result < maxK);
+            result <<= 10;
+            if (**stringPtr=='G') {
+                assert(result < maxK);
+                result <<= 10;
+            }
+        }
+        (*stringPtr)++;  /* skip `K` or `M` */
+        if (**stringPtr=='i') (*stringPtr)++;
+        if (**stringPtr=='B') (*stringPtr)++;
+    }
+    return result;
+}
+
+
+/** longCommandWArg() :
+ *  check if *stringPtr is the same as longCommand.
+ *  If yes, @return 1 and advances *stringPtr to the position which immediately follows longCommand.
+ * @return 0 and doesn't modify *stringPtr otherwise.
+ */
+static int longCommandWArg(const char** stringPtr, const char* longCommand)
+{
+    size_t const comSize = strlen(longCommand);
+    int const result = !strncmp(*stringPtr, longCommand, comSize);
+    if (result) *stringPtr += comSize;
+    return result;
+}
+
+
+#include "pool.h"
+
+/* As some hashes use different algorithms depending on input size,
+ * it can be necessary to test multiple input sizes
+ * to paint an accurage picture on collision performance */
+#define SAMPLE_SIZE_DEFAULT 256
+#define HASHFN_ID_DEFAULT 0
+
+void help(const char* exeName)
+{
+    printf("usage: %s [hashName] [opt] \n\n", exeName);
+    printf("list of hashNames : ");
+    printf("%s ", hashfnTable[0].name);
+    for (int i=1; i < HASH_FN_TOTAL; i++) {
+        printf(", %s ", hashfnTable[i].name);
+    }
+    printf(" \n");
+    printf("default hashName is %s \n", hashfnTable[HASHFN_ID_DEFAULT].name);
+
+    printf(" \n");
+    printf("Optional parameters: \n");
+    printf("--filter : activated the filter. Reduce memory usage for same nb of hashes. Slower. \n");
+    printf("--len=#  : select length of input (%i bytes by default) \n", SAMPLE_SIZE_DEFAULT);
+    printf("--nbh=#  : select nb of hashes to generate (%llu by default) \n", (unsigned long long)select_nbh(64));
+}
+
+int bad_argument(const char* exeName)
+{
+    printf("incorrect command : \n");
+    help(exeName);
+    return 1;
+}
+
+
+int main(int argc, const char** argv)
+{
+    if (sizeof(size_t) < 8) return 1;  // cannot work on systems without ability to allocate objects >= 4 GB
+
+    assert(argc > 0);
+    const char* const exeName = argv[0];
+    uint64_t totalH = 0;  /* auto, based on nbBits */
+    int bflog = 0;    /* auto */
+    int filter = 0;   /* disabled */
+    size_t sampleSize = SAMPLE_SIZE_DEFAULT;
+    int hashID = HASHFN_ID_DEFAULT;
+    int threadlog = 0;
+    uint64_t prngSeed = 0;
+
+    int arg_nb;
+    for (arg_nb = 1; arg_nb < argc; arg_nb++) {
+        const char** arg = argv + arg_nb;
+
+        if (!strcmp(*arg, "-h")) { help(exeName); return 0; }
+        if (longCommandWArg(arg, "-T")) { threadlog = (int)readU64FromChar(arg); continue; }
+
+        if (!strcmp(*arg, "--filter"))    { filter=1; continue; }
+        if (!strcmp(*arg, "--no-filter")) { filter=0; continue; }
+
+        if (longCommandWArg(arg, "--seed")) { prngSeed = readU64FromChar(arg); continue; }
+        if (longCommandWArg(arg, "--nbh=")) { totalH = readU64FromChar(arg); continue; }
+        if (longCommandWArg(arg, "--filter=")) { filter=1; bflog = (int)readU64FromChar(arg); assert(bflog < 64); continue; }
+        if (longCommandWArg(arg, "--filterlog=")) { filter=1; bflog = (int)readU64FromChar(arg); assert(bflog < 64); continue; }
+        if (longCommandWArg(arg, "--size=")) { sampleSize = (size_t)readU64FromChar(arg); continue; }
+        if (longCommandWArg(arg, "--len=")) { sampleSize = (size_t)readU64FromChar(arg); continue; }
+        if (longCommandWArg(arg, "--threadlog=")) { threadlog = (int)readU64FromChar(arg); continue; }
+
+        /* argument understood as hash name (must be correct) */
+        int hnb;
+        for (hnb=0; hnb < HASH_FN_TOTAL; hnb++) {
+            if (!strcmp(*arg, hashfnTable[hnb].name)) { hashID = hnb; break; }
+        }
+        if (hnb == HASH_FN_TOTAL) return bad_argument(exeName);
+    }
+
+    /* init */
+    const char* const hname = hashfnTable[hashID].name;
+    int const hwidth = hashfnTable[hashID].bits;
+    if (totalH == 0) totalH = select_nbh(hwidth);
+    double const targetColls = estimateNbCollisions(totalH, hwidth);
+    if (bflog == 0) bflog = highestBitSet(totalH) + 1;   /* auto-size filter */
+    if (!filter) bflog = -1; // disable filter
+
+    if (sizeof(size_t) < 8)
+      EXIT("This program has not been validated on architectures other than "
+           "64bit \n");
+
+    printf(" *** Collision tester for 64+ bit hashes ***  \n\n");
+    printf("Testing %s algorithm (%i-bit) \n", hname, hwidth);
+    printf("This program will allocate a lot of memory, \n");
+    printf("generate %llu %i-bit hashes from samples of %u bytes, \n",
+            (unsigned long long)totalH, hwidth, (unsigned)sampleSize);
+    printf("and attempt to produce %.0f collisions. \n\n", targetColls);
+
+    int const nbThreads = 1 << threadlog;
+    if (nbThreads <= 0) EXIT("Invalid --threadlog value.");
+
+    if (nbThreads == 1) {
+
+        searchCollisions_parameters params;
+        params.nbH = totalH;
+        params.mask = 0;
+        params.maskSelector = 0;
+        params.sampleSize = sampleSize;
+        params.filterLog = bflog;
+        params.hashID = hashID;
+        params.display = 1;
+        params.resultPtr = NULL;
+        params.prngSeed = prngSeed;
+        params.nbThreads = 1;
+        time_collisions(params);
+
+    } else { /*  nbThreads > 1 */
+
+        /* use multithreading */
+        if (threadlog >= 30) EXIT("too many threads requested");
+        if ((uint64_t)nbThreads > (totalH >> 16))
+            EXIT("too many threads requested");
+        if (bflog > 0 && threadlog > (bflog-10))
+            EXIT("too many threads requested");
+        printf("using %i threads ... \n", nbThreads);
+
+        /* allocation */
+        time_t const programTBegin = time(NULL);
+        POOL_ctx* const pt = POOL_create((size_t)nbThreads, 1);
+        if (!pt) EXIT("not enough memory for threads");
+        searchCollisions_results* const MTresults = calloc (sizeof(searchCollisions_results), (size_t)nbThreads);
+        if (!MTresults) EXIT("not enough memory");
+        searchCollisions_parameters* const MTparams = calloc (sizeof(searchCollisions_parameters), (size_t)nbThreads);
+        if (!MTparams) EXIT("not enough memory");
+
+        /* distribute jobs */
+        for (int tnb=0; tnb<nbThreads; tnb++) {
+            MTparams[tnb].nbH = totalH;
+            MTparams[tnb].mask = (uint64_t)nbThreads - 1;
+            MTparams[tnb].sampleSize = sampleSize;
+            MTparams[tnb].filterLog = bflog ? bflog - threadlog : 0;
+            MTparams[tnb].hashID = hashID;
+            MTparams[tnb].display = 0;
+            MTparams[tnb].resultPtr = MTresults+tnb;
+            MTparams[tnb].prngSeed = prngSeed;
+            MTparams[tnb].maskSelector = (uint64_t)tnb;
+            POOL_add(pt, MT_searchCollisions, MTparams + tnb);
+        }
+        POOL_free(pt);  /* actually joins and free */
+
+        /* Gather results */
+        uint64_t nbCollisions=0;
+        for (int tnb=0; tnb<nbThreads; tnb++) {
+            nbCollisions += MTresults[tnb].nbCollisions;
+        }
+
+        double const programTDelay = difftime(time(NULL), programTBegin);
+        size_t const programBytesSelf = getProcessMemUsage(0);
+        size_t const programBytesChildren = getProcessMemUsage(1);
+        printf("\n\n");
+        printf("===>   found  %llu collisions (x%.2f, %.1f expected) in %s \n",
+                (unsigned long long)nbCollisions,
+                (double)nbCollisions / targetColls,
+                targetColls,
+                displayDelay(programTDelay));
+        if (programBytesSelf)
+          printf("===>   MaxRSS(self) %zuMB, MaxRSS(children) %zuMB\n",
+                 programBytesSelf>>20,
+                 programBytesChildren>>20);
+        printf("------------------------------------------ \n");
+
+        /* Clean up */
+        free(MTparams);
+        free(MTresults);
+    }
+
+    return 0;
+}

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -888,7 +888,7 @@ static int longCommandWArg(const char** stringPtr, const char* longCommand)
 /* As some hashes use different algorithms depending on input size,
  * it can be necessary to test multiple input sizes
  * to paint an accurage picture on collision performance */
-#define SAMPLE_SIZE_DEFAULT 256
+#define SAMPLE_SIZE_DEFAULT 255
 #define HASHFN_ID_DEFAULT 0
 
 void help(const char* exeName)

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -374,7 +374,7 @@ inline int Filter_insert(Filter* bf, int bflog, uint64_t hash)
 
 /* Check if provided 64-bit hash is a collision candidate
  * Requires the slot to be occupied by at least 2 candidates.
- * return >0 if hash is collision candidate
+ * return >0 if hash is a collision candidate
  *         0 otherwise (slot unoccupied, or only one candidate)
  * note: slot unoccupied should not happen in this algorithm,
  *       since all hashes are supposed to have been inserted at least once.
@@ -935,7 +935,7 @@ static int longCommandWArg(const char** stringPtr, const char* longCommand)
 
 /* As some hashes use different algorithms depending on input size,
  * it can be necessary to test multiple input sizes
- * to paint an accurage picture on collision performance */
+ * to paint an accurate picture on collision performance */
 #define SAMPLE_SIZE_DEFAULT 255
 #define HASHFN_ID_DEFAULT 0
 
@@ -954,7 +954,7 @@ void help(const char* exeName)
     printf("Optional parameters: \n");
     printf("--nbh=#  : select nb of hashes to generate (%llu by default) \n", (unsigned long long)select_nbh(64));
     printf("--filter : activated the filter. Reduce memory usage for same nb of hashes. Slower. \n");
-    printf("---threadlog=# : use 2^# threads \n");
+    printf("--threadlog=# : use 2^# threads \n");
     printf("--len=#  : select length of input (%i bytes by default) \n", SAMPLE_SIZE_DEFAULT);
 }
 

--- a/tests/collisions/pool.c
+++ b/tests/collisions/pool.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+
+/* ======   Dependencies   ======= */
+#include <stddef.h>    /* size_t */
+#include <stdlib.h>    /* malloc, calloc, free */
+#include <string.h>    /* memcpy */
+#include <assert.h>
+
+#include "pool.h"
+
+
+/* ======   Compiler specifics   ====== */
+#if defined(_MSC_VER)
+#  pragma warning(disable : 4204)        /* disable: C4204: non-constant aggregate initializer */
+#endif
+
+
+/* ===  Build Macro  === */
+
+#ifndef POOL_MT   // can be defined on command line
+#  define POOL_MT 1
+#endif
+
+
+/* ===  Implementation  === */
+
+#if POOL_MT
+
+#include "threading.h"   /* pthread adaptation */
+
+/* A job is a function and an opaque argument */
+typedef struct POOL_job_s {
+    POOL_function function;
+    void *opaque;
+} POOL_job;
+
+struct POOL_ctx_s {
+    /* Keep track of the threads */
+    ZSTD_pthread_t* threads;
+    size_t threadCapacity;
+    size_t threadLimit;
+
+    /* The queue is a circular buffer */
+    POOL_job *queue;
+    size_t queueHead;
+    size_t queueTail;
+    size_t queueSize;
+
+    /* The number of threads working on jobs */
+    size_t numThreadsBusy;
+    /* Indicates if the queue is empty */
+    int queueEmpty;
+
+    /* The mutex protects the queue */
+    ZSTD_pthread_mutex_t queueMutex;
+    /* Condition variable for pushers to wait on when the queue is full */
+    ZSTD_pthread_cond_t queuePushCond;
+    /* Condition variables for poppers to wait on when the queue is empty */
+    ZSTD_pthread_cond_t queuePopCond;
+    /* Indicates if the queue is shutting down */
+    int shutdown;
+};
+
+/* POOL_thread() :
+ * Work thread for the thread pool.
+ * Waits for jobs and executes them.
+ * @returns : NULL on failure else non-null.
+ */
+static void* POOL_thread(void* opaque)
+{
+    POOL_ctx* const ctx = (POOL_ctx*)opaque;
+    if (!ctx) { return NULL; }
+    for (;;) {
+        /* Lock the mutex and wait for a non-empty queue or until shutdown */
+        ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+
+        while ( ctx->queueEmpty
+            || (ctx->numThreadsBusy >= ctx->threadLimit) ) {
+            if (ctx->shutdown) {
+                /* even if !queueEmpty, (possible if numThreadsBusy >= threadLimit),
+                 * a few threads will be shutdown while !queueEmpty,
+                 * but enough threads will remain active to finish the queue */
+                ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+                return opaque;
+            }
+            ZSTD_pthread_cond_wait(&ctx->queuePopCond, &ctx->queueMutex);
+        }
+        /* Pop a job off the queue */
+        {   POOL_job const job = ctx->queue[ctx->queueHead];
+            ctx->queueHead = (ctx->queueHead + 1) % ctx->queueSize;
+            ctx->numThreadsBusy++;
+            ctx->queueEmpty = ctx->queueHead == ctx->queueTail;
+            /* Unlock the mutex, signal a pusher, and run the job */
+            ZSTD_pthread_cond_signal(&ctx->queuePushCond);
+            ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+
+            job.function(job.opaque);
+
+            /* If the intended queue size was 0, signal after finishing job */
+            ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+            ctx->numThreadsBusy--;
+            if (ctx->queueSize == 1) {
+                ZSTD_pthread_cond_signal(&ctx->queuePushCond);
+            }
+            ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+        }
+    }  /* for (;;) */
+    assert(0);  /* Unreachable */
+}
+
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize)
+{
+    POOL_ctx* ctx;
+    /* Check parameters */
+    if (!numThreads) { return NULL; }
+    /* Allocate the context and zero initialize */
+    ctx = (POOL_ctx*)calloc(1, sizeof(POOL_ctx));
+    if (!ctx) { return NULL; }
+    /* Initialize the job queue.
+     * It needs one extra space since one space is wasted to differentiate
+     * empty and full queues.
+     */
+    ctx->queueSize = queueSize + 1;
+    ctx->queue = (POOL_job*)malloc(ctx->queueSize * sizeof(POOL_job));
+    ctx->queueHead = 0;
+    ctx->queueTail = 0;
+    ctx->numThreadsBusy = 0;
+    ctx->queueEmpty = 1;
+    (void)ZSTD_pthread_mutex_init(&ctx->queueMutex, NULL);
+    (void)ZSTD_pthread_cond_init(&ctx->queuePushCond, NULL);
+    (void)ZSTD_pthread_cond_init(&ctx->queuePopCond, NULL);
+    ctx->shutdown = 0;
+    /* Allocate space for the thread handles */
+    ctx->threads = (ZSTD_pthread_t*)malloc(numThreads * sizeof(ZSTD_pthread_t));
+    ctx->threadCapacity = 0;
+    /* Check for errors */
+    if (!ctx->threads || !ctx->queue) { POOL_free(ctx); return NULL; }
+    /* Initialize the threads */
+    {   size_t i;
+        for (i = 0; i < numThreads; ++i) {
+            if (ZSTD_pthread_create(&ctx->threads[i], NULL, &POOL_thread, ctx)) {
+                ctx->threadCapacity = i;
+                POOL_free(ctx);
+                return NULL;
+        }   }
+        ctx->threadCapacity = numThreads;
+        ctx->threadLimit = numThreads;
+    }
+    return ctx;
+}
+
+/*! POOL_join() :
+    Shutdown the queue, wake any sleeping threads, and join all of the threads.
+*/
+static void POOL_join(POOL_ctx* ctx) {
+    /* Shut down the queue */
+    ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+    ctx->shutdown = 1;
+    ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+
+    /* Wake up sleeping threads */
+    ZSTD_pthread_cond_broadcast(&ctx->queuePushCond);
+    ZSTD_pthread_cond_broadcast(&ctx->queuePopCond);
+
+    /* Join all of the threads */
+    {   size_t i;
+        for (i = 0; i < ctx->threadCapacity; ++i) {
+            ZSTD_pthread_join(ctx->threads[i], NULL);  /* note : could fail */
+    }   }
+}
+
+void POOL_free(POOL_ctx *ctx) {
+    if (!ctx) { return; }
+    POOL_join(ctx);
+    ZSTD_pthread_mutex_destroy(&ctx->queueMutex);
+    ZSTD_pthread_cond_destroy(&ctx->queuePushCond);
+    ZSTD_pthread_cond_destroy(&ctx->queuePopCond);
+    free(ctx->queue);
+    free(ctx->threads);
+    free(ctx);
+}
+
+
+
+size_t POOL_sizeof(POOL_ctx *ctx) {
+    if (ctx==NULL) return 0;  /* supports sizeof NULL */
+    return sizeof(*ctx)
+        + ctx->queueSize * sizeof(POOL_job)
+        + ctx->threadCapacity * sizeof(ZSTD_pthread_t);
+}
+
+
+/* @return : 0 on success, 1 on error */
+static int POOL_resize_internal(POOL_ctx* ctx, size_t numThreads)
+{
+    if (numThreads <= ctx->threadCapacity) {
+        if (!numThreads) return 1;
+        ctx->threadLimit = numThreads;
+        return 0;
+    }
+    /* numThreads > threadCapacity */
+    {   ZSTD_pthread_t* const threadPool = (ZSTD_pthread_t*)malloc(numThreads * sizeof(ZSTD_pthread_t));
+        if (!threadPool) return 1;
+        /* replace existing thread pool */
+        memcpy(threadPool, ctx->threads, ctx->threadCapacity * sizeof(*threadPool));
+        free(ctx->threads);
+        ctx->threads = threadPool;
+        /* Initialize additional threads */
+        {   size_t threadId;
+            for (threadId = ctx->threadCapacity; threadId < numThreads; ++threadId) {
+                if (ZSTD_pthread_create(&threadPool[threadId], NULL, &POOL_thread, ctx)) {
+                    ctx->threadCapacity = threadId;
+                    return 1;
+            }   }
+    }   }
+    /* successfully expanded */
+    ctx->threadCapacity = numThreads;
+    ctx->threadLimit = numThreads;
+    return 0;
+}
+
+/* @return : 0 on success, 1 on error */
+int POOL_resize(POOL_ctx* ctx, size_t numThreads)
+{
+    int result;
+    if (ctx==NULL) return 1;
+    ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+    result = POOL_resize_internal(ctx, numThreads);
+    ZSTD_pthread_cond_broadcast(&ctx->queuePopCond);
+    ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+    return result;
+}
+
+/**
+ * Returns 1 if the queue is full and 0 otherwise.
+ *
+ * When queueSize is 1 (pool was created with an intended queueSize of 0),
+ * then a queue is empty if there is a thread free _and_ no job is waiting.
+ */
+static int isQueueFull(POOL_ctx const* ctx) {
+    if (ctx->queueSize > 1) {
+        return ctx->queueHead == ((ctx->queueTail + 1) % ctx->queueSize);
+    } else {
+        return (ctx->numThreadsBusy == ctx->threadLimit) ||
+               !ctx->queueEmpty;
+    }
+}
+
+
+static void POOL_add_internal(POOL_ctx* ctx, POOL_function function, void *opaque)
+{
+    POOL_job const job = {function, opaque};
+    assert(ctx != NULL);
+    if (ctx->shutdown) return;
+
+    ctx->queueEmpty = 0;
+    ctx->queue[ctx->queueTail] = job;
+    ctx->queueTail = (ctx->queueTail + 1) % ctx->queueSize;
+    ZSTD_pthread_cond_signal(&ctx->queuePopCond);
+}
+
+void POOL_add(POOL_ctx* ctx, POOL_function function, void* opaque)
+{
+    assert(ctx != NULL);
+    ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+    /* Wait until there is space in the queue for the new job */
+    while (isQueueFull(ctx) && (!ctx->shutdown)) {
+        ZSTD_pthread_cond_wait(&ctx->queuePushCond, &ctx->queueMutex);
+    }
+    POOL_add_internal(ctx, function, opaque);
+    ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+}
+
+
+int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque)
+{
+    assert(ctx != NULL);
+    ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+    if (isQueueFull(ctx)) {
+        ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+        return 0;
+    }
+    POOL_add_internal(ctx, function, opaque);
+    ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+    return 1;
+}
+
+
+#else  /* POOL_MT  not defined */
+
+/* ========================== */
+/* No multi-threading support */
+/* ========================== */
+
+
+/* We don't need any data, but if it is empty, malloc() might return NULL. */
+struct POOL_ctx_s {
+    int dummy;
+};
+static POOL_ctx g_ctx;
+
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize) {
+    (void)numThreads;
+    (void)queueSize;
+    return &g_ctx;
+}
+
+void POOL_free(POOL_ctx* ctx) {
+    assert(!ctx || ctx == &g_ctx);
+    (void)ctx;
+}
+
+int POOL_resize(POOL_ctx* ctx, size_t numThreads) {
+    (void)ctx; (void)numThreads;
+    return 0;
+}
+
+void POOL_add(POOL_ctx* ctx, POOL_function function, void* opaque) {
+    (void)ctx;
+    function(opaque);
+}
+
+int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque) {
+    (void)ctx;
+    function(opaque);
+    return 1;
+}
+
+size_t POOL_sizeof(POOL_ctx* ctx) {
+    if (ctx==NULL) return 0;  /* supports sizeof NULL */
+    assert(ctx == &g_ctx);
+    return sizeof(*ctx);
+}
+
+#endif  /* ZSTD_MULTITHREAD */

--- a/tests/collisions/pool.h
+++ b/tests/collisions/pool.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+#ifndef POOL_H
+#define POOL_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+
+#include <stddef.h>   /* size_t */
+
+typedef struct POOL_ctx_s POOL_ctx;
+
+/*! POOL_create() :
+ *  Create a thread pool with at most `numThreads` threads.
+ * `numThreads` must be at least 1.
+ *  The maximum number of queued jobs before blocking is `queueSize`.
+ * @return : POOL_ctx pointer on success, else NULL.
+*/
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize);
+
+/*! POOL_free() :
+ *  Free a thread pool returned by POOL_create().
+ */
+void POOL_free(POOL_ctx* ctx);
+
+/*! POOL_resize() :
+ *  Expands or shrinks pool's number of threads.
+ *  This is more efficient than releasing + creating a new context,
+ *  since it tries to preserve and re-use existing threads.
+ * `numThreads` must be at least 1.
+ * @return : 0 when resize was successful,
+ *           !0 (typically 1) if there is an error.
+ *    note : only numThreads can be resized, queueSize remains unchanged.
+ */
+int POOL_resize(POOL_ctx* ctx, size_t numThreads);
+
+/*! POOL_sizeof() :
+ * @return threadpool memory usage
+ *  note : compatible with NULL (returns 0 in this case)
+ */
+size_t POOL_sizeof(POOL_ctx* ctx);
+
+/*! POOL_function :
+ *  The function type that can be added to a thread pool.
+ */
+typedef void (*POOL_function)(void*);
+
+/*! POOL_add() :
+ *  Add the job `function(opaque)` to the thread pool. `ctx` must be valid.
+ *  Possibly blocks until there is room in the queue.
+ *  Note : The function may be executed asynchronously,
+ *         therefore, `opaque` must live until function has been completed.
+ */
+void POOL_add(POOL_ctx* ctx, POOL_function function, void* opaque);
+
+
+/*! POOL_tryAdd() :
+ *  Add the job `function(opaque)` to thread pool _if_ a worker is available.
+ *  Returns immediately even if not (does not block).
+ * @return : 1 if successful, 0 if not.
+ */
+int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque);
+
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/tests/collisions/sort.cc
+++ b/tests/collisions/sort.cc
@@ -1,0 +1,58 @@
+/* sort.cc - C++ sort functions
+*
+*  Copyright (C) 2019-present, Yann Collet
+*  GPL v2 License
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+*  You can contact the author at :
+*  - xxHash homepage : http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+/* C++ sort functions tend to run faster than C ones
+ * due to template-like inline optimizations.
+ * Also, the glibc's qsort() seems to inflate memory budget
+ * resulting in OOM crashes on server.
+ */
+
+#include <algorithm>  // std::sort
+#define XXH_INLINE_ALL  /* XXH128_cmp */
+#include <xxhash.h>
+
+#include "sort.hh"
+
+void sort64(uint64_t* table, size_t size)
+{
+    std::sort(table, table + size);
+}
+
+#include <stdlib.h>  // qsort
+
+void sort128(XXH128_hash_t* table, size_t size)
+{
+#if 0
+    // C++ sort using a custom function object
+    struct {
+        bool operator()(XXH128_hash_t a, XXH128_hash_t b) const
+        {
+            return XXH128_cmp(&a, &b);
+        }
+    } customLess;
+    std::sort(table, table + size, customLess);
+#else
+    qsort(table, size, sizeof(*table), XXH128_cmp);
+#endif
+}

--- a/tests/collisions/sort.hh
+++ b/tests/collisions/sort.hh
@@ -1,0 +1,40 @@
+/* sort.hh - headers for C++ sort functions
+*
+*  Copyright (C) 2019-present, Yann Collet
+*  GPL v2 License
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along
+*  with this program; if not, write to the Free Software Foundation, Inc.,
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+*  You can contact the author at :
+*  - xxHash homepage : http://www.xxhash.com
+*  - xxHash source repository : https://github.com/Cyan4973/xxHash
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>   // size
+#include <stdint.h>   // uint64_t
+#define XXH_STATIC_LINKING_ONLY  // XXH128_hash_t
+#include "xxhash.h"
+
+void sort64(uint64_t* table, size_t size);
+
+void sort128(XXH128_hash_t* table, size_t size);
+
+#ifdef __cplusplus
+}  // extern C
+#endif

--- a/tests/collisions/threading.c
+++ b/tests/collisions/threading.c
@@ -76,7 +76,7 @@ int ZSTD_pthread_join(ZSTD_pthread_t thread, void **value_ptr)
     case WAIT_ABANDONED:
         return EINVAL;
     default:
-        return GetLastError();
+        return (int)GetLastError();
     }
 }
 

--- a/tests/collisions/threading.c
+++ b/tests/collisions/threading.c
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016 Tino Reichardt
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ *
+ * You can contact the author at:
+ * - zstdmt source repository: https://github.com/mcmilk/zstdmt
+ */
+
+/**
+ * This file will hold wrapper for systems, which do not support pthreads
+ */
+
+
+ /* ===  Build Macro  === */
+
+ #ifndef POOL_MT   // can be defined on command line
+ #  define POOL_MT 1
+ #endif
+
+
+/* create fake symbol to avoid empty translation unit warning */
+int g_ZSTD_threading_useles_symbol;
+
+#if POOL_MT && defined(_WIN32)
+
+/**
+ * Windows minimalist Pthread Wrapper, based on :
+ * http://www.cse.wustl.edu/~schmidt/win32-cv-1.html
+ */
+
+
+/* ===  Dependencies  === */
+#include <process.h>
+#include <errno.h>
+#include "threading.h"
+
+
+/* ===  Implementation  === */
+
+static unsigned __stdcall worker(void *arg)
+{
+    ZSTD_pthread_t* const thread = (ZSTD_pthread_t*) arg;
+    thread->arg = thread->start_routine(thread->arg);
+    return 0;
+}
+
+int ZSTD_pthread_create(ZSTD_pthread_t* thread, const void* unused,
+            void* (*start_routine) (void*), void* arg)
+{
+    (void)unused;
+    thread->arg = arg;
+    thread->start_routine = start_routine;
+    thread->handle = (HANDLE) _beginthreadex(NULL, 0, worker, thread, 0, NULL);
+
+    if (!thread->handle)
+        return errno;
+    else
+        return 0;
+}
+
+int ZSTD_pthread_join(ZSTD_pthread_t thread, void **value_ptr)
+{
+    DWORD result;
+
+    if (!thread.handle) return 0;
+
+    result = WaitForSingleObject(thread.handle, INFINITE);
+    switch (result) {
+    case WAIT_OBJECT_0:
+        if (value_ptr) *value_ptr = thread.arg;
+        return 0;
+    case WAIT_ABANDONED:
+        return EINVAL;
+    default:
+        return GetLastError();
+    }
+}
+
+#endif   /* POOL_MT */

--- a/tests/collisions/threading.h
+++ b/tests/collisions/threading.h
@@ -32,15 +32,11 @@ extern "C" {
  * Windows minimalist Pthread Wrapper, based on :
  * http://www.cse.wustl.edu/~schmidt/win32-cv-1.html
  */
-#ifdef WINVER
-#  undef WINVER
-#  define WINVER       0x0600
-#endif
+#undef WINVER
+#define WINVER       0x0600
 
-#ifdef _WIN32_WINNT
-#  undef _WIN32_WINNT
-#  define _WIN32_WINNT 0x0600
-#endif
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
 
 #ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN

--- a/tests/collisions/threading.h
+++ b/tests/collisions/threading.h
@@ -29,18 +29,19 @@ extern "C" {
 #if POOL_MT && defined(_WIN32)
 
 /**
- * Windows minimalist Pthread Wrapper, based on :
- * http://www.cse.wustl.edu/~schmidt/win32-cv-1.html
+ * Define windows version before include
  */
-#undef WINVER
+#undef  WINVER
 #define WINVER       0x0600
 
-#undef _WIN32_WINNT
+#undef  _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
 
 #ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
 #endif
+
+#include "windows.h"
 
 /* mutex */
 #define ZSTD_pthread_mutex_t           CRITICAL_SECTION

--- a/tests/collisions/threading.h
+++ b/tests/collisions/threading.h
@@ -34,23 +34,17 @@ extern "C" {
  */
 #ifdef WINVER
 #  undef WINVER
+#  define WINVER       0x0600
 #endif
-#define WINVER       0x0600
 
 #ifdef _WIN32_WINNT
 #  undef _WIN32_WINNT
+#  define _WIN32_WINNT 0x0600
 #endif
-#define _WIN32_WINNT 0x0600
 
 #ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
 #endif
-
-#undef ERROR   /* reported already defined on VS 2015 (Rich Geldreich) */
-#include <windows.h>
-#undef ERROR
-#define ERROR(name) ZSTD_ERROR(name)
-
 
 /* mutex */
 #define ZSTD_pthread_mutex_t           CRITICAL_SECTION

--- a/tests/collisions/threading.h
+++ b/tests/collisions/threading.h
@@ -41,7 +41,8 @@ extern "C" {
 #  define WIN32_LEAN_AND_MEAN
 #endif
 
-#include "windows.h"
+#include <windows.h>
+#include <stdio.h>
 
 /* mutex */
 #define ZSTD_pthread_mutex_t           CRITICAL_SECTION

--- a/tests/collisions/threading.h
+++ b/tests/collisions/threading.h
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016 Tino Reichardt
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ *
+ * You can contact the author at:
+ * - zstdmt source repository: https://github.com/mcmilk/zstdmt
+ */
+
+#ifndef THREADING_H_938743
+#define THREADING_H_938743
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/* ===  Build Macro  === */
+
+#ifndef POOL_MT   // can be defined on command line
+#  define POOL_MT 1
+#endif
+
+
+/* ===  Implementation  === */
+
+#if POOL_MT && defined(_WIN32)
+
+/**
+ * Windows minimalist Pthread Wrapper, based on :
+ * http://www.cse.wustl.edu/~schmidt/win32-cv-1.html
+ */
+#ifdef WINVER
+#  undef WINVER
+#endif
+#define WINVER       0x0600
+
+#ifdef _WIN32_WINNT
+#  undef _WIN32_WINNT
+#endif
+#define _WIN32_WINNT 0x0600
+
+#ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
+
+#undef ERROR   /* reported already defined on VS 2015 (Rich Geldreich) */
+#include <windows.h>
+#undef ERROR
+#define ERROR(name) ZSTD_ERROR(name)
+
+
+/* mutex */
+#define ZSTD_pthread_mutex_t           CRITICAL_SECTION
+#define ZSTD_pthread_mutex_init(a, b)  ((void)(b), InitializeCriticalSection((a)), 0)
+#define ZSTD_pthread_mutex_destroy(a)  DeleteCriticalSection((a))
+#define ZSTD_pthread_mutex_lock(a)     EnterCriticalSection((a))
+#define ZSTD_pthread_mutex_unlock(a)   LeaveCriticalSection((a))
+
+/* condition variable */
+#define ZSTD_pthread_cond_t             CONDITION_VARIABLE
+#define ZSTD_pthread_cond_init(a, b)    ((void)(b), InitializeConditionVariable((a)), 0)
+#define ZSTD_pthread_cond_destroy(a)    ((void)(a))
+#define ZSTD_pthread_cond_wait(a, b)    SleepConditionVariableCS((a), (b), INFINITE)
+#define ZSTD_pthread_cond_signal(a)     WakeConditionVariable((a))
+#define ZSTD_pthread_cond_broadcast(a)  WakeAllConditionVariable((a))
+
+/* ZSTD_pthread_create() and ZSTD_pthread_join() */
+typedef struct {
+    HANDLE handle;
+    void* (*start_routine)(void*);
+    void* arg;
+} ZSTD_pthread_t;
+
+int ZSTD_pthread_create(ZSTD_pthread_t* thread, const void* unused,
+                   void* (*start_routine) (void*), void* arg);
+
+int ZSTD_pthread_join(ZSTD_pthread_t thread, void** value_ptr);
+
+/**
+ * add here more wrappers as required
+ */
+
+
+#elif POOL_MT   /* posix assumed ; need a better detection method */
+/* ===   POSIX Systems   === */
+#  include <pthread.h>
+
+#define ZSTD_pthread_mutex_t            pthread_mutex_t
+#define ZSTD_pthread_mutex_init(a, b)   pthread_mutex_init((a), (b))
+#define ZSTD_pthread_mutex_destroy(a)   pthread_mutex_destroy((a))
+#define ZSTD_pthread_mutex_lock(a)      pthread_mutex_lock((a))
+#define ZSTD_pthread_mutex_unlock(a)    pthread_mutex_unlock((a))
+
+#define ZSTD_pthread_cond_t             pthread_cond_t
+#define ZSTD_pthread_cond_init(a, b)    pthread_cond_init((a), (b))
+#define ZSTD_pthread_cond_destroy(a)    pthread_cond_destroy((a))
+#define ZSTD_pthread_cond_wait(a, b)    pthread_cond_wait((a), (b))
+#define ZSTD_pthread_cond_signal(a)     pthread_cond_signal((a))
+#define ZSTD_pthread_cond_broadcast(a)  pthread_cond_broadcast((a))
+
+#define ZSTD_pthread_t                  pthread_t
+#define ZSTD_pthread_create(a, b, c, d) pthread_create((a), (b), (c), (d))
+#define ZSTD_pthread_join(a, b)         pthread_join((a),(b))
+
+#else  /* POOL_MT == 0 */
+/* No multithreading support */
+
+typedef int ZSTD_pthread_mutex_t;
+#define ZSTD_pthread_mutex_init(a, b)   ((void)(a), (void)(b), 0)
+#define ZSTD_pthread_mutex_destroy(a)   ((void)(a))
+#define ZSTD_pthread_mutex_lock(a)      ((void)(a))
+#define ZSTD_pthread_mutex_unlock(a)    ((void)(a))
+
+typedef int ZSTD_pthread_cond_t;
+#define ZSTD_pthread_cond_init(a, b)    ((void)(a), (void)(b), 0)
+#define ZSTD_pthread_cond_destroy(a)    ((void)(a))
+#define ZSTD_pthread_cond_wait(a, b)    ((void)(a), (void)(b))
+#define ZSTD_pthread_cond_signal(a)     ((void)(a))
+#define ZSTD_pthread_cond_broadcast(a)  ((void)(a))
+
+/* do not use ZSTD_pthread_t */
+
+#endif /* POOL_MT */
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* THREADING_H_938743 */

--- a/xxh3.h
+++ b/xxh3.h
@@ -34,7 +34,7 @@
 
 /* Note :
    This file is separated for development purposes.
-   It will be integrated into `xxhash.c` when development phase is complete.
+   It will be integrated into `xxhash.h` when development stage is completed.
 */
 
 #ifndef XXH3_H_1397135465
@@ -83,7 +83,7 @@
 #endif
 
 /*
- * One goal of XXH3 was to make it fast on both 32-bit and 64-bit, while
+ * One goal of XXH3 is to make it fast on both 32-bit and 64-bit, while
  * remaining a true 64-bit/128-bit hash function.
  *
  * This is done by prioritizing a subset of 64-bit operations that can be


### PR DESCRIPTION
Add a new test tool, the brute-force collision tester,
used to verify the quality of 64-bit hash functions
with regards to collision ratio.

This kind of analysis is out of `SMHasher` range, this it takes many billions of hashes to observe just a few collisions.

The tool requires a huge amount of memory, to store hash values, or even just to filter candidates.
See `README.md` for details.

