### PR TITLE
Intel vector instruction dispatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ xxhsum
 xxhsum32
 xxhsum_privateXXH
 xxhsum_inlinedXXH
+dispatch
 tests/generate_unicode_test
 
 # compilation chain

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
             - cppcheck
       script:
         - make -B test-all
+        - make clean
+        - make dispatch
 
     - name: Check results consistency on x64
       arch: amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - make clean
         - CPPFLAGS="-mavx2 -DXXH_VECTOR=2" make check   # AVX2 code path
         - make clean
-        - CPPFLAGS="-mavx512f -DXXH_VECTOR=5" make check   # AVX512 code path
+        - CPPFLAGS="-mavx512f -DXXH_VECTOR=3" make check   # AVX512 code path
         - make clean
         - CPPFLAGS=-DXXH_REROLL=1 make check   # reroll code path (#240)
         - make -C tests/bench
@@ -52,7 +52,7 @@ matrix:
         - CC=arm-linux-gnueabi-gcc CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static RUN_ENV=qemu-arm-static make check   # Scalar code path
         - make clean
         # NEON (32-bit)
-        - CC=arm-linux-gnueabi-gcc CPPFLAGS=-DXXH_VECTOR=3 CFLAGS="-O3 -march=armv7-a -fPIC -mfloat-abi=softfp -mfpu=neon-vfpv4" LDFLAGS=-static RUN_ENV=qemu-arm-static make check   # NEON code path
+        - CC=arm-linux-gnueabi-gcc CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -march=armv7-a -fPIC -mfloat-abi=softfp -mfpu=neon-vfpv4" LDFLAGS=-static RUN_ENV=qemu-arm-static make check   # NEON code path
 
     - name: aarch64 compilation and consistency checks
       dist: xenial
@@ -62,13 +62,13 @@ matrix:
         - CPPFLAGS=-DXXH_VECTOR=0 make check   # Scalar code path
         # NEON (64-bit)
         - make clean
-        - CPPFLAGS=-DXXH_VECTOR=3 make check   # NEON code path
+        - CPPFLAGS=-DXXH_VECTOR=4 make check   # NEON code path
         # clang
         - make clean
         - CC=clang CPPFLAGS=-DXXH_VECTOR=0 make check   # Scalar code path
         # clang + NEON
         - make clean
-        - CC=clang CPPFLAGS=-DXXH_VECTOR=3 make check   # NEON code path
+        - CC=clang CPPFLAGS=-DXXH_VECTOR=4 make check   # NEON code path
 
     # We need Bionic here because the QEMU versions shipped in the older repos
     # do not support POWER8 emulation, and compiling QEMU from source is a pain.
@@ -90,7 +90,7 @@ matrix:
         - CC=powerpc64-linux-gnu-gcc RUN_ENV=qemu-ppc64-static CPPFLAGS=-DXXH_VECTOR=0 CFLAGS="-O3" LDFLAGS="-static -m64" make check   # Scalar code path
         - make clean
         # VSX code
-        - CC=powerpc64-linux-gnu-gcc RUN_ENV="qemu-ppc64-static -cpu power8" CFLAGS="-O3 -maltivec -mvsx -mcpu=power8 -mpower8-vector" LDFLAGS="-static -m64" make check   # Auto code path
+        - CC=powerpc64-linux-gnu-gcc RUN_ENV="qemu-ppc64-static -cpu power8" CPPFLAGS=-DXXH_VECTOR=5 CFLAGS="-O3 -maltivec -mvsx -mcpu=power8 -mpower8-vector" LDFLAGS="-static -m64" make check   # Auto code path
         - make clean
 
     - name: PPC64LE compilation and consistency checks
@@ -101,7 +101,7 @@ matrix:
         - CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static make check
         # VSX code path (64-bit)
         - make clean
-        - CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" make check
+        - CPPFLAGS=-DXXH_VECTOR=5 CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" make check
 
     - name: IBM s390x compilation and consistency checks
       dist: bionic
@@ -111,7 +111,7 @@ matrix:
         - CPPFLAGS=-DXXH_VECTOR=0 LDFLAGS=-static make check
         # s390x code path (64-bit)
         - make clean
-        - CPPFLAGS=-DXXH_VECTOR=4 CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" make check
+        - CPPFLAGS=-DXXH_VECTOR=5 CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" make check
 
     - name: cmake build test
       script:

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ default: lib xxhsum_and_links
 all: lib xxhsum xxhsum_inlinedXXH
 
 ## xxhsum is the command line interface (CLI)
+ifeq ($(DISPATCH),1)
+xxhsum: CPPFLAGS += -DXXHSUM_DISPATCH=1
+xxhsum: xxh_x86dispatch.o
+endif
 xxhsum: xxhash.o xxhsum.o
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 

--- a/Makefile
+++ b/Makefile
@@ -68,15 +68,16 @@ endif
 LIBXXH = libxxhash.$(SHARED_EXT_VER)
 
 
+## generate CLI and libraries in release mode (default for `make`)
 .PHONY: default
-default:  ## generate CLI and libraries in release mode (default for `make`)
 default: DEBUGFLAGS=
 default: lib xxhsum_and_links
 
 .PHONY: all
-all: lib xxhsum xxhsum_inlinedXXH
+all: lib xxhsum xxhsum_inlinedXXH dispatch
 
-xxhsum: xxhash.o xxhsum.o  ## generate command line interface (CLI)
+## xxhsum is the command line interface (CLI)
+xxhsum: xxhash.o xxhsum.o
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 
 xxhsum32: CFLAGS += -m32  ## generate CLI in 32-bits mode
@@ -88,7 +89,7 @@ dispatch: xxhash.o xxh_x86dispatch.o xxhsum.c
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 
 xxhash.o: xxhash.c xxhash.h xxh3.h
-xxhsum.o: xxhsum.c xxhash.h xxh3.h
+xxhsum.o: xxhsum.c xxhash.h xxh3.h xxh_x86dispatch.h
 xxh_x86dispatch.o: xxh_x86dispatch.c xxh_x86dispatch.h xxhash.h xxh3.h
 
 .PHONY: xxhsum_and_links

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ default: DEBUGFLAGS=
 default: lib xxhsum_and_links
 
 .PHONY: all
-all: lib xxhsum xxhsum_inlinedXXH dispatch
+all: lib xxhsum xxhsum_inlinedXXH
 
 ## xxhsum is the command line interface (CLI)
 xxhsum: xxhash.o xxhsum.o
@@ -84,6 +84,7 @@ xxhsum32: CFLAGS += -m32  ## generate CLI in 32-bits mode
 xxhsum32: xxhash.c xxhsum.c  ## do not generate object (avoid mixing different ABI)
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 
+## dispatch only works for x86/x64 systems
 dispatch: CPPFLAGS += -DXXHSUM_DISPATCH=1
 dispatch: xxhash.o xxh_x86dispatch.o xxhsum.c
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,18 @@ xxhsum32: CFLAGS += -m32  ## generate CLI in 32-bits mode
 xxhsum32: xxhash.c xxhsum.c  ## do not generate object (avoid mixing different ABI)
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 
+dispatch: CPPFLAGS += -DXXHSUM_DISPATCH=1
+dispatch: xxhash.o xxh_x86dispatch.o xxhsum.c
+	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
+
 xxhash.o: xxhash.c xxhash.h xxh3.h
 	$(CC) $(FLAGS) -c $< -o $@
-xxhsum.o: xxhsum.c xxhash.h
+xxhsum.o: xxhsum.c xxhash.h xxh3.h
+	$(CC) $(FLAGS) -c $< -o $@
+xxh_x86dispatch.o: CPPFLAGS += -DXXH_DISPATCH_DEBUG=1
+xxh_x86dispatch.o: CFLAGS += -mavx2
+#xxh_x86dispatch.o: CFLAGS += -mavx512f  # crashes ??
+xxh_x86dispatch.o: xxh_x86dispatch.c xxh_x86dispatch.h xxhash.h xxh3.h
 	$(CC) $(FLAGS) -c $< -o $@
 
 .PHONY: xxhsum_and_links
@@ -147,7 +156,7 @@ help:  ## list documented targets
 clean:  ## remove all build artifacts
 	@$(RM) -r *.dSYM   # Mac OS-X specific
 	@$(RM) core *.o *.$(SHARED_EXT) *.$(SHARED_EXT).* *.a libxxhash.pc
-	@$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT)
+	@$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) dispatch$(EXT)
 	@$(RM) xxh32sum$(EXT) xxh64sum$(EXT) xxh128sum$(EXT)
 	@echo cleaning completed
 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ DEBUGFLAGS+=-Wall -Wextra -Wconversion -Wcast-qual -Wcast-align -Wshadow \
             -Wstrict-prototypes -Wundef -Wpointer-arith -Wformat-security \
             -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings \
             -Wredundant-decls -Wstrict-overflow=2
-CFLAGS += $(DEBUGFLAGS)
-FLAGS   = $(CFLAGS) $(CPPFLAGS) $(MOREFLAGS)
+CFLAGS += $(DEBUGFLAGS) $(MOREFLAGS)
+FLAGS   = $(CFLAGS) $(CPPFLAGS)
 XXHSUM_VERSION = $(LIBVER)
 
 # Define *.exe as extension for Windows systems
@@ -88,14 +88,8 @@ dispatch: xxhash.o xxh_x86dispatch.o xxhsum.c
 	$(CC) $(FLAGS) $^ $(LDFLAGS) -o $@$(EXT)
 
 xxhash.o: xxhash.c xxhash.h xxh3.h
-	$(CC) $(FLAGS) -c $< -o $@
 xxhsum.o: xxhsum.c xxhash.h xxh3.h
-	$(CC) $(FLAGS) -c $< -o $@
-xxh_x86dispatch.o: CPPFLAGS += -DXXH_DISPATCH_DEBUG=1
-xxh_x86dispatch.o: CFLAGS += -mavx2
-#xxh_x86dispatch.o: CFLAGS += -mavx512f  # crashes ??
 xxh_x86dispatch.o: xxh_x86dispatch.c xxh_x86dispatch.h xxhash.h xxh3.h
-	$(CC) $(FLAGS) -c $< -o $@
 
 .PHONY: xxhsum_and_links
 xxhsum_and_links: xxhsum xxh32sum xxh64sum xxh128sum

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ which can be observed in the following graphs:
 To access these new prototypes, one needs to unlock their declaration, using the build macro `XXH_STATIC_LINKING_ONLY`.
 
 The algorithm is currently in development, meaning its return values might still change in future versions.
-However, the API is stable, and can be used in production, typically for ephemeral
-data (produced and consumed in same session).
+However, the API is stable, and can be used in production,
+typically for generation of ephemeral hashes (produced and consumed in same session).
 
 `XXH3` has now reached "release candidate" status.
 If everything remains fine, its format will be "frozen" and become final.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ The following macros can be set at compilation time to modify libxxhash's behavi
                            It's possible to skip auto-detection and simply state that the architecture is little-endian by setting this macro to 1.
                            Setting it to 0 states big-endian.
 
+For the Command Line Interface `xxhsum`, the following environment variables can also be set :
+- `DISPATCH=1` : use `xxh_x86dispatch.c`, to automatically select between `scalar`, `sse2`, `avx2` or `avx512` instruction set at runtime, depending on local host. This option is only valid for `x86`/`x64` systems.
+
 
 ### Building xxHash - Using vcpkg
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ The algorithm is currently in development, meaning its return values might still
 However, the API is stable, and can be used in production, typically for ephemeral
 data (produced and consumed in same session).
 
-Since `v0.7.3`, `XXH3` has reached "release candidate" status,
-meaning that, if everything remains fine, its current format will be "frozen" and become the final one.
+`XXH3` has now reached "release candidate" status.
+If everything remains fine, its format will be "frozen" and become final.
 After which, return values of `XXH3` and `XXH128` will no longer change in future versions.
 `XXH3`'s return values will be officially finalized upon reaching `v0.8.0`.
 
@@ -114,9 +114,10 @@ The following macros can be set at compilation time to modify libxxhash's behavi
                            when running on architectures unable to load memory from unaligned addresses, or suffering a performance penalty from it.
                            It is (slightly) detrimental on platform with good unaligned memory access performance (same instruction for both aligned and unaligned accesses).
                            This option is automatically disabled on `x86`, `x64` and `aarch64`, and enabled on all other platforms.
+- `XXH_VECTOR` : manually select a vector instruction set (default: auto-selected at compilation time). `0`==`scalar`, `1`==`sse2`, `2`==`avx2`, `3`==`avx512`, `4`==`neon`, `5`==`vsx`
 - `XXH_NO_PREFETCH` : disable prefetching. XXH3 only.
 - `XXH_PREFETCH_DIST` : select prefecting distance. XXH3 only.
-- `XXH_NO_INLINE_HINTS`: By default, xxHash uses tricks like `__attribute__((always_inline))` and `__forceinline` to improve performance at the cost of code size.
+- `XXH_NO_INLINE_HINTS`: By default, xxHash uses `__attribute__((always_inline))` and `__forceinline` to improve performance at the cost of code size.
                          Defining this macro to 1 will mark all internal functions as `static`, allowing the compiler to decide whether to inline a function or not.
                          This is very useful when optimizing for smallest binary size,
                          and is automatically defined when compiling with `-O0`, `-Os`, `-Oz`, or `-fno-inline` on GCC and Clang.

--- a/xxh3.h
+++ b/xxh3.h
@@ -983,27 +983,29 @@ XXH3_accumulate_512_avx512(void* XXH_RESTRICT acc,
     XXH_ASSERT((((size_t)acc) & 63) == 0);
     XXH_STATIC_ASSERT(XXH_STRIPE_LEN == sizeof(__m512i));
 
-    /* data_vec    = input[0]; */
-    __m512i const data_vec    = _mm512_loadu_si512   (input);
-    /* key_vec     = secret[0]; */
-    __m512i const key_vec     = _mm512_loadu_si512   (secret);
-    /* data_key    = data_vec ^ key_vec; */
-    __m512i const data_key    = _mm512_xor_si512     (data_vec, key_vec);
-    /* data_key_lo = data_key >> 32; */
-    __m512i const data_key_lo = _mm512_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
-    /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
-    __m512i const product     = _mm512_mul_epu32     (data_key, data_key_lo);
-    if (accWidth == XXH3_acc_128bits) {
-        /* xacc[0] += swap(data_vec); */
-        __m512i const data_swap = _mm512_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
-        __m512i const sum       = _mm512_add_epi64(*xacc, data_swap);
-        /* xacc[0] += product; */
-        *xacc = _mm512_add_epi64(product, sum);
-    } else {  /* XXH3_acc_64bits */
-        /* xacc[0] += data_vec; */
-        __m512i const sum = _mm512_add_epi64(*xacc, data_vec);
-        /* xacc[0] += product; */
-        *xacc = _mm512_add_epi64(product, sum);
+    {
+        /* data_vec    = input[0]; */
+        __m512i const data_vec    = _mm512_loadu_si512   (input);
+        /* key_vec     = secret[0]; */
+        __m512i const key_vec     = _mm512_loadu_si512   (secret);
+        /* data_key    = data_vec ^ key_vec; */
+        __m512i const data_key    = _mm512_xor_si512     (data_vec, key_vec);
+        /* data_key_lo = data_key >> 32; */
+        __m512i const data_key_lo = _mm512_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
+        /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
+        __m512i const product     = _mm512_mul_epu32     (data_key, data_key_lo);
+        if (accWidth == XXH3_acc_128bits) {
+            /* xacc[0] += swap(data_vec); */
+            __m512i const data_swap = _mm512_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
+            __m512i const sum       = _mm512_add_epi64(*xacc, data_swap);
+            /* xacc[0] += product; */
+            *xacc = _mm512_add_epi64(product, sum);
+        } else {  /* XXH3_acc_64bits */
+            /* xacc[0] += data_vec; */
+            __m512i const sum = _mm512_add_epi64(*xacc, data_vec);
+            /* xacc[0] += product; */
+            *xacc = _mm512_add_epi64(product, sum);
+        }
     }
 }
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -2499,7 +2499,7 @@ XXH3_128bits_internal(const void* input, size_t len,
                       XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen,
                       XXH3_hashLong128_f f_hl128)
 {
-    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+    XXH_ASSERT(secretLen >= XXH3_SECRET_SIZE_MIN);
     /*
      * If an action is to be taken if `secret` conditions are not respected,
      * it should be done here.

--- a/xxh3.h
+++ b/xxh3.h
@@ -1752,33 +1752,15 @@ XXH3_hashLong_64b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
     return XXH3_mergeAccs(acc, secret + XXH_SECRET_MERGEACCS_START, (xxh_u64)len * XXH_PRIME64_1);
 }
 
-XXH_NO_INLINE XXH64_hash_t
-XXH3_hashLong_64b_defaultVec(const xxh_u8* XXH_RESTRICT input, size_t len,
-                             const xxh_u8* XXH_RESTRICT secret, size_t secretSize)
-{
-    return XXH3_hashLong_64b_internal(input, len, secret, secretSize,
-                XXH3_accumulate_512, XXH3_scrambleAcc);
-}
-
 /*
- * It's important for performance that XXH3_hashLong is not inlined. Not sure
- * why (uop cache maybe?), but the difference is large and easily measurable.
- */
-XXH_NO_INLINE XXH64_hash_t
-XXH3_hashLong_64b_defaultSecret(const xxh_u8* XXH_RESTRICT input, size_t len)
-{
-    return XXH3_hashLong_64b_defaultVec(input, len, XXH3_kSecret, sizeof(XXH3_kSecret));
-}
-
-/*
- * It's important for performance that XXH3_hashLong is not inlined. Not sure
- * why (uop cache maybe?), but the difference is large and easily measurable.
+ * It's important for performance that XXH3_hashLong is not inlined.
  */
 XXH_NO_INLINE XXH64_hash_t
 XXH3_hashLong_64b_withSecret(const xxh_u8* XXH_RESTRICT input, size_t len,
-                             const xxh_u8* XXH_RESTRICT secret, size_t secretSize)
+                              XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
 {
-    return XXH3_hashLong_64b_defaultVec(input, len, secret, secretSize);
+    (void)seed64;
+    return XXH3_hashLong_64b_internal(input, len, secret, secretLen, XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
 /*
@@ -1799,7 +1781,10 @@ XXH3_hashLong_64b_withSeed_internal(const xxh_u8* input, size_t len,
                                     XXH3_f_scrambleAcc f_scramble,
                                     XXH3_f_initCustomSecret f_initSec)
 {
-    if (seed == 0) return XXH3_hashLong_64b_defaultSecret(input, len);
+    if (seed == 0)
+        return XXH3_hashLong_64b_internal(input, len,
+                                          XXH3_kSecret, sizeof(XXH3_kSecret),
+                                          f_acc512, f_scramble);
 #if XXH_VECTOR == XXH_AVX2 || XXH_VECTOR == XXH_AVX512
     // manually deal with alignment of the custom secret
     // this will avoid pushing the rsp register to stack
@@ -1814,60 +1799,67 @@ XXH3_hashLong_64b_withSeed_internal(const xxh_u8* input, size_t len,
     {   XXH_ALIGN(XXH_SEC_ALIGN) xxh_u8 secret[XXH_SECRET_DEFAULT_SIZE];
         f_initSec(secret, seed);
         return XXH3_hashLong_64b_internal(input, len, secret, sizeof(secret),
-                        f_acc512, f_scramble);
+                                          f_acc512, f_scramble);
     }
 #endif
 }
 
+/*
+ * It's important for performance that XXH3_hashLong is not inlined.
+ */
 XXH_NO_INLINE XXH64_hash_t
-XXH3_hashLong_64b_withSeed(const xxh_u8* input, size_t len, XXH64_hash_t seed)
+XXH3_hashLong_64b_withSeed(const xxh_u8* input, size_t len,
+                           XXH64_hash_t seed, const xxh_u8* secret, size_t secretLen)
 {
+    (void)secret; (void)secretLen;
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
                 XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
 }
+
+
+typedef XXH64_hash_t (*XXH3_hashLong64_f)(const xxh_u8* XXH_RESTRICT, size_t,
+                                          XXH64_hash_t, const xxh_u8* XXH_RESTRICT, size_t);
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_64bits_internal(const void* XXH_RESTRICT input, size_t len,
+                     XXH64_hash_t seed64, const void* XXH_RESTRICT secret, size_t secretLen,
+                     XXH3_hashLong64_f f_hashLong)
+{
+    XXH_ASSERT(secretLen >= XXH3_SECRET_SIZE_MIN);
+    /*
+     * If an action is to be taken if `secretLen` condition is not respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash.
+     * Also, note that function signature doesn't offer room to return an error.
+     */
+    if (len <= 16)
+        return XXH3_len_0to16_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, seed64);
+    if (len <= 128)
+        return XXH3_len_17to128_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretLen, seed64);
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_len_129to240_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretLen, seed64);
+    return f_hashLong((const xxh_u8*)input, len, seed64, (const xxh_u8*)secret, secretLen);
+}
+
 
 /* ===   Public entry point   === */
 
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* input, size_t len)
 {
-    if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, XXH3_kSecret, 0);
-    if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
-    if (len <= XXH3_MIDSIZE_MAX)
-         return XXH3_len_129to240_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
-    return XXH3_hashLong_64b_defaultSecret((const xxh_u8*)input, len);
+    return XXH3_64bits_internal(input, len, 0, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_64b_withSecret);
 }
 
 XXH_PUBLIC_API XXH64_hash_t
 XXH3_64bits_withSecret(const void* input, size_t len, const void* secret, size_t secretSize)
 {
-    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
-    /*
-     * If an action is to be taken if `secret` conditions are not respected,
-     * it should be done here.
-     * For now, it's a contract pre-condition.
-     * Adding a check and a branch here would cost performance at every hash.
-     */
-    if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, 0);
-    if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretSize, 0);
-    if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretSize, 0);
-    return XXH3_hashLong_64b_withSecret((const xxh_u8*)input, len, (const xxh_u8*)secret, secretSize);
+    return XXH3_64bits_internal(input, len, 0, secret, secretSize, XXH3_hashLong_64b_withSecret);
 }
 
 XXH_PUBLIC_API XXH64_hash_t
 XXH3_64bits_withSeed(const void* input, size_t len, XXH64_hash_t seed)
 {
-    if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, XXH3_kSecret, seed);
-    if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
-    if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
-    return XXH3_hashLong_64b_withSeed((const xxh_u8*)input, len, seed);
+    return XXH3_64bits_internal(input, len, seed, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_64b_withSeed);
 }
 
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -2529,7 +2529,7 @@ XXH_PUBLIC_API XXH128_hash_t
 XXH3_128bits_withSecret(const void* input, size_t len, const void* secret, size_t secretSize)
 {
     return XXH3_128bits_internal(input, len, 0,
-                                 secret, secretSize,
+                                 (const xxh_u8*)secret, secretSize,
                                  XXH3_hashLong_128b_defaultSecret);
 }
 

--- a/xxh3.h
+++ b/xxh3.h
@@ -161,9 +161,9 @@
 #define XXH_SCALAR 0 /* Portable scalar version */
 #define XXH_SSE2   1 /* SSE2 for Pentium 4 and all x86_64 */
 #define XXH_AVX2   2 /* AVX2 for Haswell and Bulldozer */
-#define XXH_NEON   3 /* NEON for most ARMv7-A and all AArch64 */
-#define XXH_VSX    4 /* VSX and ZVector for POWER8/z13 */
-#define XXH_AVX512 5 /* AVX512 for Skylake and Icelake */
+#define XXH_AVX512 3 /* AVX512 for Skylake and Icelake */
+#define XXH_NEON   4 /* NEON for most ARMv7-A and all AArch64 */
+#define XXH_VSX    5 /* VSX and ZVector for POWER8/z13 */
 
 #ifndef XXH_VECTOR    /* can be defined on command line */
 #  if defined(__AVX512F__)
@@ -187,11 +187,13 @@
 #endif
 
 /*
- * Controls the alignment of the accumulator.
- * This is for compatibility with aligned vector loads, which are usually faster.
+ * Controls the alignment of the accumulator,
+ * for compatibility with aligned vector loads, which are usually faster.
  */
 #ifndef XXH_ACC_ALIGN
-#  if XXH_VECTOR == XXH_SCALAR  /* scalar */
+#  if defined(XXH_X86DISPATCH)
+#     define XXH_ACC_ALIGN 64  /* for compatibility with avx512 */
+#  elif XXH_VECTOR == XXH_SCALAR  /* scalar */
 #     define XXH_ACC_ALIGN 8
 #  elif XXH_VECTOR == XXH_SSE2  /* sse2 */
 #     define XXH_ACC_ALIGN 16
@@ -201,14 +203,13 @@
 #     define XXH_ACC_ALIGN 16
 #  elif XXH_VECTOR == XXH_VSX   /* vsx */
 #     define XXH_ACC_ALIGN 16
-#  elif XXH_VECTOR == XXH_AVX512 /* avx512 */
+#  elif XXH_VECTOR == XXH_AVX512  /* avx512 */
 #     define XXH_ACC_ALIGN 64
 #  endif
 #endif
 
-#if defined(XXH_X86DISPATCH)
-#  define XXH_SEC_ALIGN 64
-#elif XXH_VECTOR == XXH_SSE2 || XXH_VECTOR == XXH_AVX2 || XXH_VECTOR == XXH_AVX512
+#if defined(XXH_X86DISPATCH) || XXH_VECTOR == XXH_SSE2 \
+    || XXH_VECTOR == XXH_AVX2 || XXH_VECTOR == XXH_AVX512
 #  define XXH_SEC_ALIGN XXH_ACC_ALIGN
 #else
 #  define XXH_SEC_ALIGN 8

--- a/xxh3.h
+++ b/xxh3.h
@@ -1191,7 +1191,11 @@ XXH_FORCE_INLINE XXH_TARGET_AVX2 void XXH3_initCustomSecret_avx2(void* XXH_RESTR
 
 #if (XXH_VECTOR == XXH_SSE2) || defined(XXH_X86DISPATCH)
 
-XXH_FORCE_INLINE void
+#ifndef XXH_TARGET_SSE2
+# define XXH_TARGET_SSE2  /* disable attribute target */
+#endif
+
+XXH_FORCE_INLINE XXH_TARGET_SSE2 void
 XXH3_accumulate_512_sse2( void* XXH_RESTRICT acc,
                     const void* XXH_RESTRICT input,
                     const void* XXH_RESTRICT secret,
@@ -1234,7 +1238,7 @@ XXH3_accumulate_512_sse2( void* XXH_RESTRICT acc,
     }   }
 }
 
-XXH_FORCE_INLINE void
+XXH_FORCE_INLINE XXH_TARGET_SSE2 void
 XXH3_scrambleAcc_sse2(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 {
     XXH_ASSERT((((size_t)acc) & 15) == 0);
@@ -1263,7 +1267,7 @@ XXH3_scrambleAcc_sse2(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
     }
 }
 
-XXH_FORCE_INLINE void XXH3_initCustomSecret_sse2(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
+XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
 {
     XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
     (void)(&XXH_writeLE64);

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -385,7 +385,7 @@ XXHL64_secret_avx512(const void* XXH_RESTRICT input, size_t len, const void* sec
 #endif
 
 
-/* ===   Dispatchers   === */
+/* ====    Dispatchers    ==== */
 
 typedef XXH64_hash_t (*XXH3_dispatchx86_hashLong64_default)(const void* XXH_RESTRICT, size_t);
 
@@ -426,8 +426,6 @@ static const coreFunctions_s k_coreFunc[NB_DISPATCHES] = {
         /* avx512 */ { XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512 },
 };
 
-
-
 static void setDispatch(void)
 {
     int vecID = XXH_featureTest();
@@ -442,6 +440,8 @@ static void setDispatch(void)
     g_coreFunc = k_coreFunc[vecID];
 }
 
+
+/* ====    XXH3 public functions    ==== */
 
 static XXH64_hash_t
 XXH3_hashLong_64b_defaultSecret_selection(const xxh_u8* input, size_t len,
@@ -491,4 +491,15 @@ XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
     if (g_coreFunc.accumulate_512 == NULL) setDispatch();
     return XXH3_update(state, (const xxh_u8*)input, len,
                        XXH3_acc_64bits, g_coreFunc.accumulate_512, g_coreFunc.scrambleAcc);
+}
+
+
+/* ====    XXH128 public functions    ==== */
+
+XXH_errorcode
+XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
+{
+    if (g_coreFunc.accumulate_512 == NULL) setDispatch();
+    return XXH3_update(state, (const xxh_u8*)input, len,
+                       XXH3_acc_128bits, g_coreFunc.accumulate_512, g_coreFunc.scrambleAcc);
 }

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -542,6 +542,7 @@ static const dispatch128Functions_s k_dispatch128[NB_DISPATCHES] = {
 static void setDispatch(void)
 {
     int vecID = XXH_featureTest();
+    XXH_STATIC_ASSERT(XXH_AVX512 == NB_DISPATCHES-1);
     assert(XXH_SCALAR <= vecID && vecID <= XXH_AVX512);
 #ifndef XXH_DISPATCH_AVX512
     assert(vecID != XXH_AVX512);

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -424,53 +424,44 @@ static void setDispatch(void)
 }
 
 
-static XXH64_hash_t XXH3_hashLong_64b_defaultSecret_selection(const void* input, size_t len)
+static XXH64_hash_t
+XXH3_hashLong_64b_defaultSecret_selection(const xxh_u8* input, size_t len,
+                                          XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
 {
+    (void)seed64; (void)secret; (void)secretLen;
     if (g_dispatch.hashLong64_default == NULL) setDispatch();
     return g_dispatch.hashLong64_default(input, len);
 }
 
 XXH64_hash_t XXH3_64bits_dispatch(const void* input, size_t len)
 {
-    if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, XXH3_kSecret, 0);
-    if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
-    if (len <= XXH3_MIDSIZE_MAX)
-         return XXH3_len_129to240_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), 0);
-    return XXH3_hashLong_64b_defaultSecret_selection((const xxh_u8*)input, len);
+    return XXH3_64bits_internal(input, len, 0, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_64b_defaultSecret_selection);
 }
 
-static XXH64_hash_t XXH3_hashLong_64b_withSeed_selection(const void* input, size_t len, XXH64_hash_t seed)
+static XXH64_hash_t
+XXH3_hashLong_64b_withSeed_selection(const xxh_u8* input, size_t len,
+                                     XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
 {
+    (void)secret; (void)secretLen;
     if (g_dispatch.hashLong64_seed == NULL) setDispatch();
-    return g_dispatch.hashLong64_seed(input, len, seed);
+    return g_dispatch.hashLong64_seed(input, len, seed64);
 }
 
 XXH64_hash_t XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)
 {
-    if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, XXH3_kSecret, seed);
-    if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
-    if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed);
-    return XXH3_hashLong_64b_withSeed_selection(input, len, seed);
+    return XXH3_64bits_internal(input, len, seed, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_64b_withSeed_selection);
 }
 
-static XXH64_hash_t XXH3_hashLong_64b_withSecret_selection(const void* input, size_t len, const void* secret, size_t secretLen)
+static XXH64_hash_t
+XXH3_hashLong_64b_withSecret_selection(const xxh_u8* input, size_t len,
+                                       XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
 {
+    (void)seed64;
     if (g_dispatch.hashLong64_secret == NULL) setDispatch();
     return g_dispatch.hashLong64_secret(input, len, secret, secretLen);
 }
 
 XXH64_hash_t XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen)
 {
-    if (len <= 16)
-        return XXH3_len_0to16_64b((const xxh_u8*)input, len, secret, 0);
-    if (len <= 128)
-        return XXH3_len_17to128_64b((const xxh_u8*)input, len, secret, secretLen, 0);
-    if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b((const xxh_u8*)input, len, secret, secretLen, 0);
-    return XXH3_hashLong_64b_withSecret_selection(input, len, secret, secretLen);
+    return XXH3_64bits_internal(input, len, 0, secret, secretLen, XXH3_hashLong_64b_withSecret_selection);
 }

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -413,6 +413,38 @@ XXHL128_default_avx512(const void* XXH_RESTRICT input, size_t len)
 }
 #endif
 
+/* ===   XXH128 Secret variants   === */
+
+XXH_NO_INLINE XXH128_hash_t
+XXHL128_secret_scalar(const void* XXH_RESTRICT input, size_t len, const void* XXH_RESTRICT secret, size_t secretLen)
+{
+    return XXH3_hashLong_128b_internal(input, len, secret, secretLen,
+                    XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
+}
+
+XXH_NO_INLINE XXH_TARGET_SSE2 XXH128_hash_t
+XXHL128_secret_sse2(const void* XXH_RESTRICT input, size_t len, const void* XXH_RESTRICT secret, size_t secretLen)
+{
+    return XXH3_hashLong_128b_internal(input, len, secret, secretLen,
+                    XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
+}
+
+XXH_NO_INLINE XXH_TARGET_AVX2 XXH128_hash_t
+XXHL128_secret_avx2(const void* XXH_RESTRICT input, size_t len, const void* XXH_RESTRICT secret, size_t secretLen)
+{
+    return XXH3_hashLong_128b_internal(input, len, secret, secretLen,
+                    XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2);
+}
+
+#ifdef XXH_DISPATCH_AVX512
+XXH_NO_INLINE XXH_TARGET_AVX512 XXH128_hash_t
+XXHL128_secret_avx512(const void* XXH_RESTRICT input, size_t len, const void* XXH_RESTRICT secret, size_t secretLen)
+{
+    return XXH3_hashLong_128b_internal(input, len, secret, secretLen,
+                    XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512);
+}
+#endif
+
 
 /* ====    Dispatchers    ==== */
 
@@ -457,17 +489,20 @@ static const coreFunctions_s k_coreFunc[NB_DISPATCHES] = {
 
 typedef XXH128_hash_t (*XXH3_dispatchx86_hashLong128_default)(const void* XXH_RESTRICT, size_t);
 
+typedef XXH128_hash_t (*XXH3_dispatchx86_hashLong128_withSecret)(const void* XXH_RESTRICT, size_t, const void* XXH_RESTRICT, size_t);
+
 typedef struct {
     XXH3_dispatchx86_hashLong128_default    hashLong128_default;
+    XXH3_dispatchx86_hashLong128_withSecret hashLong128_secret;
 } dispatch128Functions_s;
 
-static dispatch128Functions_s g_dispatch128 = { NULL };
+static dispatch128Functions_s g_dispatch128 = { NULL, NULL };
 
 static const dispatch128Functions_s k_dispatch128[NB_DISPATCHES] = {
-        /* scalar */ { XXHL128_default_scalar },
-        /* sse2   */ { XXHL128_default_sse2 },
-        /* avx2   */ { XXHL128_default_avx2 },
-        /* avx512 */ { XXHL128_default_avx512 }
+        /* scalar */ { XXHL128_default_scalar, XXHL128_secret_scalar },
+        /* sse2   */ { XXHL128_default_sse2,   XXHL128_secret_sse2 },
+        /* avx2   */ { XXHL128_default_avx2,   XXHL128_secret_avx2 },
+        /* avx512 */ { XXHL128_default_avx512, XXHL128_secret_avx512 }
 };
 
 static void setDispatch(void)
@@ -553,6 +588,20 @@ XXH3_hashLong_128b_defaultSecret_selection(const xxh_u8* input, size_t len,
 XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len)
 {
     return XXH3_128bits_internal(input, len, 0, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_128b_defaultSecret_selection);
+}
+
+static XXH128_hash_t
+XXH3_hashLong_128b_withSecret_selection(const xxh_u8* input, size_t len,
+                                        XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
+{
+    (void)seed64;
+    if (g_dispatch128.hashLong128_secret == NULL) setDispatch();
+    return g_dispatch128.hashLong128_secret(input, len, secret, secretLen);
+}
+
+XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen)
+{
+    return XXH3_128bits_internal(input, len, 0, secret, secretLen, XXH3_hashLong_128b_withSecret_selection);
 }
 
 XXH_errorcode

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -294,26 +294,26 @@ static int XXH_featureTest(void)
 /* ===   XXH3, default variants   === */
 
 XXH_NO_INLINE XXH64_hash_t
-XXH3_hashLong_64b_defaultSecret_forcescalar(const void* XXH_RESTRICT input, size_t len)
+XXHL64_default_scalar(const void* XXH_RESTRICT input, size_t len)
 {
     return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
 }
 
 XXH_NO_INLINE XXH_TARGET_SSE2 XXH64_hash_t
-XXH3_hashLong_64b_defaultSecret_forcesse2(const void* XXH_RESTRICT input, size_t len)
+XXHL64_default_sse2(const void* XXH_RESTRICT input, size_t len)
 {
     return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
 }
 
 XXH_NO_INLINE XXH_TARGET_AVX2 XXH64_hash_t
-XXH3_hashLong_64b_defaultSecret_forceavx2(const void* XXH_RESTRICT input, size_t len)
+XXHL64_default_avx2(const void* XXH_RESTRICT input, size_t len)
 {
     return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2);
 }
 
 #ifdef XXH_DISPATCH_AVX512
 XXH_NO_INLINE XXH_TARGET_AVX512 XXH64_hash_t
-XXH3_hashLong_64b_defaultSecret_forceavx512(const void* XXH_RESTRICT input, size_t len)
+XXHL64_default_avx512(const void* XXH_RESTRICT input, size_t len)
 {
     return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512);
 }
@@ -323,21 +323,21 @@ XXH3_hashLong_64b_defaultSecret_forceavx512(const void* XXH_RESTRICT input, size
 /* ===   XXH3, Seeded variants   === */
 
 XXH_NO_INLINE XXH64_hash_t
-XXH3_hashLong_64b_withSeed_forcescalar(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+XXHL64_seed_scalar(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
 {
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
                     XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar, XXH3_initCustomSecret_scalar);
 }
 
 XXH_NO_INLINE XXH_TARGET_SSE2 XXH64_hash_t
-XXH3_hashLong_64b_withSeed_forcesse2(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+XXHL64_seed_sse2(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
 {
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
                     XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2, XXH3_initCustomSecret_sse2);
 }
 
 XXH_NO_INLINE XXH_TARGET_AVX2 XXH64_hash_t
-XXH3_hashLong_64b_withSeed_forceavx2(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+XXHL64_seed_avx2(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
 {
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
                     XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2, XXH3_initCustomSecret_avx2);
@@ -345,7 +345,7 @@ XXH3_hashLong_64b_withSeed_forceavx2(const void* XXH_RESTRICT input, size_t len,
 
 #ifdef XXH_DISPATCH_AVX512
 XXH_NO_INLINE XXH_TARGET_AVX512 XXH64_hash_t
-XXH3_hashLong_64b_withSeed_forceavx512(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+XXHL64_seed_avx512(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
 {
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
                     XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512, XXH3_initCustomSecret_avx512);
@@ -355,21 +355,21 @@ XXH3_hashLong_64b_withSeed_forceavx512(const void* XXH_RESTRICT input, size_t le
 /* ===   XXH3, Secret variants   === */
 
 XXH_NO_INLINE XXH64_hash_t
-XXH3_hashLong_64b_withSecret_forcescalar(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
+XXHL64_secret_scalar(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
 {
     return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
                     XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
 }
 
 XXH_NO_INLINE XXH_TARGET_SSE2 XXH64_hash_t
-XXH3_hashLong_64b_withSecret_forcesse2(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
+XXHL64_secret_sse2(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
 {
     return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
                     XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
 }
 
 XXH_NO_INLINE XXH_TARGET_AVX2 XXH64_hash_t
-XXH3_hashLong_64b_withSecret_forceavx2(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
+XXHL64_secret_avx2(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
 {
     return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
                     XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2);
@@ -377,7 +377,7 @@ XXH3_hashLong_64b_withSecret_forceavx2(const void* XXH_RESTRICT input, size_t le
 
 #ifdef XXH_DISPATCH_AVX512
 XXH_NO_INLINE XXH_TARGET_AVX512 XXH64_hash_t
-XXH3_hashLong_64b_withSecret_forceavx512(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
+XXHL64_secret_avx512(const void* XXH_RESTRICT input, size_t len, const void* secret, size_t secretLen)
 {
     return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
                     XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512);
@@ -403,10 +403,10 @@ static dispatchFunctions_s g_dispatch = { NULL, NULL, NULL};
 
 #define NB_DISPATCHES 4
 static const dispatchFunctions_s k_dispatch[NB_DISPATCHES] = {
-        /* scalar */ { XXH3_hashLong_64b_defaultSecret_forcescalar, XXH3_hashLong_64b_withSeed_forcescalar, XXH3_hashLong_64b_withSecret_forcescalar },
-        /* sse2   */ { XXH3_hashLong_64b_defaultSecret_forcesse2, XXH3_hashLong_64b_withSeed_forcesse2, XXH3_hashLong_64b_withSecret_forcesse2 },
-        /* avx2   */ { XXH3_hashLong_64b_defaultSecret_forceavx2, XXH3_hashLong_64b_withSeed_forceavx2, XXH3_hashLong_64b_withSecret_forceavx2 },
-        /* avx512 */ { XXH3_hashLong_64b_defaultSecret_forceavx512, XXH3_hashLong_64b_withSeed_forceavx512, XXH3_hashLong_64b_withSecret_forceavx512 }
+        /* scalar */ { XXHL64_default_scalar, XXHL64_seed_scalar, XXHL64_secret_scalar },
+        /* sse2   */ { XXHL64_default_sse2,   XXHL64_seed_sse2,   XXHL64_secret_sse2 },
+        /* avx2   */ { XXHL64_default_avx2,   XXHL64_seed_avx2,   XXHL64_secret_avx2 },
+        /* avx512 */ { XXHL64_default_avx512, XXHL64_seed_avx512, XXHL64_secret_avx512 }
 };
 
 
@@ -426,8 +426,7 @@ static void setDispatch(void)
 
 static XXH64_hash_t XXH3_hashLong_64b_defaultSecret_selection(const void* input, size_t len)
 {
-    if (g_dispatch.hashLong64_default == NULL)
-        setDispatch();
+    if (g_dispatch.hashLong64_default == NULL) setDispatch();
     return g_dispatch.hashLong64_default(input, len);
 }
 
@@ -444,8 +443,7 @@ XXH64_hash_t XXH3_64bits_dispatch(const void* input, size_t len)
 
 static XXH64_hash_t XXH3_hashLong_64b_withSeed_selection(const void* input, size_t len, XXH64_hash_t seed)
 {
-    if (g_dispatch.hashLong64_seed == NULL)
-        setDispatch();
+    if (g_dispatch.hashLong64_seed == NULL) setDispatch();
     return g_dispatch.hashLong64_seed(input, len, seed);
 }
 
@@ -462,8 +460,7 @@ XXH64_hash_t XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_
 
 static XXH64_hash_t XXH3_hashLong_64b_withSecret_selection(const void* input, size_t len, const void* secret, size_t secretLen)
 {
-    if (g_dispatch.hashLong64_secret == NULL)
-        setDispatch();
+    if (g_dispatch.hashLong64_secret == NULL) setDispatch();
     return g_dispatch.hashLong64_secret(input, len, secret, secretLen);
 }
 

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -319,7 +319,6 @@ XXHL64_default_avx512(const void* XXH_RESTRICT input, size_t len)
 }
 #endif
 
-
 /* ===   XXH3, Seeded variants   === */
 
 XXH_NO_INLINE XXH64_hash_t
@@ -445,6 +444,38 @@ XXHL128_secret_avx512(const void* XXH_RESTRICT input, size_t len, const void* XX
 }
 #endif
 
+/* ===   XXH128 Seeded variants   === */
+
+XXH_NO_INLINE XXH128_hash_t
+XXHL128_seed_scalar(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_hashLong_128b_withSeed_internal(input, len, seed,
+                    XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar, XXH3_initCustomSecret_scalar);
+}
+
+XXH_NO_INLINE XXH_TARGET_SSE2 XXH128_hash_t
+XXHL128_seed_sse2(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_hashLong_128b_withSeed_internal(input, len, seed,
+                    XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2, XXH3_initCustomSecret_sse2);
+}
+
+XXH_NO_INLINE XXH_TARGET_AVX2 XXH128_hash_t
+XXHL128_seed_avx2(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_hashLong_128b_withSeed_internal(input, len, seed,
+                    XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2, XXH3_initCustomSecret_avx2);
+}
+
+#ifdef XXH_DISPATCH_AVX512
+XXH_NO_INLINE XXH_TARGET_AVX512 XXH128_hash_t
+XXHL128_seed_avx512(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_hashLong_128b_withSeed_internal(input, len, seed,
+                    XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512, XXH3_initCustomSecret_avx512);
+}
+#endif
+
 
 /* ====    Dispatchers    ==== */
 
@@ -489,20 +520,23 @@ static const coreFunctions_s k_coreFunc[NB_DISPATCHES] = {
 
 typedef XXH128_hash_t (*XXH3_dispatchx86_hashLong128_default)(const void* XXH_RESTRICT, size_t);
 
+typedef XXH128_hash_t (*XXH3_dispatchx86_hashLong128_withSeed)(const void* XXH_RESTRICT, size_t, XXH64_hash_t);
+
 typedef XXH128_hash_t (*XXH3_dispatchx86_hashLong128_withSecret)(const void* XXH_RESTRICT, size_t, const void* XXH_RESTRICT, size_t);
 
 typedef struct {
     XXH3_dispatchx86_hashLong128_default    hashLong128_default;
+    XXH3_dispatchx86_hashLong128_withSeed   hashLong128_seed;
     XXH3_dispatchx86_hashLong128_withSecret hashLong128_secret;
 } dispatch128Functions_s;
 
-static dispatch128Functions_s g_dispatch128 = { NULL, NULL };
+static dispatch128Functions_s g_dispatch128 = { NULL, NULL, NULL };
 
 static const dispatch128Functions_s k_dispatch128[NB_DISPATCHES] = {
-        /* scalar */ { XXHL128_default_scalar, XXHL128_secret_scalar },
-        /* sse2   */ { XXHL128_default_sse2,   XXHL128_secret_sse2 },
-        /* avx2   */ { XXHL128_default_avx2,   XXHL128_secret_avx2 },
-        /* avx512 */ { XXHL128_default_avx512, XXHL128_secret_avx512 }
+        /* scalar */ { XXHL128_default_scalar, XXHL128_seed_scalar, XXHL128_secret_scalar },
+        /* sse2   */ { XXHL128_default_sse2,   XXHL128_seed_sse2,   XXHL128_secret_sse2 },
+        /* avx2   */ { XXHL128_default_avx2,   XXHL128_seed_avx2,   XXHL128_secret_avx2 },
+        /* avx512 */ { XXHL128_default_avx512, XXHL128_seed_avx512, XXHL128_secret_avx512 }
 };
 
 static void setDispatch(void)
@@ -588,6 +622,20 @@ XXH3_hashLong_128b_defaultSecret_selection(const xxh_u8* input, size_t len,
 XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len)
 {
     return XXH3_128bits_internal(input, len, 0, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_128b_defaultSecret_selection);
+}
+
+static XXH128_hash_t
+XXH3_hashLong_128b_withSeed_selection(const xxh_u8* input, size_t len,
+                                     XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
+{
+    (void)secret; (void)secretLen;
+    if (g_dispatch128.hashLong128_seed == NULL) setDispatch();
+    return g_dispatch128.hashLong128_seed(input, len, seed64);
+}
+
+XXH128_hash_t XXH3_128bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_128bits_internal(input, len, seed, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_128b_withSeed_selection);
 }
 
 static XXH128_hash_t

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -68,6 +68,7 @@
 #define XXH_X86DISPATCH
 #define XXH_TARGET_AVX512 __attribute__((__target__("avx512f")))
 #define XXH_TARGET_AVX2 __attribute__((__target__("avx2")))
+#define XXH_TARGET_SSE2 __attribute__((__target__("sse2")))
 #include "xxhash.h"
 
 /*
@@ -295,13 +296,13 @@ static int XXH_featureTest(void)
 typedef XXH64_hash_t (*XXH3_dispatchx86_hashLong64_default)(const void* XXH_RESTRICT, size_t);
 static XXH3_dispatchx86_hashLong64_default g_dispatch_hashLong64_default = NULL;
 
-XXH_NO_INLINE __attribute__((__target__ ("no-sse3"))) XXH64_hash_t  /* no-sse2 can crash compilation on x64 */
+XXH_NO_INLINE XXH64_hash_t
 XXH3_hashLong_64b_defaultSecret_forcesscalar(const void* XXH_RESTRICT input, size_t len)
 {
     return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
 }
 
-XXH_NO_INLINE __attribute__((__target__ ("sse2"))) XXH64_hash_t
+XXH_NO_INLINE XXH_TARGET_SSE2 XXH64_hash_t
 XXH3_hashLong_64b_defaultSecret_forcesse2(const void* XXH_RESTRICT input, size_t len)
 {
     return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
@@ -366,14 +367,14 @@ typedef XXH64_hash_t (*XXH3_dispatchx86_hashLong64_withSeed)(const void* XXH_RES
 static XXH3_dispatchx86_hashLong64_withSeed g_dispatch_hashLong64_seed = NULL;
 
 
-XXH_NO_INLINE __attribute__((__target__ ("no-sse3"))) XXH64_hash_t  /* no-sse2 can crash compilation on x64 */
+XXH_NO_INLINE XXH64_hash_t  /* no-sse2 can crash compilation on x64 */
 XXH3_hashLong_64b_withSeed_forcescalar(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
 {
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
                     XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar, XXH3_initCustomSecret_scalar);
 }
 
-XXH_NO_INLINE __attribute__((__target__ ("sse2"))) XXH64_hash_t
+XXH_NO_INLINE XXH_TARGET_SSE2 XXH64_hash_t
 XXH3_hashLong_64b_withSeed_forcesse2(const void* XXH_RESTRICT input, size_t len, XXH64_hash_t seed)
 {
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -1,0 +1,63 @@
+/*
+ * xxHash - XXH3 Dispatcher for x86-based targets
+ * Copyright (C) 2020 Yann Collet
+ *
+ * BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * You can contact the author at:
+ *   - xxHash homepage: https://www.xxhash.com
+ *   - xxHash source repository: https://github.com/Cyan4973/xxHash
+ */
+
+#ifndef XXH_X86DISPATCH_H_13563687684
+#define XXH_X86DISPATCH_H_13563687684
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+
+#include <xxhash.h>  /* XXH64_hash_t */
+
+XXH64_hash_t XXH3_64bits_dispatch(const void* input, size_t len);
+XXH64_hash_t XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
+
+
+#ifndef XXH_DISPATCH_DISABLE_RENAME
+
+# undef  XXH3_64bits
+# define XXH3_64bits XXH3_64bits_dispatch
+# undef  XXH3_64bits_withSeed
+# define XXH3_64bits_withSeed XXH3_64bits_withSeed_dispatch
+
+#endif /* XXH_DISPATCH_DISABLE_RENAME */
+
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* XXH_X86DISPATCH_H_13563687684 */

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -44,14 +44,19 @@ extern "C" {
 
 XXH64_hash_t XXH3_64bits_dispatch(const void* input, size_t len);
 XXH64_hash_t XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
+XXH64_hash_t XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
 
 
+/* automatic replacement of XXH3 functions.
+ * can be disabled by setting XXH_DISPATCH_DISABLE_RENAME */
 #ifndef XXH_DISPATCH_DISABLE_RENAME
 
 # undef  XXH3_64bits
 # define XXH3_64bits XXH3_64bits_dispatch
 # undef  XXH3_64bits_withSeed
 # define XXH3_64bits_withSeed XXH3_64bits_withSeed_dispatch
+# undef  XXH3_64bits_withSecret
+# define XXH3_64bits_withSecret XXH3_64bits_withSecret_dispatch
 
 #endif /* XXH_DISPATCH_DISABLE_RENAME */
 

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -47,6 +47,7 @@ XXH64_hash_t XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_
 XXH64_hash_t XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
 XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
+XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
 /* automatic replacement of XXH3 functions.
  * can be disabled by setting XXH_DISPATCH_DISABLE_RENAME */
@@ -60,6 +61,9 @@ XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input
 # define XXH3_64bits_withSecret XXH3_64bits_withSecret_dispatch
 # undef  XXH3_64bits_update
 # define XXH3_64bits_update XXH3_64bits_update_dispatch
+
+# undef  XXH3_128bits_update
+# define XXH3_128bits_update XXH3_128bits_update_dispatch
 
 #endif /* XXH_DISPATCH_DISABLE_RENAME */
 

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 
-#include <xxhash.h>  /* XXH64_hash_t */
+#include <xxhash.h>  /* XXH64_hash_t, XXH3_state_t */
 
 XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len);
 XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
@@ -48,12 +48,14 @@ XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, con
 XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
 XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len);
+XXH128_hash_t XXH3_128bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
 XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
 XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
+
 /* automatic replacement of XXH3 functions.
- * can be disabled by setting XXH_DISPATCH_DISABLE_RENAME */
-#ifndef XXH_DISPATCH_DISABLE_RENAME
+ * can be disabled by setting XXH_DISPATCH_DISABLE_REPLACE */
+#ifndef XXH_DISPATCH_DISABLE_REPLACE
 
 # undef  XXH3_64bits
 # define XXH3_64bits XXH3_64bits_dispatch
@@ -64,14 +66,19 @@ XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* inpu
 # undef  XXH3_64bits_update
 # define XXH3_64bits_update XXH3_64bits_update_dispatch
 
+# undef  XXH128
+# define XXH128 XXH3_128bits_withSeed_dispatch
+# define XXH3_128bits XXH3_128bits_dispatch
 # undef  XXH3_128bits
 # define XXH3_128bits XXH3_128bits_dispatch
+# undef  XXH3_128bits_withSeed
+# define XXH3_128bits_withSeed XXH3_128bits_withSeed_dispatch
 # undef  XXH3_128bits_withSecret
 # define XXH3_128bits_withSecret XXH3_128bits_withSecret_dispatch
 # undef  XXH3_128bits_update
 # define XXH3_128bits_update XXH3_128bits_update_dispatch
 
-#endif /* XXH_DISPATCH_DISABLE_RENAME */
+#endif /* XXH_DISPATCH_DISABLE_REPLACE */
 
 
 #if defined (__cplusplus)

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -42,11 +42,12 @@ extern "C" {
 
 #include <xxhash.h>  /* XXH64_hash_t */
 
-XXH64_hash_t XXH3_64bits_dispatch(const void* input, size_t len);
-XXH64_hash_t XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
-XXH64_hash_t XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
+XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len);
+XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
+XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
 XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
+XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len);
 XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
 /* automatic replacement of XXH3 functions.
@@ -62,6 +63,8 @@ XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* inpu
 # undef  XXH3_64bits_update
 # define XXH3_64bits_update XXH3_64bits_update_dispatch
 
+# undef  XXH3_128bits
+# define XXH3_128bits XXH3_128bits_dispatch
 # undef  XXH3_128bits_update
 # define XXH3_128bits_update XXH3_128bits_update_dispatch
 

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -48,6 +48,7 @@ XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, con
 XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
 XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len);
+XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
 XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
 /* automatic replacement of XXH3 functions.
@@ -65,6 +66,8 @@ XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* inpu
 
 # undef  XXH3_128bits
 # define XXH3_128bits XXH3_128bits_dispatch
+# undef  XXH3_128bits_withSecret
+# define XXH3_128bits_withSecret XXH3_128bits_withSecret_dispatch
 # undef  XXH3_128bits_update
 # define XXH3_128bits_update XXH3_128bits_update_dispatch
 

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -45,6 +45,7 @@ extern "C" {
 XXH64_hash_t XXH3_64bits_dispatch(const void* input, size_t len);
 XXH64_hash_t XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
 XXH64_hash_t XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
+XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
 
 
 /* automatic replacement of XXH3 functions.
@@ -57,6 +58,8 @@ XXH64_hash_t XXH3_64bits_withSecret_dispatch(const void* input, size_t len, cons
 # define XXH3_64bits_withSeed XXH3_64bits_withSeed_dispatch
 # undef  XXH3_64bits_withSecret
 # define XXH3_64bits_withSecret XXH3_64bits_withSecret_dispatch
+# undef  XXH3_64bits_update
+# define XXH3_64bits_update XXH3_64bits_update_dispatch
 
 #endif /* XXH_DISPATCH_DISABLE_RENAME */
 

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 
-#include <xxhash.h>  /* XXH64_hash_t, XXH3_state_t */
+#include "xxhash.h"  /* XXH64_hash_t, XXH3_state_t */
 
 XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len);
 XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);

--- a/xxhash.h
+++ b/xxhash.h
@@ -861,26 +861,27 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  pragma warning(disable : 4127) /* disable: C4127: conditional expression is constant */
 #endif
 
-#if XXH_NO_INLINE_HINTS /* disable inlining hints */
-#  define XXH_FORCE_INLINE static
-#  define XXH_NO_INLINE static
-#elif defined(_MSC_VER)    /* Visual Studio */
-#  define XXH_FORCE_INLINE static __forceinline
-#  define XXH_NO_INLINE static __declspec(noinline)
-#else
-#  if defined (__cplusplus) \
-    || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
-#    ifdef __GNUC__
-#      define XXH_FORCE_INLINE static inline __attribute__((always_inline))
-#      define XXH_NO_INLINE static __attribute__((noinline))
-#    else
-#      define XXH_FORCE_INLINE static inline
-#      define XXH_NO_INLINE static
-#    endif
+#if XXH_NO_INLINE_HINTS  /* disable inlining hints */
+#  if defined(__GNUC__)
+#    define XXH_FORCE_INLINE static __attribute__((unused))
 #  else
 #    define XXH_FORCE_INLINE static
-#    define XXH_NO_INLINE static
-#  endif /* __STDC_VERSION__ */
+#  endif
+#  define XXH_NO_INLINE static
+/* enable inlining hints */
+#elif defined(_MSC_VER)  /* Visual Studio */
+#  define XXH_FORCE_INLINE static __forceinline
+#  define XXH_NO_INLINE static __declspec(noinline)
+#elif defined(__GNUC__)
+#  define XXH_FORCE_INLINE static __inline__ __attribute__((always_inline, unused))
+#  define XXH_NO_INLINE static __attribute__((noinline))
+#elif defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))   /* C99 */
+#  define XXH_FORCE_INLINE static inline
+#  define XXH_NO_INLINE static
+#else
+#  define XXH_FORCE_INLINE static
+#  define XXH_NO_INLINE static
 #endif
 
 

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -58,6 +58,10 @@
 #define XXH_STATIC_LINKING_ONLY   /* *_state_t */
 #include "xxhash.h"
 
+#ifdef XXHSUM_DISPATCH
+#  include "xxh_x86dispatch.h"
+#endif
+
 
 /* ************************************
  *  OS-Specific Includes


### PR DESCRIPTION
Started from a baseline developed by @easyaspi314 (#358),
`xxh_x86dispatch.c` makes it possible to dynamically detect
which vector instruction set is present on the active system
and use the (presumable) best available one,
using this priority order : `avx512` > `avx2` > `sse2` > `scalar`.

3rd party applications willing to employ this ability
just have to `#include "xxh_x86dispatch.h"`.
This header automatically includes `xxhash.h`,
and swap relevant `XXH3`/`XXH128` symbols
with their vector dispatch counterpart.

Only runs on `x86`/`x64`.
Only compiles with `gcc` and `clang`.

added : `make dispatch` target, which compiles `xxhsum` with this new ability.
added : `make xxhsum DISPATCH=1`, which is equivalent to `make dispatch`