### PR TITLE
updated len [4-8] for xxh3

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -674,15 +674,15 @@ XXH3_len_4to8_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_h
     seed ^= (xxh_u64)XXH_swap32((xxh_u32)seed) << 32;
     {   xxh_u32 const input1 = XXH_readLE32(input);
         xxh_u32 const input2 = XXH_readLE32(input + len - 4);
-        xxh_u32 const bitflip1 = (XXH_readLE32(secret+8) ^ XXH_readLE32(secret+12)) + (xxh_u32)(seed >> 32);
-        xxh_u32 const bitflip2 = (XXH_readLE32(secret+16) ^ XXH_readLE32(secret+20)) - (xxh_u32)seed;
-        xxh_u32 const key1 = XXH_swap32(input1) ^ bitflip1;
-        xxh_u32 const key2 = input2 ^ bitflip2;
-        xxh_u64 const mix = XXH_mult32to64(key1, key2)
-                          + ((xxh_u64)input1 << 32)
-                          + ((xxh_u64)(XXH_rotl32(input2,23)) << 32)
-                          + len;
-        return XXH3_avalanche(XXH_xorshift64(mix, 59));
+        xxh_u64 const bitflip = (XXH_readLE64(secret+8) ^ XXH_readLE64(secret+16)) - seed;
+        xxh_u64 const input64 = input2 + (((xxh_u64)input1) << 32);
+        xxh_u64 x = input64 ^ bitflip;
+        /* this mix is inspired by Pelle Evensen's rrmxmx */
+        x ^= XXH_rotl64(x, 49) ^ XXH_rotl64(x, 24);
+        x *= 0x9FB21C651E98DF25ULL;
+        x ^= (x >> 35) + len ;
+        x *= 0x9FB21C651E98DF25ULL;
+        return XXH_xorshift64(x, 28);
     }
 }
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -880,8 +880,8 @@ static void BMK_sanityCheck(void)
     BMK_testXXH3(NULL,           0, prime64, 0x6AFCE90814C488CBULL);
     BMK_testXXH3(sanityBuffer,   1, 0,       0xB936EBAE24CB01C5ULL);  /*  1 -  3 */
     BMK_testXXH3(sanityBuffer,   1, prime64, 0xF541B1905037FC39ULL);  /*  1 -  3 */
-    BMK_testXXH3(sanityBuffer,   6, 0,       0x5AD7EA2EF78ED766ULL);  /*  4 -  8 */
-    BMK_testXXH3(sanityBuffer,   6, prime64, 0x006191EDA5230C98ULL);  /*  4 -  8 */
+    BMK_testXXH3(sanityBuffer,   6, 0,       0x27B56A84CD2D7325ULL);  /*  4 -  8 */
+    BMK_testXXH3(sanityBuffer,   6, prime64, 0x84589C116AB59AB9ULL);  /*  4 -  8 */
     BMK_testXXH3(sanityBuffer,  12, 0,       0xA713DAF0DFBB77E7ULL);  /*  9 - 16 */
     BMK_testXXH3(sanityBuffer,  12, prime64, 0xE7303E1B2336DE0EULL);  /*  9 - 16 */
     BMK_testXXH3(sanityBuffer,  24, 0,       0xA3FE70BF9D3510EBULL);  /* 17 - 32 */
@@ -909,7 +909,7 @@ static void BMK_sanityCheck(void)
         assert(sizeof(sanityBuffer) >= XXH3_SECRET_SIZE_MIN + 7 + 11);
         BMK_testXXH3_withSecret(NULL,           0, secret, secretSize, 0x6775FD10343C92C3ULL);  /* empty string */
         BMK_testXXH3_withSecret(sanityBuffer,   1, secret, secretSize, 0xC3382C326E24E3CDULL);  /*  1 -  3 */
-        BMK_testXXH3_withSecret(sanityBuffer,   6, secret, secretSize, 0x6726BBF76FB142FAULL);  /*  4 -  8 */
+        BMK_testXXH3_withSecret(sanityBuffer,   6, secret, secretSize, 0x82C90AB0519369ADULL);  /*  4 -  8 */
         BMK_testXXH3_withSecret(sanityBuffer,  12, secret, secretSize, 0x14631E773B78EC57ULL);  /*  9 - 16 */
         BMK_testXXH3_withSecret(sanityBuffer,  24, secret, secretSize, 0xCDD5542E4A9D9FE8ULL);  /* 17 - 32 */
         BMK_testXXH3_withSecret(sanityBuffer,  48, secret, secretSize, 0x33ABD54D094B2534ULL);  /* 33 - 64 */


### PR DESCRIPTION
one more time ...

This is (hopefully) the last change for this release.

The recent brute-force collision tester found a weakness right in this range.

The new version is inspired by rrmxmx, and passes all tests with flying colors.
Btw, it also restores bijectivity for 64-bit inputs.

It's also a bit slower (138 - > 125).

I tried to restore its speed, and almost reached it, by replacing the first 2 `rotl` by a single one.
However, invariably, some quality test fail somewhere.
So I got tired of trying and settled on this version. 