### PR TITLE
Clean up namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ preview-man: man
 	man ./xxhsum.1
 
 .PHONY: test
-test: DEBUGFLAGS += -DDEBUGLEVEL=1
+test: DEBUGFLAGS += -DXXH_DEBUGLEVEL=1
 test: all namespaceTest check test-xxhsum-c c90test test-tools
 
 .PHONY: test-inline

--- a/xxh3.h
+++ b/xxh3.h
@@ -457,7 +457,7 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mule(xxh_u32x4 a, xxh_u32x4 b)
 #endif
 
 /* Pseudorandom secret taken directly from FARSH */
-XXH_ALIGN(64) static const xxh_u8 kSecret[XXH_SECRET_DEFAULT_SIZE] = {
+XXH_ALIGN(64) static const xxh_u8 XXH3_kSecret[XXH_SECRET_DEFAULT_SIZE] = {
     0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c, 0xf7, 0x21, 0xad, 0x1c,
     0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb, 0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f,
     0xcb, 0x79, 0xe6, 0x4e, 0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
@@ -472,6 +472,10 @@ XXH_ALIGN(64) static const xxh_u8 kSecret[XXH_SECRET_DEFAULT_SIZE] = {
     0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc, 0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce,
     0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
 };
+
+#ifdef XXH_OLD_NAMES
+#  define kSecret XXH3_kSecret
+#endif
 
 /*
  * Calculates a 32-bit to 64-bit long multiply.
@@ -702,7 +706,7 @@ XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_h
                                | ((xxh_u32)c3 <<  0) | ((xxh_u32)len << 8);
         xxh_u64 const bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret+4)) + seed;
         xxh_u64 const keyed = (xxh_u64)combined ^ bitflip;
-        xxh_u64 const mixed = keyed * PRIME64_1;
+        xxh_u64 const mixed = keyed * XXH_PRIME64_1;
         return XXH3_avalanche(mixed);
     }
 }
@@ -752,7 +756,7 @@ XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     {   if (XXH_likely(len >  8)) return XXH3_len_9to16_64b(input, len, secret, seed);
         if (XXH_likely(len >= 4)) return XXH3_len_4to8_64b(input, len, secret, seed);
         if (len) return XXH3_len_1to3_64b(input, len, secret, seed);
-        return XXH3_avalanche((PRIME64_1 + seed) ^ (XXH_readLE64(secret+56) ^ XXH_readLE64(secret+64)));
+        return XXH3_avalanche((XXH_PRIME64_1 + seed) ^ (XXH_readLE64(secret+56) ^ XXH_readLE64(secret+64)));
     }
 }
 
@@ -823,7 +827,7 @@ XXH3_len_17to128_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
     XXH_ASSERT(16 < len && len <= 128);
 
-    {   xxh_u64 acc = len * PRIME64_1;
+    {   xxh_u64 acc = len * XXH_PRIME64_1;
         if (len > 32) {
             if (len > 64) {
                 if (len > 96) {
@@ -856,7 +860,7 @@ XXH3_len_129to240_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
     #define XXH3_MIDSIZE_STARTOFFSET 3
     #define XXH3_MIDSIZE_LASTOFFSET  17
 
-    {   xxh_u64 acc = len * PRIME64_1;
+    {   xxh_u64 acc = len * XXH_PRIME64_1;
         int const nbRounds = (int)len / 16;
         int i;
         for (i=0; i<8; i++) {
@@ -901,9 +905,14 @@ XXH3_len_129to240_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
 
 /* ===    Long Keys    === */
 
-#define STRIPE_LEN 64
+#define XXH_STRIPE_LEN 64
 #define XXH_SECRET_CONSUME_RATE 8   /* nb of secret bytes consumed at each accumulation */
-#define ACC_NB (STRIPE_LEN / sizeof(xxh_u64))
+#define XXH_ACC_NB (XXH_STRIPE_LEN / sizeof(xxh_u64))
+
+#ifdef XXH_OLD_NAMES
+#  define STRIPE_LEN XXH_STRIPE_LEN
+#  define ACC_NB XXH_ACC_NB
+#endif
 
 typedef enum { XXH3_acc_64bits, XXH3_acc_128bits } XXH3_accWidth_e;
 
@@ -938,7 +947,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
 #if (XXH_VECTOR == XXH_AVX512)
 
     XXH_ASSERT((((size_t)acc) & 63) == 0);
-    XXH_STATIC_ASSERT(STRIPE_LEN == sizeof(__m512i));
+    XXH_STATIC_ASSERT(XXH_STRIPE_LEN == sizeof(__m512i));
     {   XXH_ALIGN(64) __m512i* const xacc    =       (__m512i *) acc;
 
         /* data_vec    = input[0]; */
@@ -977,7 +986,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
         const         __m256i* const xsecret = (const __m256i *) secret;
 
         size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m256i); i++) {
             /* data_vec    = xinput[i]; */
             __m256i const data_vec    = _mm256_loadu_si256    (xinput+i);
             /* key_vec     = xsecret[i]; */
@@ -1015,7 +1024,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
         const         __m128i* const xsecret = (const __m128i *) secret;
 
         size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m128i); i++) {
             /* data_vec    = xinput[i]; */
             __m128i const data_vec    = _mm_loadu_si128   (xinput+i);
             /* key_vec     = xsecret[i]; */
@@ -1050,7 +1059,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
         uint8_t const* const xsecret  = (const uint8_t *) secret;
 
         size_t i;
-        for (i=0; i < STRIPE_LEN / sizeof(uint64x2_t); i++) {
+        for (i=0; i < XXH_STRIPE_LEN / sizeof(uint64x2_t); i++) {
             /* data_vec = xinput[i]; */
             uint8x16_t data_vec    = vld1q_u8(xinput  + (i * 16));
             /* key_vec  = xsecret[i];  */
@@ -1084,7 +1093,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
     xxh_u64x2 const* const xsecret  = (xxh_u64x2 const*) secret;    /* no alignment restriction */
     xxh_u64x2 const v32 = { 32, 32 };
     size_t i;
-    for (i = 0; i < STRIPE_LEN / sizeof(xxh_u64x2); i++) {
+    for (i = 0; i < XXH_STRIPE_LEN / sizeof(xxh_u64x2); i++) {
         /* data_vec = xinput[i]; */
         xxh_u64x2 const data_vec = XXH_vec_loadu(xinput + i);
         /* key_vec = xsecret[i]; */
@@ -1116,7 +1125,7 @@ XXH3_accumulate_512(      void* XXH_RESTRICT acc,
     const xxh_u8* const xsecret = (const xxh_u8*) secret;   /* no alignment restriction */
     size_t i;
     XXH_ASSERT(((size_t)acc & (XXH_ACC_ALIGN-1)) == 0);
-    for (i=0; i < ACC_NB; i++) {
+    for (i=0; i < XXH_ACC_NB; i++) {
         xxh_u64 const data_val = XXH_readLE64(xinput + 8*i);
         xxh_u64 const data_key = data_val ^ XXH_readLE64(xsecret + i*8);
 
@@ -1156,9 +1165,9 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 #if (XXH_VECTOR == XXH_AVX512)
 
     XXH_ASSERT((((size_t)acc) & 63) == 0);
-    XXH_STATIC_ASSERT(STRIPE_LEN == sizeof(__m512i));
+    XXH_STATIC_ASSERT(XXH_STRIPE_LEN == sizeof(__m512i));
     {   XXH_ALIGN(64) __m512i* const xacc = (__m512i*) acc;
-        const __m512i prime32 = _mm512_set1_epi32((int)PRIME32_1);
+        const __m512i prime32 = _mm512_set1_epi32((int)XXH_PRIME32_1);
 
         /* xacc[0] ^= (xacc[0] >> 47) */
         __m512i const acc_vec     = *xacc;
@@ -1168,7 +1177,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
         __m512i const key_vec     = _mm512_loadu_si512   (secret);
         __m512i const data_key    = _mm512_xor_si512     (data_vec, key_vec);
 
-        /* xacc[0] *= PRIME32_1; */
+        /* xacc[0] *= XXH_PRIME32_1; */
         __m512i const data_key_hi = _mm512_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
         __m512i const prod_lo     = _mm512_mul_epu32     (data_key, prime32);
         __m512i const prod_hi     = _mm512_mul_epu32     (data_key_hi, prime32);
@@ -1182,10 +1191,10 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
         /* Unaligned. This is mainly for pointer arithmetic, and because
          * _mm256_loadu_si256 requires a const __m256i * pointer for some reason. */
         const         __m256i* const xsecret = (const __m256i *) secret;
-        const __m256i prime32 = _mm256_set1_epi32((int)PRIME32_1);
+        const __m256i prime32 = _mm256_set1_epi32((int)XXH_PRIME32_1);
 
         size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m256i); i++) {
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m256i); i++) {
             /* xacc[i] ^= (xacc[i] >> 47) */
             __m256i const acc_vec     = xacc[i];
             __m256i const shifted     = _mm256_srli_epi64    (acc_vec, 47);
@@ -1194,7 +1203,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
             __m256i const key_vec     = _mm256_loadu_si256   (xsecret+i);
             __m256i const data_key    = _mm256_xor_si256     (data_vec, key_vec);
 
-            /* xacc[i] *= PRIME32_1; */
+            /* xacc[i] *= XXH_PRIME32_1; */
             __m256i const data_key_hi = _mm256_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
             __m256i const prod_lo     = _mm256_mul_epu32     (data_key, prime32);
             __m256i const prod_hi     = _mm256_mul_epu32     (data_key_hi, prime32);
@@ -1209,10 +1218,10 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
         /* Unaligned. This is mainly for pointer arithmetic, and because
          * _mm_loadu_si128 requires a const __m128i * pointer for some reason. */
         const         __m128i* const xsecret = (const __m128i *) secret;
-        const __m128i prime32 = _mm_set1_epi32((int)PRIME32_1);
+        const __m128i prime32 = _mm_set1_epi32((int)XXH_PRIME32_1);
 
         size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(__m128i); i++) {
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m128i); i++) {
             /* xacc[i] ^= (xacc[i] >> 47) */
             __m128i const acc_vec     = xacc[i];
             __m128i const shifted     = _mm_srli_epi64    (acc_vec, 47);
@@ -1221,7 +1230,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
             __m128i const key_vec     = _mm_loadu_si128   (xsecret+i);
             __m128i const data_key    = _mm_xor_si128     (data_vec, key_vec);
 
-            /* xacc[i] *= PRIME32_1; */
+            /* xacc[i] *= XXH_PRIME32_1; */
             __m128i const data_key_hi = _mm_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
             __m128i const prod_lo     = _mm_mul_epu32     (data_key, prime32);
             __m128i const prod_hi     = _mm_mul_epu32     (data_key_hi, prime32);
@@ -1235,10 +1244,10 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 
     {   uint64x2_t* xacc       = (uint64x2_t*) acc;
         uint8_t const* xsecret = (uint8_t const*) secret;
-        uint32x2_t prime       = vdup_n_u32 (PRIME32_1);
+        uint32x2_t prime       = vdup_n_u32 (XXH_PRIME32_1);
 
         size_t i;
-        for (i=0; i < STRIPE_LEN/sizeof(uint64x2_t); i++) {
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(uint64x2_t); i++) {
             /* xacc[i] ^= (xacc[i] >> 47); */
             uint64x2_t acc_vec  = xacc[i];
             uint64x2_t shifted  = vshrq_n_u64 (acc_vec, 47);
@@ -1248,14 +1257,14 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
             uint8x16_t key_vec  = vld1q_u8(xsecret + (i * 16));
             uint64x2_t data_key = veorq_u64(data_vec, vreinterpretq_u64_u8(key_vec));
 
-            /* xacc[i] *= PRIME32_1 */
+            /* xacc[i] *= XXH_PRIME32_1 */
             uint32x2_t data_key_lo, data_key_hi;
             /* data_key_lo = (uint32x2_t) (xacc[i] & 0xFFFFFFFF);
              * data_key_hi = (uint32x2_t) (xacc[i] >> 32);
              * xacc[i] = UNDEFINED; */
             XXH_SPLIT_IN_PLACE(data_key, data_key_lo, data_key_hi);
             {   /*
-                 * prod_hi = (data_key >> 32) * PRIME32_1;
+                 * prod_hi = (data_key >> 32) * XXH_PRIME32_1;
                  *
                  * Avoid vmul_u32 + vshll_n_u32 since Clang 6 and 7 will
                  * incorrectly "optimize" this:
@@ -1275,7 +1284,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
                 uint64x2_t prod_hi = vmull_u32 (data_key_hi, prime);
                 /* xacc[i] = prod_hi << 32; */
                 xacc[i] = vshlq_n_u64(prod_hi, 32);
-                /* xacc[i] += (prod_hi & 0xFFFFFFFF) * PRIME32_1; */
+                /* xacc[i] += (prod_hi & 0xFFFFFFFF) * XXH_PRIME32_1; */
                 xacc[i] = vmlal_u32(xacc[i], data_key_lo, prime);
             }
     }   }
@@ -1289,9 +1298,9 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
         /* constants */
         xxh_u64x2 const v32  = { 32, 32 };
         xxh_u64x2 const v47 = { 47, 47 };
-        xxh_u32x4 const prime = { PRIME32_1, PRIME32_1, PRIME32_1, PRIME32_1 };
+        xxh_u32x4 const prime = { XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1 };
         size_t i;
-        for (i = 0; i < STRIPE_LEN / sizeof(xxh_u64x2); i++) {
+        for (i = 0; i < XXH_STRIPE_LEN / sizeof(xxh_u64x2); i++) {
             /* xacc[i] ^= (xacc[i] >> 47); */
             xxh_u64x2 const acc_vec  = xacc[i];
             xxh_u64x2 const data_vec = acc_vec ^ (acc_vec >> v47);
@@ -1300,7 +1309,7 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
             xxh_u64x2 const key_vec  = XXH_vec_loadu(xsecret + i);
             xxh_u64x2 const data_key = data_vec ^ key_vec;
 
-            /* xacc[i] *= PRIME32_1 */
+            /* xacc[i] *= XXH_PRIME32_1 */
             /* prod_lo = ((xxh_u64x2)data_key & 0xFFFFFFFF) * ((xxh_u64x2)prime & 0xFFFFFFFF);  */
             xxh_u64x2 const prod_even  = XXH_vec_mule((xxh_u32x4)data_key, prime);
             /* prod_hi = ((xxh_u64x2)data_key >> 32) * ((xxh_u64x2)prime >> 32);  */
@@ -1314,12 +1323,12 @@ XXH3_scrambleAcc(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
     const xxh_u8* const xsecret = (const xxh_u8*) secret;   /* no alignment restriction */
     size_t i;
     XXH_ASSERT((((size_t)acc) & (XXH_ACC_ALIGN-1)) == 0);
-    for (i=0; i < ACC_NB; i++) {
+    for (i=0; i < XXH_ACC_NB; i++) {
         xxh_u64 const key64 = XXH_readLE64(xsecret + 8*i);
         xxh_u64 acc64 = xacc[i];
         acc64 = XXH_xorshift64(acc64, 47);
         acc64 ^= key64;
-        acc64 *= PRIME32_1;
+        acc64 *= XXH_PRIME32_1;
         xacc[i] = acc64;
     }
 
@@ -1350,7 +1359,7 @@ XXH3_accumulate(     xxh_u64* XXH_RESTRICT acc,
 {
     size_t n;
     for (n = 0; n < nbStripes; n++ ) {
-        const xxh_u8* const in = input + n*STRIPE_LEN;
+        const xxh_u8* const in = input + n*XXH_STRIPE_LEN;
 #if (XXH_VECTOR == XXH_AVX512)
         if (accWidth == XXH3_acc_64bits) XXH_PREFETCH(in + XXH_PREFETCH_DIST_AVX512_64);
         else                             XXH_PREFETCH(in + XXH_PREFETCH_DIST_AVX512_128);
@@ -1370,8 +1379,8 @@ XXH3_hashLong_internal_loop( xxh_u64* XXH_RESTRICT acc,
                       const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
                             XXH3_accWidth_e accWidth)
 {
-    size_t const nb_rounds = (secretSize - STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
-    size_t const block_len = STRIPE_LEN * nb_rounds;
+    size_t const nb_rounds = (secretSize - XXH_STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
+    size_t const block_len = XXH_STRIPE_LEN * nb_rounds;
     size_t const nb_blocks = len / block_len;
 
     size_t n;
@@ -1380,21 +1389,21 @@ XXH3_hashLong_internal_loop( xxh_u64* XXH_RESTRICT acc,
 
     for (n = 0; n < nb_blocks; n++) {
         XXH3_accumulate(acc, input + n*block_len, secret, nb_rounds, accWidth);
-        XXH3_scrambleAcc(acc, secret + secretSize - STRIPE_LEN);
+        XXH3_scrambleAcc(acc, secret + secretSize - XXH_STRIPE_LEN);
     }
 
     /* last partial block */
-    XXH_ASSERT(len > STRIPE_LEN);
-    {   size_t const nbStripes = (len - (block_len * nb_blocks)) / STRIPE_LEN;
+    XXH_ASSERT(len > XXH_STRIPE_LEN);
+    {   size_t const nbStripes = (len - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
         XXH_ASSERT(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
         XXH3_accumulate(acc, input + nb_blocks*block_len, secret, nbStripes, accWidth);
 
         /* last stripe */
-        if (len & (STRIPE_LEN - 1)) {
-            const xxh_u8* const p = input + len - STRIPE_LEN;
+        if (len & (XXH_STRIPE_LEN - 1)) {
+            const xxh_u8* const p = input + len - XXH_STRIPE_LEN;
             /* Do not align on 8, so that the secret is different from the scrambler */
 #define XXH_SECRET_LASTACC_START 7
-            XXH3_accumulate_512(acc, p, secret + secretSize - STRIPE_LEN - XXH_SECRET_LASTACC_START, accWidth);
+            XXH3_accumulate_512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START, accWidth);
     }   }
 }
 
@@ -1433,14 +1442,14 @@ XXH3_mergeAccs(const xxh_u64* XXH_RESTRICT acc, const xxh_u8* XXH_RESTRICT secre
     return XXH3_avalanche(result64);
 }
 
-#define XXH3_INIT_ACC { PRIME32_3, PRIME64_1, PRIME64_2, PRIME64_3, \
-                        PRIME64_4, PRIME32_2, PRIME64_5, PRIME32_1 }
+#define XXH3_INIT_ACC { XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3, \
+                        XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1 }
 
 XXH_FORCE_INLINE XXH64_hash_t
 XXH3_hashLong_64b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
                            const xxh_u8* XXH_RESTRICT secret, size_t secretSize)
 {
-    XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[ACC_NB] = XXH3_INIT_ACC;
+    XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[XXH_ACC_NB] = XXH3_INIT_ACC;
 
     XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, XXH3_acc_64bits);
 
@@ -1449,7 +1458,7 @@ XXH3_hashLong_64b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
     /* do not align on 8, so that the secret is different from the accumulator */
 #define XXH_SECRET_MERGEACCS_START 11
     XXH_ASSERT(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
-    return XXH3_mergeAccs(acc, secret + XXH_SECRET_MERGEACCS_START, (xxh_u64)len * PRIME64_1);
+    return XXH3_mergeAccs(acc, secret + XXH_SECRET_MERGEACCS_START, (xxh_u64)len * XXH_PRIME64_1);
 }
 
 XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
@@ -1459,7 +1468,7 @@ XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
 }
 
 /* XXH3_initCustomSecret() :
- * destination `customSecret` is presumed allocated and same size as `kSecret`.
+ * destination `customSecret` is presumed allocated and same size as `XXH3_kSecret`.
  */
 XXH_FORCE_INLINE void XXH3_initCustomSecret(xxh_u8* XXH_RESTRICT customSecret, xxh_u64 seed64)
 {
@@ -1469,7 +1478,7 @@ XXH_FORCE_INLINE void XXH3_initCustomSecret(xxh_u8* XXH_RESTRICT customSecret, x
      * We need a separate pointer for the hack below.
      * Any decent compiler will optimize this out otherwise.
      */
-    const xxh_u8 *kSecretPtr = kSecret;
+    const xxh_u8 *kSecretPtr = XXH3_kSecret;
 
     XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
 
@@ -1491,7 +1500,8 @@ XXH_FORCE_INLINE void XXH3_initCustomSecret(xxh_u8* XXH_RESTRICT customSecret, x
      * SUB      STR
      *          STR
      * By forcing loads from memory (as the asm line causes Clang to assume
-     * that kSecretPtr has been changed), the pipelines are used more efficiently:
+     * that XXH3_kSecretPtr has been changed), the pipelines are used more
+     * efficiently:
      *   I   L   S
      *      LDR
      *  ADD LDR
@@ -1507,11 +1517,11 @@ XXH_FORCE_INLINE void XXH3_initCustomSecret(xxh_u8* XXH_RESTRICT customSecret, x
      * Note: in debug mode, this overrides the asm optimization
      * and Clang will emit MOVK chains again.
      */
-    XXH_ASSERT(kSecretPtr == kSecret);
+    XXH_ASSERT(kSecretPtr == XXH3_kSecret);
 
     for (i=0; i < nbRounds; i++) {
         /*
-         * The asm hack causes Clang to assume that kSecretPtr aliases with
+         * The asm hack causes Clang to assume that XXH3_kSecretPtr aliases with
          * customSecret, and on aarch64, this prevented LDP from merging two
          * loads together for free. Putting the loads together before the stores
          * properly generates LDP.
@@ -1531,7 +1541,7 @@ XXH_FORCE_INLINE void XXH3_initCustomSecret(xxh_u8* XXH_RESTRICT customSecret, x
 XXH_NO_INLINE XXH64_hash_t
 XXH3_hashLong_64b_defaultSecret(const xxh_u8* XXH_RESTRICT input, size_t len)
 {
-    return XXH3_hashLong_64b_internal(input, len, kSecret, sizeof(kSecret));
+    return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret));
 }
 
 /*
@@ -1547,7 +1557,7 @@ XXH3_hashLong_64b_withSecret(const xxh_u8* XXH_RESTRICT input, size_t len,
 
 /*
  * XXH3_hashLong_64b_withSeed():
- * Generate a custom key based on alteration of default kSecret with the seed,
+ * Generate a custom key based on alteration of default XXH3_kSecret with the seed,
  * and then use this key for long mode hashing.
  *
  * This operation is decently fast but nonetheless costs a little bit of time.
@@ -1570,11 +1580,11 @@ XXH3_hashLong_64b_withSeed(const xxh_u8* input, size_t len, XXH64_hash_t seed)
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* input, size_t len)
 {
     if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, kSecret, 0);
+        return XXH3_len_0to16_64b((const xxh_u8*)input, len, XXH3_kSecret, 0);
     if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), 0);
+        return XXH3_len_17to128_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
     if (len <= XXH3_MIDSIZE_MAX)
-         return XXH3_len_129to240_64b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), 0);
+         return XXH3_len_129to240_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
     return XXH3_hashLong_64b_defaultSecret((const xxh_u8*)input, len);
 }
 
@@ -1601,11 +1611,11 @@ XXH_PUBLIC_API XXH64_hash_t
 XXH3_64bits_withSeed(const void* input, size_t len, XXH64_hash_t seed)
 {
     if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, kSecret, seed);
+        return XXH3_len_0to16_64b((const xxh_u8*)input, len, XXH3_kSecret, seed);
     if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), seed);
+        return XXH3_len_17to128_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), seed);
+        return XXH3_len_129to240_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
     return XXH3_hashLong_64b_withSeed((const xxh_u8*)input, len, seed);
 }
 
@@ -1701,19 +1711,19 @@ XXH3_64bits_reset_internal(XXH3_state_t* statePtr,
 {
     XXH_ASSERT(statePtr != NULL);
     memset(statePtr, 0, sizeof(*statePtr));
-    statePtr->acc[0] = PRIME32_3;
-    statePtr->acc[1] = PRIME64_1;
-    statePtr->acc[2] = PRIME64_2;
-    statePtr->acc[3] = PRIME64_3;
-    statePtr->acc[4] = PRIME64_4;
-    statePtr->acc[5] = PRIME32_2;
-    statePtr->acc[6] = PRIME64_5;
-    statePtr->acc[7] = PRIME32_1;
+    statePtr->acc[0] = XXH_PRIME32_3;
+    statePtr->acc[1] = XXH_PRIME64_1;
+    statePtr->acc[2] = XXH_PRIME64_2;
+    statePtr->acc[3] = XXH_PRIME64_3;
+    statePtr->acc[4] = XXH_PRIME64_4;
+    statePtr->acc[5] = XXH_PRIME32_2;
+    statePtr->acc[6] = XXH_PRIME64_5;
+    statePtr->acc[7] = XXH_PRIME32_1;
     statePtr->seed = seed;
     XXH_ASSERT(secret != NULL);
     statePtr->secret = secret;
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
-    statePtr->secretLimit = (XXH32_hash_t)(secretSize - STRIPE_LEN);
+    statePtr->secretLimit = (XXH32_hash_t)(secretSize - XXH_STRIPE_LEN);
     statePtr->nbStripesPerBlock = statePtr->secretLimit / XXH_SECRET_CONSUME_RATE;
 }
 
@@ -1721,7 +1731,7 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_64bits_reset(XXH3_state_t* statePtr)
 {
     if (statePtr == NULL) return XXH_ERROR;
-    XXH3_64bits_reset_internal(statePtr, 0, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    XXH3_64bits_reset_internal(statePtr, 0, XXH3_kSecret, XXH_SECRET_DEFAULT_SIZE);
     return XXH_OK;
 }
 
@@ -1739,7 +1749,7 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
 {
     if (statePtr == NULL) return XXH_ERROR;
-    XXH3_64bits_reset_internal(statePtr, seed, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    XXH3_64bits_reset_internal(statePtr, seed, XXH3_kSecret, XXH_SECRET_DEFAULT_SIZE);
     XXH3_initCustomSecret(statePtr->customSecret, seed);
     statePtr->secret = statePtr->customSecret;
     return XXH_OK;
@@ -1758,7 +1768,7 @@ XXH3_consumeStripes( xxh_u64* acc,
         size_t const nbStripes = nbStripesPerBlock - *nbStripesSoFarPtr;
         XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, accWidth);
         XXH3_scrambleAcc(acc, secret + secretLimit);
-        XXH3_accumulate(acc, input + nbStripes * STRIPE_LEN, secret, totalStripes - nbStripes, accWidth);
+        XXH3_accumulate(acc, input + nbStripes * XXH_STRIPE_LEN, secret, totalStripes - nbStripes, accWidth);
         *nbStripesSoFarPtr = (XXH32_hash_t)(totalStripes - nbStripes);
     } else {
         XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, totalStripes, accWidth);
@@ -1790,8 +1800,8 @@ XXH3_update(XXH3_state_t* state, const xxh_u8* input, size_t len, XXH3_accWidth_
         }
         /* input is now > XXH3_INTERNALBUFFER_SIZE */
 
-        #define XXH3_INTERNALBUFFER_STRIPES (XXH3_INTERNALBUFFER_SIZE / STRIPE_LEN)
-        XXH_STATIC_ASSERT(XXH3_INTERNALBUFFER_SIZE % STRIPE_LEN == 0);   /* clean multiple */
+        #define XXH3_INTERNALBUFFER_STRIPES (XXH3_INTERNALBUFFER_SIZE / XXH_STRIPE_LEN)
+        XXH_STATIC_ASSERT(XXH3_INTERNALBUFFER_SIZE % XXH_STRIPE_LEN == 0);   /* clean multiple */
 
         /*
          * There is some input left inside the internal buffer.
@@ -1846,24 +1856,24 @@ XXH3_digest_long (XXH64_hash_t* acc, const XXH3_state_t* state, XXH3_accWidth_e 
      * continue ingesting more input afterwards.
      */
     memcpy(acc, state->acc, sizeof(state->acc));
-    if (state->bufferedSize >= STRIPE_LEN) {
-        size_t const totalNbStripes = state->bufferedSize / STRIPE_LEN;
+    if (state->bufferedSize >= XXH_STRIPE_LEN) {
+        size_t const totalNbStripes = state->bufferedSize / XXH_STRIPE_LEN;
         XXH32_hash_t nbStripesSoFar = state->nbStripesSoFar;
         XXH3_consumeStripes(acc,
                            &nbStripesSoFar, state->nbStripesPerBlock,
                             state->buffer, totalNbStripes,
                             state->secret, state->secretLimit,
                             accWidth);
-        if (state->bufferedSize % STRIPE_LEN) {  /* one last partial stripe */
+        if (state->bufferedSize % XXH_STRIPE_LEN) {  /* one last partial stripe */
             XXH3_accumulate_512(acc,
-                                state->buffer + state->bufferedSize - STRIPE_LEN,
+                                state->buffer + state->bufferedSize - XXH_STRIPE_LEN,
                                 state->secret + state->secretLimit - XXH_SECRET_LASTACC_START,
                                 accWidth);
         }
-    } else {  /* bufferedSize < STRIPE_LEN */
+    } else {  /* bufferedSize < XXH_STRIPE_LEN */
         if (state->bufferedSize) { /* one last stripe */
-            xxh_u8 lastStripe[STRIPE_LEN];
-            size_t const catchupSize = STRIPE_LEN - state->bufferedSize;
+            xxh_u8 lastStripe[XXH_STRIPE_LEN];
+            size_t const catchupSize = XXH_STRIPE_LEN - state->bufferedSize;
             memcpy(lastStripe, state->buffer + sizeof(state->buffer) - catchupSize, catchupSize);
             memcpy(lastStripe + catchupSize, state->buffer, state->bufferedSize);
             XXH3_accumulate_512(acc,
@@ -1876,17 +1886,17 @@ XXH3_digest_long (XXH64_hash_t* acc, const XXH3_state_t* state, XXH3_accWidth_e 
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
 {
     if (state->totalLen > XXH3_MIDSIZE_MAX) {
-        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[ACC_NB];
+        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[XXH_ACC_NB];
         XXH3_digest_long(acc, state, XXH3_acc_64bits);
         return XXH3_mergeAccs(acc,
                               state->secret + XXH_SECRET_MERGEACCS_START,
-                              (xxh_u64)state->totalLen * PRIME64_1);
+                              (xxh_u64)state->totalLen * XXH_PRIME64_1);
     }
     /* len <= XXH3_MIDSIZE_MAX: short code */
     if (state->seed)
         return XXH3_64bits_withSeed(state->buffer, (size_t)state->totalLen, state->seed);
     return XXH3_64bits_withSecret(state->buffer, (size_t)(state->totalLen),
-                                  state->secret, state->secretLimit + STRIPE_LEN);
+                                  state->secret, state->secretLimit + XXH_STRIPE_LEN);
 }
 
 /* ==========================================
@@ -1928,8 +1938,8 @@ XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
         xxh_u64 const bitfliph = (XXH_readLE32(secret+8) ^ XXH_readLE32(secret+12)) - seed;
         xxh_u64 const keyed_lo = (xxh_u64)combinedl ^ bitflipl;
         xxh_u64 const keyed_hi = (xxh_u64)combinedh ^ bitfliph;
-        xxh_u64 const mixedl = keyed_lo * PRIME64_1;
-        xxh_u64 const mixedh = keyed_hi * PRIME64_5;
+        xxh_u64 const mixedl = keyed_lo * XXH_PRIME64_1;
+        xxh_u64 const mixedh = keyed_hi * XXH_PRIME64_5;
         XXH128_hash_t h128;
         h128.low64  = XXH3_avalanche(mixedl);
         h128.high64 = XXH3_avalanche(mixedh);
@@ -1951,7 +1961,7 @@ XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
         xxh_u64 const keyed = input_64 ^ bitflip;
 
         /* Shift len to the left to ensure it is even, this avoids even multiplies. */
-        XXH128_hash_t m128 = XXH_mult64to128(keyed, PRIME64_1 + (len << 2));
+        XXH128_hash_t m128 = XXH_mult64to128(keyed, XXH_PRIME64_1 + (len << 2));
 
         m128.high64 += (m128.low64 << 1);
         m128.low64  ^= (m128.high64 >> 3);
@@ -1974,7 +1984,7 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
         xxh_u64 const bitfliph = (XXH_readLE64(secret+48) ^ XXH_readLE64(secret+56)) + seed;
         xxh_u64 const input_lo = XXH_readLE64(input);
         xxh_u64       input_hi = XXH_readLE64(input + len - 8);
-        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, PRIME64_1);
+        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, XXH_PRIME64_1);
         /*
          * Put len in the middle of m128 to ensure that the length gets mixed to
          * both the low and high bits in the 128x64 multiply below.
@@ -1983,7 +1993,7 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
         input_hi   ^= bitfliph;
         /*
          * Add the high 32 bits of input_hi to the high 32 bits of m128, then
-         * add the long product of the low 32 bits of input_hi and PRIME32_2 to
+         * add the long product of the low 32 bits of input_hi and XXH_PRIME32_2 to
          * the high 64 bits of m128.
          *
          * The best approach to this operation is different on 32-bit and 64-bit.
@@ -1995,7 +2005,7 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
              * On 32-bit, it removes an ADC and delays a dependency between the two
              * halves of m128.high64, but it generates an extra mask on 64-bit.
              */
-            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64((xxh_u32)input_hi, PRIME32_2);
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64((xxh_u32)input_hi, XXH_PRIME32_2);
         } else {
             /*
              * 64-bit optimized (albeit more confusing) version.
@@ -2005,7 +2015,7 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
              * Let:
              *    a = input_hi.lo = (input_hi & 0x00000000FFFFFFFF)
              *    b = input_hi.hi = (input_hi & 0xFFFFFFFF00000000)
-             *    c = PRIME32_2
+             *    c = XXH_PRIME32_2
              *
              *    a + (b * c)
              * Inverse Property: x + y - x == y
@@ -2016,19 +2026,19 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
              *    a + b + (b * (c - 1))
              *
              * Substitute a, b, and c:
-             *    input_hi.hi + input_hi.lo + ((xxh_u64)input_hi.lo * (PRIME32_2 - 1))
+             *    input_hi.hi + input_hi.lo + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
              *
              * Since input_hi.hi + input_hi.lo == input_hi, we get this:
-             *    input_hi + ((xxh_u64)input_hi.lo * (PRIME32_2 - 1))
+             *    input_hi + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
              */
-            m128.high64 += input_hi + XXH_mult32to64((xxh_u32)input_hi, PRIME32_2 - 1);
+            m128.high64 += input_hi + XXH_mult32to64((xxh_u32)input_hi, XXH_PRIME32_2 - 1);
         }
         /* m128 ^= XXH_swap64(m128 >> 64); */
         m128.low64  ^= XXH_swap64(m128.high64);
 
-        {   /* 128x64 multiply: h128 = m128 * PRIME64_2; */
-            XXH128_hash_t h128 = XXH_mult64to128(m128.low64, PRIME64_2);
-            h128.high64 += m128.high64 * PRIME64_2;
+        {   /* 128x64 multiply: h128 = m128 * XXH_PRIME64_2; */
+            XXH128_hash_t h128 = XXH_mult64to128(m128.low64, XXH_PRIME64_2);
+            h128.high64 += m128.high64 * XXH_PRIME64_2;
 
             h128.low64   = XXH3_avalanche(h128.low64);
             h128.high64  = XXH3_avalanche(h128.high64);
@@ -2049,8 +2059,8 @@ XXH3_len_0to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
         {   XXH128_hash_t h128;
             xxh_u64 const bitflipl = XXH_readLE64(secret+64) ^ XXH_readLE64(secret+72);
             xxh_u64 const bitfliph = XXH_readLE64(secret+80) ^ XXH_readLE64(secret+88);
-            h128.low64 = XXH3_avalanche((PRIME64_1 + seed) ^ bitflipl);
-            h128.high64 = XXH3_avalanche((PRIME64_2 - seed) ^ bitfliph);
+            h128.low64 = XXH3_avalanche((XXH_PRIME64_1 + seed) ^ bitflipl);
+            h128.high64 = XXH3_avalanche((XXH_PRIME64_2 - seed) ^ bitfliph);
             return h128;
     }   }
 }
@@ -2079,7 +2089,7 @@ XXH3_len_17to128_128b(const xxh_u8* XXH_RESTRICT input, size_t len,
     XXH_ASSERT(16 < len && len <= 128);
 
     {   XXH128_hash_t acc;
-        acc.low64 = len * PRIME64_1;
+        acc.low64 = len * XXH_PRIME64_1;
         acc.high64 = 0;
         if (len > 32) {
             if (len > 64) {
@@ -2093,9 +2103,9 @@ XXH3_len_17to128_128b(const xxh_u8* XXH_RESTRICT input, size_t len,
         acc = XXH128_mix32B(acc, input, input+len-16, secret, seed);
         {   XXH128_hash_t h128;
             h128.low64  = acc.low64 + acc.high64;
-            h128.high64 = (acc.low64    * PRIME64_1)
-                        + (acc.high64   * PRIME64_4)
-                        + ((len - seed) * PRIME64_2);
+            h128.high64 = (acc.low64    * XXH_PRIME64_1)
+                        + (acc.high64   * XXH_PRIME64_4)
+                        + ((len - seed) * XXH_PRIME64_2);
             h128.low64  = XXH3_avalanche(h128.low64);
             h128.high64 = (XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
             return h128;
@@ -2114,7 +2124,7 @@ XXH3_len_129to240_128b(const xxh_u8* XXH_RESTRICT input, size_t len,
     {   XXH128_hash_t acc;
         int const nbRounds = (int)len / 32;
         int i;
-        acc.low64 = len * PRIME64_1;
+        acc.low64 = len * XXH_PRIME64_1;
         acc.high64 = 0;
         for (i=0; i<4; i++) {
             acc = XXH128_mix32B(acc,
@@ -2142,9 +2152,9 @@ XXH3_len_129to240_128b(const xxh_u8* XXH_RESTRICT input, size_t len,
 
         {   XXH128_hash_t h128;
             h128.low64  = acc.low64 + acc.high64;
-            h128.high64 = (acc.low64    * PRIME64_1)
-                        + (acc.high64   * PRIME64_4)
-                        + ((len - seed) * PRIME64_2);
+            h128.high64 = (acc.low64    * XXH_PRIME64_1)
+                        + (acc.high64   * XXH_PRIME64_4)
+                        + ((len - seed) * XXH_PRIME64_2);
             h128.low64  = XXH3_avalanche(h128.low64);
             h128.high64 = (XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
             return h128;
@@ -2156,7 +2166,7 @@ XXH_FORCE_INLINE XXH128_hash_t
 XXH3_hashLong_128b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
                             const xxh_u8* XXH_RESTRICT secret, size_t secretSize)
 {
-    XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[ACC_NB] = XXH3_INIT_ACC;
+    XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[XXH_ACC_NB] = XXH3_INIT_ACC;
 
     XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, XXH3_acc_128bits);
 
@@ -2166,11 +2176,11 @@ XXH3_hashLong_128b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
     {   XXH128_hash_t h128;
         h128.low64  = XXH3_mergeAccs(acc,
                                      secret + XXH_SECRET_MERGEACCS_START,
-                                     (xxh_u64)len * PRIME64_1);
+                                     (xxh_u64)len * XXH_PRIME64_1);
         h128.high64 = XXH3_mergeAccs(acc,
                                      secret + secretSize
                                             - sizeof(acc) - XXH_SECRET_MERGEACCS_START,
-                                     ~((xxh_u64)len * PRIME64_2));
+                                     ~((xxh_u64)len * XXH_PRIME64_2));
         return h128;
     }
 }
@@ -2182,7 +2192,7 @@ XXH3_hashLong_128b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
 XXH_NO_INLINE XXH128_hash_t
 XXH3_hashLong_128b_defaultSecret(const xxh_u8* input, size_t len)
 {
-    return XXH3_hashLong_128b_internal(input, len, kSecret, sizeof(kSecret));
+    return XXH3_hashLong_128b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret));
 }
 
 /*
@@ -2213,11 +2223,11 @@ XXH3_hashLong_128b_withSeed(const xxh_u8* input, size_t len, XXH64_hash_t seed)
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(const void* input, size_t len)
 {
     if (len <= 16)
-        return XXH3_len_0to16_128b((const xxh_u8*)input, len, kSecret, 0);
+        return XXH3_len_0to16_128b((const xxh_u8*)input, len, XXH3_kSecret, 0);
     if (len <= 128)
-        return XXH3_len_17to128_128b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), 0);
+        return XXH3_len_17to128_128b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_128b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), 0);
+        return XXH3_len_129to240_128b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
     return XXH3_hashLong_128b_defaultSecret((const xxh_u8*)input, len);
 }
 
@@ -2244,11 +2254,11 @@ XXH_PUBLIC_API XXH128_hash_t
 XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed)
 {
     if (len <= 16)
-        return XXH3_len_0to16_128b((const xxh_u8*)input, len, kSecret, seed);
+        return XXH3_len_0to16_128b((const xxh_u8*)input, len, XXH3_kSecret, seed);
     if (len <= 128)
-         return XXH3_len_17to128_128b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), seed);
+         return XXH3_len_17to128_128b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
     if (len <= XXH3_MIDSIZE_MAX)
-         return XXH3_len_129to240_128b((const xxh_u8*)input, len, kSecret, sizeof(kSecret), seed);
+         return XXH3_len_129to240_128b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
     return XXH3_hashLong_128b_withSeed((const xxh_u8*)input, len, seed);
 }
 
@@ -2278,7 +2288,7 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_128bits_reset(XXH3_state_t* statePtr)
 {
     if (statePtr == NULL) return XXH_ERROR;
-    XXH3_128bits_reset_internal(statePtr, 0, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    XXH3_128bits_reset_internal(statePtr, 0, XXH3_kSecret, XXH_SECRET_DEFAULT_SIZE);
     return XXH_OK;
 }
 
@@ -2296,7 +2306,7 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
 {
     if (statePtr == NULL) return XXH_ERROR;
-    XXH3_128bits_reset_internal(statePtr, seed, kSecret, XXH_SECRET_DEFAULT_SIZE);
+    XXH3_128bits_reset_internal(statePtr, seed, XXH3_kSecret, XXH_SECRET_DEFAULT_SIZE);
     XXH3_initCustomSecret(statePtr->customSecret, seed);
     statePtr->secret = statePtr->customSecret;
     return XXH_OK;
@@ -2311,17 +2321,17 @@ XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len)
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
 {
     if (state->totalLen > XXH3_MIDSIZE_MAX) {
-        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[ACC_NB];
+        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[XXH_ACC_NB];
         XXH3_digest_long(acc, state, XXH3_acc_128bits);
-        XXH_ASSERT(state->secretLimit + STRIPE_LEN >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+        XXH_ASSERT(state->secretLimit + XXH_STRIPE_LEN >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
         {   XXH128_hash_t h128;
             h128.low64  = XXH3_mergeAccs(acc,
                                          state->secret + XXH_SECRET_MERGEACCS_START,
-                                         (xxh_u64)state->totalLen * PRIME64_1);
+                                         (xxh_u64)state->totalLen * XXH_PRIME64_1);
             h128.high64 = XXH3_mergeAccs(acc,
-                                         state->secret + state->secretLimit + STRIPE_LEN
+                                         state->secret + state->secretLimit + XXH_STRIPE_LEN
                                                        - sizeof(acc) - XXH_SECRET_MERGEACCS_START,
-                                         ~((xxh_u64)state->totalLen * PRIME64_2));
+                                         ~((xxh_u64)state->totalLen * XXH_PRIME64_2));
             return h128;
         }
     }
@@ -2329,7 +2339,7 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
     if (state->seed)
         return XXH3_128bits_withSeed(state->buffer, (size_t)state->totalLen, state->seed);
     return XXH3_128bits_withSecret(state->buffer, (size_t)(state->totalLen),
-                                   state->secret, state->secretLimit + STRIPE_LEN);
+                                   state->secret, state->secretLimit + XXH_STRIPE_LEN);
 }
 
 /* 128-bit utility functions */

--- a/xxh3.h
+++ b/xxh3.h
@@ -407,7 +407,7 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_loadu(const void *ptr)
  /* s390x is always big endian, no issue on this platform */
 #  define XXH_vec_mulo vec_mulo
 #  define XXH_vec_mule vec_mule
-# elif defined(__clang__) && __has_builtin(__builtin_altivec_vmuleuw)
+# elif defined(__clang__) && XXH_HAS_BUILTIN(__builtin_altivec_vmuleuw)
 /* Clang has a better way to control this, we can just use the builtin which doesn't swap. */
 #  define XXH_vec_mulo __builtin_altivec_vmulouw
 #  define XXH_vec_mule __builtin_altivec_vmuleuw

--- a/xxhash.h
+++ b/xxhash.h
@@ -950,7 +950,8 @@ typedef union { xxh_u32 u32; } __attribute__((packed)) unalign;
 static xxh_u32 XXH_read32(const void* ptr)
 {
     typedef union { xxh_u32 u32; } __attribute__((packed)) xxh_unalign;
-    return ((const xxh_unalign*)ptr)->u32; }
+    return ((const xxh_unalign*)ptr)->u32;
+}
 
 #else
 
@@ -1538,9 +1539,11 @@ static xxh_u64 XXH_read64(const void* memPtr) { return *(const xxh_u64*) memPtr;
 #ifdef XXH_OLD_NAMES
 typedef union { xxh_u32 u32; xxh_u64 u64; } __attribute__((packed)) unalign64;
 #endif
-static xxh_u64 XXH_read64(const void* ptr) {
+static xxh_u64 XXH_read64(const void* ptr)
+{
     typedef union { xxh_u32 u32; xxh_u64 u64; } __attribute__((packed)) xxh_unalign64;
-    return ((const xxh_unalign64*)ptr)->u64; }
+    return ((const xxh_unalign64*)ptr)->u64;
+}
 
 #else
 


### PR DESCRIPTION
 - Every symbol, typedef, and macro is prefixed with `XXH` or `xxh`.
 - For compatibility with legacy code that messes with the internals, `XXH_OLD_NAMES` can be defined to wrap old names in macros. This also brings back `U32` and friends.