### PR TITLE
[xxh128] last quality updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ v0.7.3
 - API: `xxhash.h` can now be included in any order, with and without `XXH_STATIC_LINKING_ONLY` and `XXH_INLINE_ALL`
 - build: xxHash's implementation has been transferred into `xxhash.h`. There is no more need to have `xxhash.c` in the `/include` directory for `XXH_INLINE_ALL` to work
 - build: VCpkg installation instructions, by @LilyWangL
+- install: create pkg-config file, by @bket
 - doc: Highly improved code documentation, by @easyaspi314
 - misc: New test tool in `/tests/collisions`: brute force collision tester for 64-bit hashes
 

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -101,20 +101,22 @@ The command line becomes:
 Here are a few results produced with this tester:
 
 | Algorithm | Input Len | Nb Hashes | Expected | Nb Collisions | Notes |
-| --- | --- | --- | --- | --- | --- |
-| __XXH3__ | 256 | 100 Gi | 312.5 | 326 |  |
-| __XXH64__ | 256 | 100 Gi | 312.5 | 294 |  |
-| __XXH128__ | 256 | 100 Gi | 0.0 | 0 | As a 128-bit hash, we expect XXH128 to generate 0 collisions |
+| ---        | --- | ---    | ---   | --- | --- |
+| __XXH3__   | 255 | 100 Gi | 312.5 | 326 |  |
+| __XXH64__  | 255 | 100 Gi | 312.5 | 294 |  |
 | __XXH128__ low 64-bit | 512 | 100 Gi | 312.5 | 321 |  |
 | __XXH128__ high 64-bit | 512 | 100 Gi | 312.5 | 325 |  |
+| __XXH128__ | 255 | 100 Gi |   0.0 |   0 | a 128-bit hash is expected to generate 0 collisions |
 
 Test on small inputs:
 
-| Algorithm | Input Len | Nb Hashes | Expected | Nb Collisions | Notes |
-| --- | --- | --- | --- | --- | --- |
-| __XXH3__ | 8 |  |  |  | To be restarted |
-| __XXH64__ | 8 | 100 Gi | 312.5 | __0__ | `XXH64` is bijective for `len==8` |
-| __XXH128__ | 16 | 25 Gi | 0.0 | 0 | test range 9-16 |
-| __XXH128__ | 32 | 25 Gi | 0.0 | 0 | test range 17-128 |
-| __XXH128__ | 100 | 13 Gi | 0.0 | 0 | test range 17-128 |
-| __XXH128__ | 200 | 13 Gi | 0.0 | 0 | test range 129-240 |
+| Algorithm  | Input Len | Nb Hashes | Expected | Nb Collisions | Notes |
+| ---        | --- | ---    | --- | --- | --- |
+| __XXH64__  |   8 | 100 Gi | 312.5 | __0__ | `XXH64` is bijective for `len==8` |
+| __XXH3__   |   8 |  14 Gi |   6.1 | __0__ | `XXH3` is also bijective for `len==8` |
+| __XXH3__   |  16 |  14 Gi |   6.1 | 6 |  |
+| __XXH3__   |  32 |  14 Gi |   6.1 | 3 |  |
+| __XXH128__ |  16 |  25 Gi |   0.0 | 0 | test range 9-16 |
+| __XXH128__ |  32 |  25 Gi |   0.0 | 0 | test range 17-128 |
+| __XXH128__ | 100 |  13 Gi |   0.0 | 0 | test range 17-128 |
+| __XXH128__ | 200 |  13 Gi |   0.0 | 0 | test range 129-240 |

--- a/tests/collisions/README.md
+++ b/tests/collisions/README.md
@@ -113,7 +113,7 @@ Test on small inputs:
 | Algorithm  | Input Len | Nb Hashes | Expected | Nb Collisions | Notes |
 | ---        | --- | ---    | --- | --- | --- |
 | __XXH64__  |   8 | 100 Gi | 312.5 | __0__ | `XXH64` is bijective for `len==8` |
-| __XXH3__   |   8 |  14 Gi |   6.1 | __0__ | `XXH3` is also bijective for `len==8` |
+| __XXH3__   |   8 | 100 Gi | 312.5 | __0__ | `XXH3` is also bijective for `len==8` |
 | __XXH3__   |  16 |  14 Gi |   6.1 | 6 |  |
 | __XXH3__   |  32 |  14 Gi |   6.1 | 3 |  |
 | __XXH128__ |  16 |  25 Gi |   0.0 | 0 | test range 9-16 |

--- a/xxh3.h
+++ b/xxh3.h
@@ -1663,16 +1663,17 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
     XXH_ASSERT(input != NULL);
     XXH_ASSERT(secret != NULL);
     XXH_ASSERT(9 <= len && len <= 16);
-    {   xxh_u64 const bitflipl = XXH_readLE64(secret+32) ^ XXH_readLE64(secret+40);
-        xxh_u64 const bitfliph = (XXH_readLE64(secret+48) ^ XXH_readLE64(secret+56)) - seed;
-        xxh_u64 const input_lo = XXH_readLE64(input)           ^ bitflipl;
-        xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ bitfliph;
-        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi, PRIME64_1);
+    {   xxh_u64 const bitflipl = (XXH_readLE64(secret+32) ^ XXH_readLE64(secret+40)) - seed;
+        xxh_u64 const bitfliph = (XXH_readLE64(secret+48) ^ XXH_readLE64(secret+56)) + seed;
+        xxh_u64 const input_lo = XXH_readLE64(input);
+        xxh_u64       input_hi = XXH_readLE64(input + len - 8);
+        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, PRIME64_1);
         /*
          * Put len in the middle of m128 to ensure that the length gets mixed to
          * both the low and high bits in the 128x64 multiply below.
          */
         m128.low64  += (xxh_u64)(len - 1) << 54;
+        input_hi ^= bitfliph;
         /*
          * Add the high 32 bits of input_hi to the high 32 bits of m128, then
          * add the long product of the low 32 bits of input_hi and PRIME32_2 to

--- a/xxh3.h
+++ b/xxh3.h
@@ -1651,7 +1651,9 @@ XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
         m128.high64 += (m128.low64 << 1);
         m128.low64  ^= (m128.high64 >> 3);
 
-        m128.low64   = XXH3_avalanche(m128.low64);
+        m128.low64   = XXH_xorshift64(m128.low64, 35);
+        m128.low64  *= 0x9FB21C651E98DF25ULL;
+        m128.low64   = XXH_xorshift64(m128.low64, 28);
         m128.high64  = XXH3_avalanche(m128.high64);
         return m128;
     }

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1015,16 +1015,16 @@ static void BMK_sanityCheck(void)
     {   XXH128_hash_t const expected = { 0xCA57C628C04B45B8ULL, 0x916831F4DCD21CF9ULL };
         BMK_testXXH128(sanityBuffer,   1, prime, expected);         /* 1-3 */
     }
-    {   XXH128_hash_t const expected = { 0x0A1FEB03C43E230BULL, 0x082AFE0B8162D12AULL };
+    {   XXH128_hash_t const expected = { 0x3E7039BDDA43CFC6ULL, 0x082AFE0B8162D12AULL };
         BMK_testXXH128(sanityBuffer,   6, 0,     expected);         /* 4-8 */
     }
-    {   XXH128_hash_t const expected = { 0x27009AF08E752462ULL, 0x5A865B5389ABD2B1ULL };
+    {   XXH128_hash_t const expected = { 0x269D8F70BE98856EULL, 0x5A865B5389ABD2B1ULL };
         BMK_testXXH128(sanityBuffer,   6, prime, expected);         /* 4-8 */
     }
-    {   XXH128_hash_t const expected = { 0xB861B5B843FA2B05ULL, 0x2740D95C051A0805ULL };
+    {   XXH128_hash_t const expected = { 0x061A192713F69AD9ULL, 0x6E3EFD8FC7802B18ULL };
         BMK_testXXH128(sanityBuffer,  12, 0,     expected);         /* 9-16 */
     }
-    {   XXH128_hash_t const expected = { 0x7866B84B18E8E4A4ULL, 0x649BDCD012D2E858ULL };
+    {   XXH128_hash_t const expected = { 0x9BE9F9A67F3C7DFBULL, 0xD7E09D518A3405D3ULL };
         BMK_testXXH128(sanityBuffer,  12, prime, expected);         /* 9-16 */
     }
     {   XXH128_hash_t const expected = { 0x1E7044D28B1B901DULL, 0x0CE966E4678D3761ULL };


### PR DESCRIPTION
Improved quality in a few remaining tests
when restricting the analysis to the low 64-bit of `xxh128`.