### PR TITLE
simplified XXH_PREFETCH_DIST logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,33 +95,38 @@ The following macros can be set at compilation time to modify libxxhash's behavi
 - `XXH_INLINE_ALL`: Make all functions `inline`, with implementations being directly included within `xxhash.h`.
                     Inlining functions is beneficial for speed on small keys.
                     It's _extremely effective_ when key length is expressed as _a compile time constant_,
-                    with performance improvements being observed in the +200% range .
+                    with performance improvements observed in the +200% range .
                     See [this article](https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html) for details.
-                    Note: there is no need to compile an `xxhash.o` object file in this case.
-- `XXH_NO_INLINE_HINTS`: By default, xxHash uses tricks like `__attribute__((always_inline))` and `__forceinline` to try and improve performance at the cost of code size. Defining this to 1 will mark all internal functions as `static`, allowing the compiler to decide whether to inline a function or not. This is very useful when optimizing for the smallest binary size, and it is automatically defined when compiling with `-O0`, `-Os`, `-Oz`, or `-fno-inline` on GCC and Clang. This may also increase performance depending on the compiler and the architecture.
-- `XXH_REROLL`: Reduces the size of the generated code by not unrolling some loops. Impact on performance may vary, depending on the platform and the algorithm.
+- `XXH_PRIVATE_API`: same outcome as `XXH_INLINE_ALL`. Still available for legacy reasons.
+                    The different name underlines that XXH_* symbols will not be exported.
+- `XXH_NAMESPACE`: Prefixes all symbols with the value of `XXH_NAMESPACE`.
+                    This macro can only use compilable character set.
+                    Useful to evade symbol naming collisions,
+                    in case of multiple inclusions of xxHash's source code.
+                    Client applications still use the regular function name,
+                    as symbols are automatically translated through `xxhash.h`.
 - `XXH_ACCEPT_NULL_INPUT_POINTER`: if set to `1`, when input is a `NULL` pointer,
                                    xxHash'd result is the same as a zero-length input
                                    (instead of a dereference segfault).
-                                   Adds one branch at the beginning of the hash.
+                                   Adds one branch at the beginning of each hash.
 - `XXH_FORCE_MEMORY_ACCESS`: The default method `0` uses a portable `memcpy()` notation.
                              Method `1` uses a gcc-specific `packed` attribute, which can provide better performance for some targets.
                              Method `2` forces unaligned reads, which is not standards compliant, but might sometimes be the only way to extract better read performance.
                              Method `3` uses a byteshift operation, which is best for old compilers which don't inline `memcpy()` or big-endian systems without a byteswap instruction
-- `XXH_CPU_LITTLE_ENDIAN`: By default, endianess is determined at compile time.
-                           It's possible to skip auto-detection and force format to little-endian, by setting this macro to 1.
-                            Setting it to 0 forces big-endian.
-- `XXH_PRIVATE_API`: same impact as `XXH_INLINE_ALL`.
-                     Name underlines that XXH_* symbols will not be exported.
-- `XXH_NAMESPACE`: Prefixes all symbols with the value of `XXH_NAMESPACE`.
-                    Useful to evade symbol naming collisions,
-                    in case of multiple inclusions of xxHash's source code.
-                    Client applications can still use the regular function name,
-                    as symbols are automatically translated through `xxhash.h`.
+- `XXH_NO_PREFETCH` : disable prefetching. XXH3 only.
+- `XXH_PREFETCH_DIST` : select prefecting distance. XXH3 only.
+- `XXH_NO_INLINE_HINTS`: By default, xxHash uses tricks like `__attribute__((always_inline))` and `__forceinline` to try and improve performance at the cost of code size.
+                    Defining this to 1 will mark all internal functions as `static`, allowing the compiler to decide whether to inline a function or not.
+                    This is very useful when optimizing for the smallest binary size, and it is automatically defined when compiling with `-O0`, `-Os`, `-Oz`, or `-fno-inline` on GCC and Clang.
+                    This may also increase performance depending on the compiler and the architecture.
+- `XXH_REROLL`: Reduces the size of the generated code by not unrolling some loops. Impact on performance may vary, depending on the platform and the algorithm.
 - `XXH_STATIC_LINKING_ONLY`: gives access to the state declaration for static allocation.
                              Incompatible with dynamic linking, due to risks of ABI changes.
 - `XXH_NO_LONG_LONG`: removes support for XXH3 and XXH64 for targets without 64-bit support.
 - `XXH_IMPORT`: MSVC specific: should only be defined for dynamic linking, as it prevents linkage errors.
+- `XXH_CPU_LITTLE_ENDIAN`: By default, endianess is determined at compile time, but if compiler cannot determine endianness, it becomes a runtime test.
+                           It's possible to skip auto-detection and force format to little-endian, by setting this macro to 1.
+                           Setting it to 0 forces big-endian.
 
 
 ### Building xxHash - Using vcpkg
@@ -172,7 +177,7 @@ XXH64_hash_t calcul_hash_streaming(FileHandler fh)
     /* Feed the state with input data, any size, any number of times */
     (...)
     while ( /* any condition */ ) {
-        size_t const length = get_more_data(buffer, bufferSize, fh);   
+        size_t const length = get_more_data(buffer, bufferSize, fh);
         if (XXH64_update(state, buffer, length) == XXH_ERROR) abort();
         (...)
     }


### PR DESCRIPTION
distinguishes :
- `__clang__` : 320
- `AVX512` : 512
- the rest : 384

conflict with #350