### PR TITLE
Remove "Loading..." from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ test-xxhsum-c: xxhsum
 	# xxhsum does not display "Loading" message into stderr either
 	! ./xxhsum xxh* 2>&1 | grep Loading
 	# Check that xxhsum do display filename that it failed to open.
-	LC_ALL=C xxhsum noneexistent 2>&1 | grep "Error: Could not open 'nonexistent'"
+	LC_ALL=C ./xxhsum noneexistent 2>&1 | grep "Error: Could not open 'nonexistent'"
 	# xxhsum to/from file, shell redirection
 	./xxhsum xxh* > .test.xxh64
 	./xxhsum -H0 xxh* > .test.xxh32

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ test-xxhsum-c: xxhsum
 	! ./xxhsum -q xxh* 2>&1 | grep Loading
 	# xxhsum does not display "Loading" message into stderr either
 	! ./xxhsum xxh* 2>&1 | grep Loading
+	# Check that xxhsum do display filename that it failed to open.
+	LC_ALL=C xxhsum noneexistent 2>&1 | grep "Error: Could not open 'nonexistent'"
 	# xxhsum to/from file, shell redirection
 	./xxhsum xxh* > .test.xxh64
 	./xxhsum -H0 xxh* > .test.xxh32

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,8 @@ test-xxhsum-c: xxhsum
 	./xxhsum -H0 xxh* | ./xxhsum -c -
 	# xxhsum -q does not display "Loading" message into stderr (#251)
 	! ./xxhsum -q xxh* 2>&1 | grep Loading
+	# xxhsum does not display "Loading" message into stderr either
+	! ./xxhsum xxh* 2>&1 | grep Loading
 	# xxhsum to/from file, shell redirection
 	./xxhsum xxh* > .test.xxh64
 	./xxhsum -H0 xxh* > .test.xxh32

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ test-xxhsum-c: xxhsum
 	# xxhsum does not display "Loading" message into stderr either
 	! ./xxhsum xxh* 2>&1 | grep Loading
 	# Check that xxhsum do display filename that it failed to open.
-	LC_ALL=C ./xxhsum noneexistent 2>&1 | grep "Error: Could not open 'nonexistent'"
+	LC_ALL=C ./xxhsum nonexistent 2>&1 | grep "Error: Could not open 'nonexistent'"
 	# xxhsum to/from file, shell redirection
 	./xxhsum xxh* > .test.xxh64
 	./xxhsum -H0 xxh* > .test.xxh32

--- a/xxhsum.1
+++ b/xxhsum.1
@@ -42,10 +42,6 @@ Displays xxhsum version and exits
 Hash selection\. \fIHASHTYPE\fR means \fB0\fR=32bits, \fB1\fR=64bits, \fB2\fR=128bits\. Default value is \fB1\fR (64bits)
 .
 .TP
-\fB\-q\fR, \fB\-\-quiet\fR
-Remove status messages like "Loading\.\.\." written to \fBstderr\fR \.
-.
-.TP
 \fB\-\-little\-endian\fR
 Set output hexadecimal checksum value as little endian convention\. By default, value is displayed as big endian\.
 .
@@ -62,7 +58,7 @@ Read xxHash sums from \fIFILE\fR and check them
 .
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
-On top of removing status messages written to \fBstderr\fR, also don\'t print OK for each successfully verified file
+Don\'t print OK for each successfully verified file
 .
 .TP
 \fB\-\-strict\fR

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -39,9 +39,6 @@ OPTIONS
   Hash selection. <HASHTYPE> means `0`=32bits, `1`=64bits, `2`=128bits.
   Default value is `1` (64bits)
 
-* `-q`, `--quiet`:
-  Remove status messages like "Loading..." written to `stderr`.
-
 * `--little-endian`:
   Set output hexadecimal checksum value as little endian convention.
   By default, value is displayed as big endian.
@@ -55,9 +52,8 @@ OPTIONS
   Read xxHash sums from <FILE> and check them
 
 * `-q`, `--quiet`:
-  On top of removing status messages written to `stderr`,
-  also don't print OK for each successfully verified file
-
+  Don't print OK for each successfully verified file
+  
 * `--strict`:
   Return an error code if any line in the file is invalid,
   not just if some checksums are wrong.

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1359,24 +1359,11 @@ static int BMK_hash(const char* fileName,
         return 1;
     }
 
-    /* loading notification */
-    {   const size_t fileNameSize = strlen(fileName);
-        const char* const fileNameEnd = fileName + fileNameSize;
-        const int maxInfoFilenameSize = (int)(fileNameSize > 30 ? 30 : fileNameSize);
-        int infoFilenameSize = 1;
-        while ((infoFilenameSize < maxInfoFilenameSize)
-            && (fileNameEnd[-1-infoFilenameSize] != '/')
-            && (fileNameEnd[-1-infoFilenameSize] != '\\') )
-              infoFilenameSize++;
-        DISPLAYLEVEL(2, "\rLoading %s...  \r", fileNameEnd - infoFilenameSize);
+    /* Load file & update hash */
+    hashValue = BMK_hashStream(inFile, hashType, buffer, blockSize);
 
-        /* Load file & update hash */
-        hashValue = BMK_hashStream(inFile, hashType, buffer, blockSize);
-
-        fclose(inFile);
-        free(buffer);
-        DISPLAYLEVEL(2, "%*s             \r", infoFilenameSize, "");  /* erase line */
-    }
+    fclose(inFile);
+    free(buffer);
 
     /* display Hash value followed by file name */
     switch(hashType)

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -834,7 +834,6 @@ static int BMK_benchFiles(char** fileNamesTable, int nbFiles, U32 specificTest)
             }
 
             /* Fill input buffer */
-            DISPLAYLEVEL(2, "\rLoading %s...        \n", inFileName);
             {   size_t const readSize = fread(alignedBuffer, 1, benchedSize, inFile);
                 fclose(inFile);
                 if(readSize != benchedSize) {
@@ -1958,11 +1957,11 @@ static int usage_advanced(const char* exename)
     usage(exename);
     DISPLAY( "Advanced :\n");
     DISPLAY( "  -V, --version        Display version information \n");
-    DISPLAY( "  -q, --quiet          Do not display 'Loading' messages \n");
     DISPLAY( "      --little-endian  Display hashes in little endian convention (default: big endian) \n");
     DISPLAY( "  -b                   Run benchmark (all variants, default) \n");
     DISPLAY( "  -b#                  Bench only variant # \n");
     DISPLAY( "  -i ITERATIONS        Number of times to run the benchmark (default: %u) \n", (unsigned)g_nbIterations);
+    DISPLAY( "  -q, --quiet          Don't display version header in benchmark mode \n");
     DISPLAY( "\n");
     DISPLAY( "The following four options are useful only when verifying checksums (-c): \n");
     DISPLAY( "  -q, --quiet          Don't print OK for each successfully verified file \n");


### PR DESCRIPTION
This makes it way easier to use xxhsum in scripts as a drop-in replacement for sha256sum, md5sum, etc, and stops polluting log files after such replacement. The Loading message also serves no real and demonstrably useful purpose, and messes up with console sometimes, or significantly slows down processing when processing big number of files (10k+).

I am aware of `--quiet` option, but sometimes some tools expect single binary name, not binary with flags, (i.e. `find -exec "xxh64sum --quiet"` will not work). And again, it should be default. All existing popular hash functions don't print such unneeded diagnostics.