### PR TITLE
remove alignment check on aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,43 +90,52 @@ After which, return values of `XXH3` and `XXH128` will no longer change in futur
 
 ### Build modifiers
 
-The following macros can be set at compilation time to modify libxxhash's behavior. They are all disabled by default.
+The following macros can be set at compilation time to modify libxxhash's behavior. They are generally disabled by default.
 
 - `XXH_INLINE_ALL`: Make all functions `inline`, with implementations being directly included within `xxhash.h`.
                     Inlining functions is beneficial for speed on small keys.
                     It's _extremely effective_ when key length is expressed as _a compile time constant_,
                     with performance improvements observed in the +200% range .
                     See [this article](https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html) for details.
-- `XXH_PRIVATE_API`: same outcome as `XXH_INLINE_ALL`. Still available for legacy reasons.
-                    The different name underlines that XXH_* symbols will not be exported.
+- `XXH_PRIVATE_API`: same outcome as `XXH_INLINE_ALL`. Still available for legacy support.
+                     The name underlines that `XXH_*` symbols will not be exported.
 - `XXH_NAMESPACE`: Prefixes all symbols with the value of `XXH_NAMESPACE`.
-                    This macro can only use compilable character set.
-                    Useful to evade symbol naming collisions,
-                    in case of multiple inclusions of xxHash's source code.
-                    Client applications still use the regular function name,
-                    as symbols are automatically translated through `xxhash.h`.
-- `XXH_ACCEPT_NULL_INPUT_POINTER`: if set to `1`, when input is a `NULL` pointer,
-                                   xxHash'd result is the same as a zero-length input
-                                   (instead of a dereference segfault).
-                                   Adds one branch at the beginning of each hash.
+                   This macro can only use compilable character set.
+                   Useful to evade symbol naming collisions,
+                   in case of multiple inclusions of xxHash's source code.
+                   Client applications still use the regular function names,
+                   as symbols are automatically translated through `xxhash.h`.
 - `XXH_FORCE_MEMORY_ACCESS`: The default method `0` uses a portable `memcpy()` notation.
                              Method `1` uses a gcc-specific `packed` attribute, which can provide better performance for some targets.
                              Method `2` forces unaligned reads, which is not standards compliant, but might sometimes be the only way to extract better read performance.
                              Method `3` uses a byteshift operation, which is best for old compilers which don't inline `memcpy()` or big-endian systems without a byteswap instruction
+- `XXH_FORCE_ALIGN_CHECK`: Use a faster direct read path when input is aligned.
+                           This option can result in dramatic performance improvement when input to hash is aligned on 32 or 64-bit boundaries,
+                           when running on architectures unable to load memory from unaligned addresses, or suffering a performance penalty from it.
+                           It is (slightly) detrimental on platform with good unaligned memory access performance (same instruction for both aligned and unaligned accesses).
+                           This option is automatically disabled on `x86`, `x64` and `aarch64`, and enabled on all other platforms.
 - `XXH_NO_PREFETCH` : disable prefetching. XXH3 only.
 - `XXH_PREFETCH_DIST` : select prefecting distance. XXH3 only.
-- `XXH_NO_INLINE_HINTS`: By default, xxHash uses tricks like `__attribute__((always_inline))` and `__forceinline` to try and improve performance at the cost of code size.
-                    Defining this to 1 will mark all internal functions as `static`, allowing the compiler to decide whether to inline a function or not.
-                    This is very useful when optimizing for the smallest binary size, and it is automatically defined when compiling with `-O0`, `-Os`, `-Oz`, or `-fno-inline` on GCC and Clang.
-                    This may also increase performance depending on the compiler and the architecture.
-- `XXH_REROLL`: Reduces the size of the generated code by not unrolling some loops. Impact on performance may vary, depending on the platform and the algorithm.
+- `XXH_NO_INLINE_HINTS`: By default, xxHash uses tricks like `__attribute__((always_inline))` and `__forceinline` to improve performance at the cost of code size.
+                         Defining this macro to 1 will mark all internal functions as `static`, allowing the compiler to decide whether to inline a function or not.
+                         This is very useful when optimizing for smallest binary size,
+                         and is automatically defined when compiling with `-O0`, `-Os`, `-Oz`, or `-fno-inline` on GCC and Clang.
+                         This may also increase performance depending on compiler and architecture.
+- `XXH_REROLL`: Reduces the size of the generated code by not unrolling some loops.
+                Impact on performance may vary, depending on platform and algorithm.
+- `XXH_ACCEPT_NULL_INPUT_POINTER`: if set to `1`, when input is a `NULL` pointer,
+                                   xxHash'd result is the same as a zero-length input
+                                   (instead of a dereference segfault).
+                                   Adds one branch at the beginning of each hash.
 - `XXH_STATIC_LINKING_ONLY`: gives access to the state declaration for static allocation.
                              Incompatible with dynamic linking, due to risks of ABI changes.
-- `XXH_NO_LONG_LONG`: removes support for XXH3 and XXH64 for targets without 64-bit support.
+- `XXH_NO_LONG_LONG`: removes compilation of algorithms relying on 64-bit types (XXH3 and XXH64). Only XXH32 will be compiled.
+                      Useful for targets (architectures and compilers) without 64-bit support.
 - `XXH_IMPORT`: MSVC specific: should only be defined for dynamic linking, as it prevents linkage errors.
-- `XXH_CPU_LITTLE_ENDIAN`: By default, endianess is determined at compile time, but if compiler cannot determine endianness, it becomes a runtime test.
-                           It's possible to skip auto-detection and force format to little-endian, by setting this macro to 1.
-                           Setting it to 0 forces big-endian.
+- `XXH_CPU_LITTLE_ENDIAN`: By default, endianess is determined by a runtime test resolved at compile time.
+                           If, for some reason, the compiler cannot simplify the runtime test, it can cost performance.
+                           It's possible to skip auto-detection and simply state that the architecture is little-endian by setting this macro to 1.
+                           Setting it to 0 states big-endian.
 
 
 ### Building xxHash - Using vcpkg


### PR DESCRIPTION
as this architecture offers decent performance for unaligned memory accesses (like `x86`/`x64`).

This modification circumvents the problem described in #383,
as the direct read path using `const xxh_u32*` will not be generated by default.

Note however that this does not go at the root of the problem,
which is currently presumed to be related to strict-aliasing
when using the direct read path _and_ inlining `XXH32()`.
This deeper issue however is more difficult to solve without a reproduction case.

I also used this opportunity to fix or reinforce documentation.