### PR TITLE
Fix copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 xxHash Library
-Copyright (c) 2012-present, Yann Collet
+Copyright (c) 2012-2020 Yann Collet
 All rights reserved.
 
 BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------
 
 xxhsum command line interface
-Copyright (c) 2013-present, Yann Collet
+Copyright (c) 2013-2020 Yann Collet
 All rights reserved.
 
 GPL v2 License

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # ################################################################
 # xxHash Makefile
-# Copyright (C) Yann Collet 2012-present
+# Copyright (C) 2012-2020 Yann Collet
 #
 # GPL v2 License
 #

--- a/tests/bench/Makefile
+++ b/tests/bench/Makefile
@@ -1,6 +1,6 @@
 # ################################################################
-# xxHash Makefile
-# Copyright (C) Yann Collet 2012-present
+# xxHash benchHash Makefile
+# Copyright (C) 2019-2020 Yann Collet
 #
 # GPL v2 License
 #

--- a/tests/bench/benchHash.c
+++ b/tests/bench/benchHash.c
@@ -1,7 +1,7 @@
 /*
 *  Hash benchmark module
 *  Part of the xxHash project
-*  Copyright (C) 2019-present, Yann Collet
+*  Copyright (C) 2019-2020 Yann Collet
 *
 *  GPL v2 License
 *

--- a/tests/bench/benchHash.h
+++ b/tests/bench/benchHash.h
@@ -1,7 +1,7 @@
 /*
 *  Hash benchmark module
 *  Part of the xxHash project
-*  Copyright (C) 2019-present, Yann Collet
+*  Copyright (C) 2019-2020 Yann Collet
 *
 *  GPL v2 License
 *

--- a/tests/bench/benchfn.c
+++ b/tests/bench/benchfn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * Copyright (C) 2016-2020 Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/bench/benchfn.h
+++ b/tests/bench/benchfn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * Copyright (C) 2016-2020 Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/bench/bhDisplay.c
+++ b/tests/bench/bhDisplay.c
@@ -1,7 +1,7 @@
 /*
 *  CSV Display module for the hash benchmark program
 *  Part of the xxHash project
-*  Copyright (C) 2019-present, Yann Collet
+*  Copyright (C) 2019-2020 Yann Collet
 *
 *  GPL v2 License
 *

--- a/tests/bench/bhDisplay.h
+++ b/tests/bench/bhDisplay.h
@@ -1,7 +1,7 @@
 /*
 *  CSV Display module for the hash benchmark program
 *  Part of the xxHash project
-*  Copyright (C) 2019-present, Yann Collet
+*  Copyright (C) 2019-2020 Yann Collet
 *
 *  GPL v2 License
 *

--- a/tests/bench/hashes.h
+++ b/tests/bench/hashes.h
@@ -1,7 +1,7 @@
 /*
 *  List hash algorithms to benchmark
 *  Part of xxHash project
-*  Copyright (C) 2019-present, Yann Collet
+*  Copyright (C) 2019-2020 Yann Collet
 *
 *  GPL v2 License
 *

--- a/tests/bench/main.c
+++ b/tests/bench/main.c
@@ -1,7 +1,7 @@
 /*
  * Main program to benchmark hash functions
  * Part of the xxHash project
- * Copyright (C) 2019-present, Yann Collet
+ * Copyright (C) 2019-2020 Yann Collet
  * GPL v2 License
  *
  * This program is free software; you can redistribute it and/or modify

--- a/tests/bench/timefn.c
+++ b/tests/bench/timefn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-present, Yann Collet, Facebook, Inc.
+ * Copyright (C) 2019-2020 Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/bench/timefn.h
+++ b/tests/bench/timefn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * Copyright (c) 2016-2020 Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -1,6 +1,6 @@
 #  Brute force collision tester for 64-bit hashes
 #  Part of xxHash project
-#  Copyright (C) 2012-present, Yann Collet
+#  Copyright (C) 2019-2020 Yann Collet
 #
 # GPL v2 License
 #

--- a/tests/collisions/allcodecs/dummy.c
+++ b/tests/collisions/allcodecs/dummy.c
@@ -1,7 +1,7 @@
 /*
  * dummy.c, a fake hash algorithm, just to test integration capabilities.
  * Part of the xxHash project
- * Copyright (C) 2020-present, Yann Collet
+ * Copyright (C) 2020 Yann Collet
  *
  * GPL v2 License
  *

--- a/tests/collisions/allcodecs/dummy.h
+++ b/tests/collisions/allcodecs/dummy.h
@@ -2,7 +2,7 @@
  * dummy.c,
  * A fake hash algorithm, just to test integration capabilities.
  * Part of the xxHash project
- * Copyright (C) 2012-present, Yann Collet
+ * Copyright (C) 2020 Yann Collet
  *
  * GPL v2 License
  *

--- a/tests/collisions/hashes.h
+++ b/tests/collisions/hashes.h
@@ -1,7 +1,7 @@
 /*
  * List of hashes for the brute force collision tester
  * Part of xxHash project
- * Copyright (C) 2019-present, Yann Collet
+ * Copyright (C) 2019-2020 Yann Collet
  *
  * GPL v2 License
  *

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -1,7 +1,7 @@
 /*
  * Brute force collision tester for 64-bit hashes
  * Part of the xxHash project
- * Copyright (C) 2019-present, Yann Collet
+ * Copyright (C) 2019-2020 Yann Collet
  *
  * GPL v2 License
  *

--- a/tests/collisions/pool.c
+++ b/tests/collisions/pool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * Copyright (C) 2016-2020 Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/collisions/pool.h
+++ b/tests/collisions/pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * Copyright (c) 2016-2020 Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/collisions/sort.cc
+++ b/tests/collisions/sort.cc
@@ -1,6 +1,6 @@
 /*
  * sort.cc - C++ sort functions
- * Copyright (C) 2019-present, Yann Collet
+ * Copyright (C) 2019-2020 Yann Collet
  * GPL v2 License
  *
  * This program is free software; you can redistribute it and/or modify

--- a/tests/collisions/sort.hh
+++ b/tests/collisions/sort.hh
@@ -1,6 +1,6 @@
 /*
  * sort.hh - headers for C++ sort functions
- * Copyright (C) 2019-present, Yann Collet
+ * Copyright (C) 2019-2020 Yann Collet
  * GPL v2 License
  *
  * This program is free software; you can redistribute it and/or modify

--- a/tests/multiInclude.c
+++ b/tests/multiInclude.c
@@ -2,7 +2,7 @@
  * Multi-include test program
  * Validates that xxhash.h can be included multiple times and in any order
  *
- * Copyright (C) Yann Collet 2020-present
+ * Copyright (C) 2020 Yann Collet
  *
  * GPL v2 License
  *

--- a/xxh3.h
+++ b/xxh3.h
@@ -1,7 +1,7 @@
 /*
  * xxHash - Extremely Fast Hash algorithm
  * Development source file for `xxh3`
- * Copyright (C) 2019-present, Yann Collet
+ * Copyright (C) 2019-2020 Yann Collet
  *
  * BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
  *

--- a/xxhash.c
+++ b/xxhash.c
@@ -1,6 +1,6 @@
 /*
  * xxHash - Extremely Fast Hash algorithm
- * Copyright (C) 2012-present, Yann Collet
+ * Copyright (C) 2012-2020 Yann Collet
  *
  * BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
  *

--- a/xxhash.h
+++ b/xxhash.h
@@ -1,7 +1,7 @@
 /*
  * xxHash - Extremely Fast Hash algorithm
  * Header File
- * Copyright (C) 2012-present, Yann Collet.
+ * Copyright (C) 2012-2020 Yann Collet
  *
  * BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
  *

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1,6 +1,6 @@
 /*
  * xxhsum - Command line interface for xxhash algorithms
- * Copyright (C) Yann Collet 2013-present
+ * Copyright (C) 2013-2020 Yann Collet
  *
  * GPL v2 License
  *


### PR DESCRIPTION
 - Replace '-present' with '-2020' (fixes #329)
 - Use correct format: `Copyright (C) <year> <name of author>`
 - Fix some obviously incorrect years from copy/paste i.e. avoid time travel

Feel free to correct any of these if they are wrong, @Cyan4973 