### PR TITLE
Update lz4-java status on github io page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ The following versions produce xxHash-compatible results in different languages.
 
 |Language                   |Author             |URL									|
 |--                         |--                 |--									|
-|__Java__ (XXH32)           |Adrien Grand       |https://github.com/jpountz/lz4-java					|
+|__Java__ (XXH32 and XXH64) |Adrien Grand       |https://github.com/jpountz/lz4-java					|
 |__Java__ (XXH64)           |Vsevolod Tolstopyatov|https://github.com/OpenHFT/Zero-Allocation-Hashing
 |__JavaScript__ (port)      |Pierre Curto       |https://npmjs.org/package/xxhashjs					|
 |__JavaScript__ (nodeJS)    |Brian White        |https://npmjs.org/package/xxhash					|


### PR DESCRIPTION
lz4-java supports both versions of the algorithm.
I did some benchmarking on lz4-java and OpenHFT zero allocation hashing. The openhft version does *not* implement a streaming version, which makes it useless for big files (those have to be read into memory entirely).
The lz4-java version on the otherhand supports XXH32 and XXH64 and has a streaming version that can be used on big files. Also it has little overhead compared to the C-algorithm (I benchmarked it [here](https://github.com/rhpvorderman/hashtest). In other words: lz4-java is a very good java implementation of xxhash. So I hope that with updating the github page more people will use that particular java implementation in their java projects.