### PR TITLE
Minor Makefile fixes

### DIFF
--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -28,10 +28,8 @@ VPATH = $(SRC_DIRS)
 CPPFLAGS += $(addprefix -I ,$(SRC_DIRS))
 CFLAGS   ?= -std=c99 \
             -Wall -Wextra -Wconversion
-CFLAGS   += -maes -mavx2
 CXXFLAGS ?= -Wall -Wextra -Wconversion --std=c++11
 LDFLAGS  += -pthread
-LDFLAGS  += -maes -mavx2
 TESTHASHES = 110000000
 
 HASH_SRC := $(sort $(wildcard allcodecs/*.c allcodecs/*.cc))

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -18,9 +18,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#  You can contact the author at :
+#  You can contact the author at:
 #  - xxHash homepage: https://www.xxhash.com
-#  - xxHash source repository : https://github.com/Cyan4973/xxHash
+#  - xxHash source repository: https://github.com/Cyan4973/xxHash
 #
 
 SRC_DIRS = ./ ../../ allcodecs/
@@ -28,7 +28,7 @@ VPATH = $(SRC_DIRS)
 CPPFLAGS += $(addprefix -I ,$(SRC_DIRS))
 CFLAGS   ?= -std=c99 \
             -Wall -Wextra -Wconversion
-CXXFLAGS ?= -Wall -Wextra -Wconversion --std=c++11
+CXXFLAGS ?= -Wall -Wextra -Wconversion -std=c++11
 LDFLAGS  += -pthread
 TESTHASHES = 110000000
 


### PR DESCRIPTION
 - Don't use `-mavx2 -maes` in `collisions`
   - Prevents `make test` from passing on non-x86 targets
 - ~~Default `$(CC)` to `gcc`~~
   - ~~classic mingw32 has `gcc` but not `cc`~~
 - Use the more proper `-std` flag instead of `--std`

TODO: proper Windows library flags: bfd accepts Linux flags, but
ld.lld errors on `-Wl,-soname`. Might be a later PR.