### PR TITLE
add optimized implementation for AVX512 targets

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1346,7 +1346,7 @@ XXH3_accumulate(     xxh_u64* XXH_RESTRICT acc,
     for (n = 0; n < nbStripes; n++ ) {
         const xxh_u8* const in = input + n*STRIPE_LEN;
 #if (XXH_VECTOR == XXH_AVX512)
-	if (accWidth == XXH3_acc_64bits) XXH_PREFETCH(in + XXH_PREFETCH_DIST_AVX512_64);
+        if (accWidth == XXH3_acc_64bits) XXH_PREFETCH(in + XXH_PREFETCH_DIST_AVX512_64);
         else                             XXH_PREFETCH(in + XXH_PREFETCH_DIST_AVX512_128);
 #else
         XXH_PREFETCH(in + XXH_PREFETCH_DIST);

--- a/xxh3.h
+++ b/xxh3.h
@@ -1327,8 +1327,14 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 }
 
 #define XXH_PREFETCH_DIST 384
-#define XXH_PREFETCH_DIST_AVX512_64  496
-#define XXH_PREFETCH_DIST_AVX512_128 384
+
+#ifdef __clang__ // for clang
+#  define XXH_PREFETCH_DIST_AVX512_64  320
+#  define XXH_PREFETCH_DIST_AVX512_128 320
+#else // for gcc
+#  define XXH_PREFETCH_DIST_AVX512_64  640
+#  define XXH_PREFETCH_DIST_AVX512_128 512
+#endif
 
 /*
  * XXH3_accumulate()

--- a/xxhash.h
+++ b/xxhash.h
@@ -451,8 +451,8 @@ struct XXH64_state_s {
  * XXH3 at competitive speeds, even if XXH64 runs slowly. Further details are
  * explained in the implementation.
  *
- * Optimized implementations are provided for AVX2, SSE2, NEON, POWER8, ZVector,
- * and scalar targets. This can be controlled with the XXH_VECTOR macro.
+ * Optimized implementations are provided for AVX512, AVX2, SSE2, NEON, POWER8,
+ * ZVector and scalar targets. This can be controlled with the XXH_VECTOR macro.
  *
  * XXH3 offers 2 variants, _64bits and _128bits.
  * When only 64 bits are needed, prefer calling the _64bits variant, as it

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -387,7 +387,9 @@ static unsigned BMK_isLittleEndian(void)
 
 /* Try to detect the architecture. */
 #if defined(ARCH_X86)
-#  if defined(__AVX2__)
+#  if defined(__AVX512F__)
+#    define ARCH ARCH_X86 " + AVX512"
+#  elif defined(__AVX2__)
 #    define ARCH ARCH_X86 " + AVX2"
 #  elif defined(__AVX__)
 #    define ARCH ARCH_X86 " + AVX"


### PR DESCRIPTION
on avx512 targets, variant with default secrets will improve 45%. The following result is compiled with `-Ofast -mavx512f`, and there is also no need to add `-mno-avx256-split-unaligned-load` with gcc.

compiling option:
- avx512 gcc-9/clang-9:  `-Ofast -mavx512f`
- avx2 gcc-9: `-Ofast -mavx2 -mno-avx256-split-unaligned-load`
- avx2 clang-9: `-Ofast -mavx2`

## compiled with Clang 9
```bash
./xxhsum 0.7.4 (64-bit x86_64 + AVX512 little endian), Clang 9.0.0 (tags/RELEASE_900/final), by Yann Collet
Sample of 100 KB...
XXH3_64b                      :     102400 ->   565524 it/s (55227.0 MB/s)
XXH3_64b unaligned            :     102400 ->   565409 it/s (55215.7 MB/s)
XXH3_64b w/seed               :     102400 ->   561795 it/s (54862.8 MB/s)
XXH3_64b w/seed unaligned     :     102400 ->   561556 it/s (54839.5 MB/s)
XXH3_64b w/secret             :     102400 ->   332811 it/s (32501.1 MB/s)
XXH3_64b w/secret unaligned   :     102400 ->   332829 it/s (32502.8 MB/s)
XXH128                        :     102400 ->   508060 it/s (49615.3 MB/s)
XXH128 unaligned              :     102400 ->   507962 it/s (49605.6 MB/s)
XXH128 w/seed                 :     102400 ->   505046 it/s (49320.9 MB/s)
XXH128 w/seed unaligned       :     102400 ->   504939 it/s (49310.5 MB/s)
XXH128 w/secret               :     102400 ->   345985 it/s (33787.6 MB/s)
XXH128 w/secret unaligned     :     102400 ->   345963 it/s (33785.4 MB/s)
```

```bash
./xxhsum 0.7.4 (64-bit x86_64 + AVX2 little endian), Clang 9.0.0 (tags/RELEASE_900/final), by Yann Collet
Sample of 100 KB...
XXH3_64b                      :     102400 ->   387469 it/s (37838.8 MB/s)
XXH3_64b unaligned            :     102400 ->   387931 it/s (37883.9 MB/s)
XXH3_64b w/seed               :     102400 ->   365748 it/s (35717.6 MB/s)
XXH3_64b w/seed unaligned     :     102400 ->   365647 it/s (35707.7 MB/s)
XXH3_64b w/secret             :     102400 ->   341313 it/s (33331.4 MB/s)
XXH3_64b w/secret unaligned   :     102400 ->   341394 it/s (33339.2 MB/s)
XXH128                        :     102400 ->   361423 it/s (35295.2 MB/s)
XXH128 unaligned              :     102400 ->   361373 it/s (35290.4 MB/s)
XXH128 w/seed                 :     102400 ->   331072 it/s (32331.3 MB/s)
XXH128 w/seed unaligned       :     102400 ->   331056 it/s (32329.7 MB/s)
XXH128 w/secret               :     102400 ->   314772 it/s (30739.4 MB/s)
XXH128 w/secret unaligned     :     102400 ->   314827 it/s (30744.8 MB/s)
```

## compiled with GCC 9

```bash
./xxhsum 0.7.4 (64-bit x86_64 + AVX512 little endian), GCC 9.2.1 20191102, by Yann Collet
Sample of 100 KB...
XXH3_64b                      :     102400 ->   512896 it/s (50087.5 MB/s)
XXH3_64b unaligned            :     102400 ->   512808 it/s (50078.9 MB/s)
XXH3_64b w/seed               :     102400 ->   521637 it/s (50941.1 MB/s)
XXH3_64b w/seed unaligned     :     102400 ->   520925 it/s (50871.6 MB/s)
XXH3_64b w/secret             :     102400 ->   341146 it/s (33315.0 MB/s)
XXH3_64b w/secret unaligned   :     102400 ->   341093 it/s (33309.8 MB/s)
XXH128                        :     102400 ->   462556 it/s (45171.5 MB/s)
XXH128 unaligned              :     102400 ->   462441 it/s (45160.3 MB/s)
XXH128 w/seed                 :     102400 ->   446254 it/s (43579.5 MB/s)
XXH128 w/seed unaligned       :     102400 ->   446616 it/s (43614.8 MB/s)
XXH128 w/secret               :     102400 ->   404667 it/s (39518.3 MB/s)
XXH128 w/secret unaligned     :     102400 ->   404753 it/s (39526.6 MB/s)
```

```bash
./xxhsum 0.7.4 (64-bit x86_64 + AVX2 little endian), GCC 9.2.1 20191102, by Yann Collet
Sample of 100 KB...
XXH3_64b                      :     102400 ->   365130 it/s (35657.2 MB/s)
XXH3_64b unaligned            :     102400 ->   363159 it/s (35464.7 MB/s)
XXH3_64b w/seed               :     102400 ->   364409 it/s (35586.8 MB/s)
XXH3_64b w/seed unaligned     :     102400 ->   364189 it/s (35565.3 MB/s)
XXH3_64b w/secret             :     102400 ->   330790 it/s (32303.7 MB/s)
XXH3_64b w/secret unaligned   :     102400 ->   330939 it/s (32318.3 MB/s)
XXH128                        :     102400 ->   333179 it/s (32537.0 MB/s)
XXH128 unaligned              :     102400 ->   333267 it/s (32545.6 MB/s)
XXH128 w/seed                 :     102400 ->   331603 it/s (32383.1 MB/s)
XXH128 w/seed unaligned       :     102400 ->   331731 it/s (32395.6 MB/s)
XXH128 w/secret               :     102400 ->   303619 it/s (29650.3 MB/s)
XXH128 w/secret unaligned     :     102400 ->   303526 it/s (29641.2 MB/s)
```