### PR TITLE
always skip scrambling for the last block

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1302,7 +1302,7 @@ XXH3_hashLong_internal_loop( xxh_u64* XXH_RESTRICT acc,
 {
     size_t const nb_rounds = (secretSize - STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
     size_t const block_len = STRIPE_LEN * nb_rounds;
-    size_t const nb_blocks = len / block_len;
+    size_t const nb_blocks = (len - 1) / block_len;
 
     size_t n;
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -1315,14 +1315,13 @@ XXH3_hashLong_internal_loop( xxh_u64* XXH_RESTRICT acc,
 
     /* last partial block */
     XXH_ASSERT(len > STRIPE_LEN);
-    {   size_t const nbStripes = (len - (block_len * nb_blocks)) / STRIPE_LEN;
+    {   size_t const nbStripes = (len - (block_len * nb_blocks) - 1) / STRIPE_LEN;
         XXH_ASSERT(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
         XXH3_accumulate(acc, input + nb_blocks*block_len, secret, nbStripes, accWidth);
 
         /* last stripe */
-        if (len & (STRIPE_LEN - 1)) {
-            const xxh_u8* const p = input + len - STRIPE_LEN;
-            /* Do not align on 8, so that the secret is different from the scrambler */
+        {   const xxh_u8* const p = input + len - STRIPE_LEN;
+            /* May not align on 8, so that the secret is different from the scrambler */
 #define XXH_SECRET_LASTACC_START 7
             XXH3_accumulate_512(acc, p, secret + secretSize - STRIPE_LEN - XXH_SECRET_LASTACC_START, accWidth);
     }   }


### PR DESCRIPTION
This will reduce a scrambling when length is align to block. On AVX2, 1K input will improve about 6% performance, 10K will improve about 3%.