### PR TITLE
Updated benchmark module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,9 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 	# multiple files
 	$(RUN_ENV) ./xxhsum$(EXT) xxhash.* xxhsum.*
 	# internal bench
-	$(RUN_ENV) ./xxhsum$(EXT) -bi1
+	$(RUN_ENV) ./xxhsum$(EXT) -bi0
 	# file bench
-	$(RUN_ENV) ./xxhsum$(EXT) -bi1 xxhash.c
+	$(RUN_ENV) ./xxhsum$(EXT) -bi0 xxhash.c
 	# 32-bit
 	$(RUN_ENV) ./xxhsum$(EXT) -H0 xxhash.c
 	# 128-bit

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 	$(RUN_ENV) ./xxhsum$(EXT) xxhash.* xxhsum.*
 	# internal bench
 	$(RUN_ENV) ./xxhsum$(EXT) -bi0
+	# long bench command
+	$(RUN_ENV) ./xxhsum$(EXT) --benchmark-all -i0
 	# file bench
 	$(RUN_ENV) ./xxhsum$(EXT) -bi0 xxhash.c
 	# 32-bit

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ test-inline:
 
 .PHONY: test-all
 test-all: CFLAGS += -Werror
-test-all: test test32 clangtest cxxtest usan test-inline listL120 trailingWhitespace staticAnalyze test-unicode
+test-all: test test32 clangtest cxxtest usan test-inline listL120 trailingWhitespace test-unicode
 
 .PHONY: test-tools
 test-tools:

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,8 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 	$(RUN_ENV) ./xxhsum$(EXT) -bi0
 	# long bench command
 	$(RUN_ENV) ./xxhsum$(EXT) --benchmark-all -i0
+	# bench multiple variants
+	$(RUN_ENV) ./xxhsum$(EXT) -b1,2,3 -i0
 	# file bench
 	$(RUN_ENV) ./xxhsum$(EXT) -bi0 xxhash.c
 	# 32-bit

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -501,23 +501,6 @@ static const dispatchFunctions_s k_dispatch[NB_DISPATCHES] = {
         /* avx512 */ { XXHL64_default_avx512, XXHL64_seed_avx512, XXHL64_secret_avx512 }
 };
 
-typedef void (*XXH3_dispatchx86_accumulate_512)(void* XXH_RESTRICT acc, const void* XXH_RESTRICT input, const void* XXH_RESTRICT secret, XXH3_accWidth_e accWidth);
-typedef void (*XXH3_dispatchx86_scrambleAcc)(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret);
-
-typedef struct {
-    XXH3_dispatchx86_accumulate_512  accumulate_512;
-    XXH3_dispatchx86_scrambleAcc     scrambleAcc;
-} coreFunctions_s;
-
-static coreFunctions_s g_coreFunc = { NULL, NULL };
-
-static const coreFunctions_s k_coreFunc[NB_DISPATCHES] = {
-        /* scalar */ { XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar },
-        /* sse2   */ { XXH3_accumulate_512_sse2,   XXH3_scrambleAcc_sse2 },
-        /* avx2   */ { XXH3_accumulate_512_avx2,   XXH3_scrambleAcc_avx2 },
-        /* avx512 */ { XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512 },
-};
-
 typedef XXH128_hash_t (*XXH3_dispatchx86_hashLong128_default)(const void* XXH_RESTRICT, size_t);
 
 typedef XXH128_hash_t (*XXH3_dispatchx86_hashLong128_withSeed)(const void* XXH_RESTRICT, size_t, XXH64_hash_t);
@@ -537,6 +520,23 @@ static const dispatch128Functions_s k_dispatch128[NB_DISPATCHES] = {
         /* sse2   */ { XXHL128_default_sse2,   XXHL128_seed_sse2,   XXHL128_secret_sse2 },
         /* avx2   */ { XXHL128_default_avx2,   XXHL128_seed_avx2,   XXHL128_secret_avx2 },
         /* avx512 */ { XXHL128_default_avx512, XXHL128_seed_avx512, XXHL128_secret_avx512 }
+};
+
+typedef void (*XXH3_dispatchx86_accumulate_512)(void* XXH_RESTRICT acc, const void* XXH_RESTRICT input, const void* XXH_RESTRICT secret, XXH3_accWidth_e accWidth);
+typedef void (*XXH3_dispatchx86_scrambleAcc)(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret);
+
+typedef struct {
+    XXH3_dispatchx86_accumulate_512  accumulate_512;
+    XXH3_dispatchx86_scrambleAcc     scrambleAcc;
+} coreFunctions_s;
+
+static coreFunctions_s g_coreFunc = { NULL, NULL };
+
+static const coreFunctions_s k_coreFunc[NB_DISPATCHES] = {
+        /* scalar */ { XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar },
+        /* sse2   */ { XXH3_accumulate_512_sse2,   XXH3_scrambleAcc_sse2 },
+        /* avx2   */ { XXH3_accumulate_512_avx2,   XXH3_scrambleAcc_avx2 },
+        /* avx512 */ { XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512 },
 };
 
 static void setDispatch(void)

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -4,11 +4,11 @@ xxhsum(1) -- print or check xxHash non-cryptographic checksums
 SYNOPSIS
 --------
 
-`xxhsum [<OPTION>] ... [<FILE>] ...`  
+`xxhsum [<OPTION>] ... [<FILE>] ...`
 `xxhsum -b [<OPTION>] ...`
 
-`xxh32sum` is equivalent to `xxhsum -H0`  
-`xxh64sum` is equivalent to `xxhsum -H1`  
+`xxh32sum` is equivalent to `xxhsum -H0`
+`xxh64sum` is equivalent to `xxhsum -H1`
 `xxh128sum` is equivalent to `xxhsum -H2`
 
 
@@ -53,7 +53,7 @@ OPTIONS
 
 * `-q`, `--quiet`:
   Don't print OK for each successfully verified file
-  
+
 * `--strict`:
   Return an error code if any line in the file is invalid,
   not just if some checksums are wrong.
@@ -71,6 +71,9 @@ OPTIONS
 
 * `-b`:
   Benchmark mode.  See [EXAMPLES](#EXAMPLES) for details.
+
+* `-b#`:
+  Specify ID of variant to be tested. Multiple variants can be selected.
 
 * `-B`<BLOCKSIZE>:
   Only useful for benchmark mode (`-b`). See [EXAMPLES](#EXAMPLES) for details.
@@ -105,12 +108,19 @@ Read xxHash sums from specific files and check them
 
     $ xxhsum -c xyz.xxh32 qux.xxh64
 
-Benchmark xxHash algorithm for 16384 bytes data in 10 times. `xxhsum`
-benchmarks all xxHash variants and output results to standard output.  
-The first column is the algorithm, thw second column is the source data
-size in bytes, the third column is the number of hashes generated per
-second (throughput), and finally the last column translates speed in
-megabytes per second.
+Benchmark xxHash algorithm.
+By default, `xxhsum` benchmarks xxHash main variants
+on a synthetic sample of 100 KB,
+and print results into standard output.
+The first column is the algorithm,
+the second column is the source data size in bytes,
+the third column is the number of hashes generated per second (throughput),
+and finally the last column translates speed in megabytes per second.
+
+    $ xxhsum -b
+
+In the following example,  the sample to hash is set to 16384 bytes,
+and the benchmark test is repeated 10 times, for increased accuracy.
 
     $ xxhsum -b -i10 -B16384
 

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -73,7 +73,8 @@ OPTIONS
   Benchmark mode.  See [EXAMPLES](#EXAMPLES) for details.
 
 * `-b#`:
-  Specify ID of variant to be tested. Multiple variants can be selected.
+  Specify ID of variant to be tested.
+  Multiple variants can be selected, separated by a ',' comma.
 
 * `-B`<BLOCKSIZE>:
   Only useful for benchmark mode (`-b`). See [EXAMPLES](#EXAMPLES) for details.
@@ -119,10 +120,12 @@ and finally the last column translates speed in megabytes per second.
 
     $ xxhsum -b
 
-In the following example,  the sample to hash is set to 16384 bytes,
-and the benchmark test is repeated 10 times, for increased accuracy.
+In the following example,
+the sample to hash is set to 16384 bytes,
+the variants to be benched are selected by their IDs,
+and each benchmark test is repeated 10 times, for increased accuracy.
 
-    $ xxhsum -b -i10 -B16384
+    $ xxhsum -b1,2,3 -i10 -B16384
 
 BUGS
 ----

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -642,6 +642,22 @@ static U32 localXXH3_128b_secret(const void* buffer, size_t bufferSize, U32 seed
     (void)seed;
     return (U32)(XXH3_128bits_withSecret(buffer, bufferSize, g_benchSecretBuf, sizeof(g_benchSecretBuf)).low64);
 }
+static U32 localXXH3_stream(const void* buffer, size_t bufferSize, U32 seed)
+{
+    XXH3_state_t state;
+    (void)seed;
+    XXH3_64bits_reset(&state);
+    XXH3_64bits_update(&state, buffer, bufferSize);
+    return (U32)XXH3_64bits_digest(&state);
+}
+static U32 localXXH128_stream(const void* buffer, size_t bufferSize, U32 seed)
+{
+    XXH3_state_t state;
+    (void)seed;
+    XXH3_128bits_reset(&state);
+    XXH3_128bits_update(&state, buffer, bufferSize);
+    return (U32)(XXH3_128bits_digest(&state).low64);
+}
 
 
 typedef struct {
@@ -649,7 +665,7 @@ typedef struct {
     hashFunction func;
 } hashInfo;
 
-#define NB_HASHFUNC 8
+#define NB_HASHFUNC 10
 static const hashInfo g_hashesToBench[NB_HASHFUNC] = {
     { "XXH32",             &localXXH32 },
     { "XXH64",             &localXXH64 },
@@ -658,7 +674,9 @@ static const hashInfo g_hashesToBench[NB_HASHFUNC] = {
     { "XXH3_64b w/secret", &localXXH3_64b_secret },
     { "XXH128",            &localXXH3_128b },
     { "XXH128 w/seed",     &localXXH3_128b_seeded },
-    { "XXH128 w/secret",   &localXXH3_128b_secret }
+    { "XXH128 w/secret",   &localXXH3_128b_secret },
+    { "XXH3_stream",       &localXXH3_stream },
+    { "XXH128_stream",     &localXXH128_stream },
 };
 
 #define NB_TESTFUNC (1 + 2 * NB_HASHFUNC)

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -2126,7 +2126,7 @@ static int XXH_main(int argc, char** argv)
         if (!strcmp(argument, "--status")) { statusOnly = 1; continue; }
         if (!strcmp(argument, "--warn")) { warn = 1; continue; }
         if (!strcmp(argument, "--help")) { return usage_advanced(exename); }
-        if (!strcmp(argument, "--version")) { DISPLAY(WELCOME_MESSAGE(exename)); return 0; }
+        if (!strcmp(argument, "--version")) { DISPLAY(WELCOME_MESSAGE(exename)); BMK_sanityCheck(); return 0; }
 
         if (*argument!='-') {
             if (filenamesStart==0) filenamesStart=i;   /* only supports a continuous list of filenames */
@@ -2171,11 +2171,14 @@ static int XXH_main(int argc, char** argv)
             case 'b':
                 argument++;
                 benchmarkMode = 1;
-                selectBenchIDs = readU32FromChar(&argument); /* select one specific test */
-                if (selectBenchIDs < NB_TESTFUNC) {
-                    g_testIDs[selectBenchIDs] = 1;
-                } else
-                    selectBenchIDs = kBenchAll;
+                do {
+                    if (*argument == ',') argument++;
+                    selectBenchIDs = readU32FromChar(&argument); /* select one specific test */
+                    if (selectBenchIDs < NB_TESTFUNC) {
+                        g_testIDs[selectBenchIDs] = 1;
+                    } else
+                        selectBenchIDs = kBenchAll;
+                } while (*argument == ',');
                 break;
 
             /* Modify Nb Iterations (benchmark only) */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -649,7 +649,8 @@ typedef struct {
     hashFunction func;
 } hashInfo;
 
-static const hashInfo g_hashesToBench[] = {
+#define NB_HASHFUNC 8
+static const hashInfo g_hashesToBench[NB_HASHFUNC] = {
     { "XXH32",             &localXXH32 },
     { "XXH64",             &localXXH64 },
     { "XXH3_64b",          &localXXH3_64b },
@@ -660,22 +661,30 @@ static const hashInfo g_hashesToBench[] = {
     { "XXH128 w/secret",   &localXXH3_128b_secret }
 };
 
-#define HASHNAME_MAX 29
+#define NB_TESTFUNC (1 + 2 * NB_HASHFUNC)
+static char g_testIDs[NB_TESTFUNC] = { 0 };
+static const char k_testIDs_default[NB_TESTFUNC] = { 0,
+        1 /*XXH32*/, 0,
+        1 /*XXH64*/, 0,
+        1 /*XXH3*/, 0, 0, 0, 0, 0,
+        1 /*XXH128*/ };
 
-static void BMK_benchHash(hashFunction h, const char* hName, const int hID,
+#define HASHNAME_MAX 29
+static void BMK_benchHash(hashFunction h, const char* hName, int testID,
                           const void* buffer, size_t bufferSize)
 {
     U32 nbh_perIteration = (U32)((300 MB) / (bufferSize+1)) + 1;  /* first iteration conservatively aims for 300 MB/s */
-    U32 iterationNb, nbIterations = g_nbIterations + !g_nbIterations /* min 1 */;
+    unsigned iterationNb, nbIterations = g_nbIterations + !g_nbIterations /* min 1 */;
     double fastestH = 100000000.;
     assert(HASHNAME_MAX > 2);
     DISPLAYLEVEL(2, "\r%80s\r", "");       /* Clean display line */
+
     for (iterationNb = 1; iterationNb <= nbIterations; iterationNb++) {
         U32 r=0;
         clock_t cStart;
 
         DISPLAYLEVEL(2, "%2u-%-*.*s : %10u ->\r",
-                        (unsigned)iterationNb,
+                        iterationNb,
                         HASHNAME_MAX, HASHNAME_MAX, hName,
                         (unsigned)bufferSize);
         cStart = clock();
@@ -686,7 +695,7 @@ static void BMK_benchHash(hashFunction h, const char* hName, const int hID,
             for (u=0; u<nbh_perIteration; u++)
                 r += h(buffer, bufferSize, u);
         }
-        if (r==0) DISPLAYLEVEL(3,".\r");  /* do something with r to defeat compiler "optimizing" away hash */
+        if (r==0) DISPLAYLEVEL(3,".\r");  /* do something with r to defeat compiler "optimizing" hash away */
 
         {   clock_t const nbTicks = BMK_clockSpan(cStart);
             double const ticksPerHash = ((double)nbTicks / TIMELOOP) / nbh_perIteration;
@@ -730,7 +739,7 @@ static void BMK_benchHash(hashFunction h, const char* hName, const int hID,
             if (ticksPerHash < fastestH) fastestH = ticksPerHash;
             if (fastestH>0.) { /* avoid div by zero */
                 DISPLAYLEVEL(2, "%2u-%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \r",
-                            (unsigned)iterationNb,
+                            iterationNb,
                             HASHNAME_MAX, HASHNAME_MAX, hName,
                             (unsigned)bufferSize,
                             (double)1 / fastestH,
@@ -742,7 +751,7 @@ static void BMK_benchHash(hashFunction h, const char* hName, const int hID,
         }
     }
     DISPLAYLEVEL(1, "%2i#%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \n",
-                    hID,
+                    testID,
                     HASHNAME_MAX, HASHNAME_MAX, hName,
                     (unsigned)bufferSize,
                     (double)1 / fastestH,
@@ -754,50 +763,32 @@ static void BMK_benchHash(hashFunction h, const char* hName, const int hID,
 
 /*!
  * BMK_benchMem():
- * specificTest: 0 == run all tests, 1+ runs specific test
  * buffer: Must be 16-byte aligned.
  * The real allocated size of buffer is supposed to be >= (bufferSize+3).
  * returns: 0 on success, 1 if error (invalid mode selected)
  */
-static int BMK_benchMem(const void* buffer, size_t bufferSize, U32 specificTest)
+static void BMK_benchMem(const void* buffer, size_t bufferSize)
 {
-    BMK_fillTestBuffer(g_benchSecretBuf, sizeof(g_benchSecretBuf));
     assert((((size_t)buffer) & 15) == 0);  /* ensure alignment */
-    {   const size_t NUM_HASHES = sizeof(g_hashesToBench) / sizeof(g_hashesToBench[0]);
-        size_t i;
-        assert(NUM_HASHES > 0);
-
-        /*
-         * specificTest == 0: all hashes
-         * Otherwise, it is the hashes in order, starting at 1.
-         * There are two entries per hash, with the first one (2 * i + 1) testing
-         * an aligned buffer and the second one (2 * i + 2) testing an unaligned
-         * buffer.
-         * For example, specificTest == 2 tests XXH32 with an unaligned buffer
-         * in the default setup.
-         */
-        if (specificTest > 2 * NUM_HASHES) {
-            DISPLAY("Benchmark mode invalid.\n");
-            return 1;
-        }
-        for (i = 0; i < NUM_HASHES; i++) {
-            assert(g_hashesToBench[i].name != NULL);
-            assert(i < (INT_MAX/2 - 2));
+    BMK_fillTestBuffer(g_benchSecretBuf, sizeof(g_benchSecretBuf));
+    {   int i;
+        for (i = 1; i < NB_TESTFUNC; i++) {
+            int const hashFuncID = (i-1) / 2;
+            assert(g_hashesToBench[hashFuncID].name != NULL);
+            if (g_testIDs[i] == 0) continue;
             /* aligned */
-            if (specificTest == 0 || specificTest == 2 * i + 1) {
-                BMK_benchHash(g_hashesToBench[i].func, g_hashesToBench[i].name, (int)(2 * i + 1), buffer, bufferSize);
+            if ((i % 2) == 1) {
+                BMK_benchHash(g_hashesToBench[hashFuncID].func, g_hashesToBench[hashFuncID].name, i, buffer, bufferSize);
             }
             /* unaligned */
-            if (specificTest == 0 || specificTest == 2 * i + 2) {
+            if ((i % 2) == 0) {
                 /* Append "unaligned". */
-                char* hashNameBuf = XXH_strcatDup(g_hashesToBench[i].name, " unaligned");
+                char* const hashNameBuf = XXH_strcatDup(g_hashesToBench[hashFuncID].name, " unaligned");
                 assert(hashNameBuf != NULL);
-                BMK_benchHash(g_hashesToBench[i].func, hashNameBuf, (int)(2 * i + 2), ((const char*)buffer)+3, bufferSize);
+                BMK_benchHash(g_hashesToBench[hashFuncID].func, hashNameBuf, i, ((const char*)buffer)+3, bufferSize);
                 free(hashNameBuf);
             }
     }   }
-
-    return 0;
 }
 
 static size_t BMK_selectBenchedSize(const char* fileName)
@@ -812,11 +803,9 @@ static size_t BMK_selectBenchedSize(const char* fileName)
 }
 
 
-static int BMK_benchFiles(char** fileNamesTable, int nbFiles, U32 specificTest)
+static int BMK_benchFiles(char** fileNamesTable, int nbFiles)
 {
-    int result = 0;
     int fileIdx;
-
     for (fileIdx=0; fileIdx<nbFiles; fileIdx++) {
         const char* const inFileName = fileNamesTable[fileIdx];
         assert(inFileName != NULL);
@@ -830,12 +819,12 @@ static int BMK_benchFiles(char** fileNamesTable, int nbFiles, U32 specificTest)
             if (inFile==NULL){
                 DISPLAY("Error: Could not open '%s': %s.\n", inFileName, strerror(errno));
                 free(buffer);
-                return 11;
+                exit(11);
             }
             if(!buffer) {
                 DISPLAY("\nError: Out of memory.\n");
                 fclose(inFile);
-                return 12;
+                exit(12);
             }
 
             /* Fill input buffer */
@@ -844,25 +833,24 @@ static int BMK_benchFiles(char** fileNamesTable, int nbFiles, U32 specificTest)
                 if(readSize != benchedSize) {
                     DISPLAY("\nError: Could not read '%s': %s.\n", inFileName, strerror(errno));
                     free(buffer);
-                    return 13;
+                    exit(13);
             }   }
 
             /* bench */
-            result |= BMK_benchMem(alignedBuffer, benchedSize, specificTest);
+            BMK_benchMem(alignedBuffer, benchedSize);
 
             free(buffer);
     }   }
-
-    return result;
+    return 0;
 }
 
 
-static int BMK_benchInternal(size_t keySize, U32 specificTest)
+static int BMK_benchInternal(size_t keySize)
 {
     void* const buffer = calloc(keySize+16+3, 1);
-    if (!buffer) {
+    if (buffer == NULL) {
         DISPLAY("\nError: Out of memory.\n");
-        return 12;
+        exit(12);
     }
 
     {   const void* const alignedBuffer = ((char*)buffer+15) - (((size_t)((char*)buffer+15)) & 0xF);  /* align on next 16 bytes */
@@ -876,10 +864,10 @@ static int BMK_benchInternal(size_t keySize, U32 specificTest)
         }
         DISPLAYLEVEL(1, "...        \n");
 
-        {   int const result = BMK_benchMem(alignedBuffer, keySize, specificTest);
-            free(buffer);
-            return result;
-    }   }
+        BMK_benchMem(alignedBuffer, keySize);
+        free(buffer);
+    }
+    return 0;
 }
 
 
@@ -2113,7 +2101,8 @@ static int XXH_main(int argc, char** argv)
     U32 strictMode    = 0;
     U32 statusOnly    = 0;
     U32 warn          = 0;
-    U32 specificTest  = 0;
+    U32 selectBenchIDs= 0;  /* 0 == use default k_testIDs_default, kBenchAll == bench all */
+    static const U32 kBenchAll = 99;
     size_t keySize    = XXH_DEFAULT_SAMPLE_SIZE;
     algoType algo     = g_defaultAlgo;
     endianess displayEndianess = big_endian;
@@ -2128,11 +2117,13 @@ static int XXH_main(int argc, char** argv)
 
         if(!argument) continue;   /* Protection if arguments are empty */
 
-        if (!strcmp(argument, "--little-endian")) { displayEndianess = little_endian; continue; }
         if (!strcmp(argument, "--check")) { fileCheckMode = 1; continue; }
+        if (!strcmp(argument, "--benchmark-all")) { benchmarkMode = 1; selectBenchIDs = kBenchAll; continue; }
+        if (!strcmp(argument, "--bench-all")) { benchmarkMode = 1; selectBenchIDs = kBenchAll; continue; }
+        if (!strcmp(argument, "--quiet")) { g_displayLevel--; continue; }
+        if (!strcmp(argument, "--little-endian")) { displayEndianess = little_endian; continue; }
         if (!strcmp(argument, "--strict")) { strictMode = 1; continue; }
         if (!strcmp(argument, "--status")) { statusOnly = 1; continue; }
-        if (!strcmp(argument, "--quiet")) { g_displayLevel--; continue; }
         if (!strcmp(argument, "--warn")) { warn = 1; continue; }
         if (!strcmp(argument, "--help")) { return usage_advanced(exename); }
         if (!strcmp(argument, "--version")) { DISPLAY(WELCOME_MESSAGE(exename)); return 0; }
@@ -2180,7 +2171,11 @@ static int XXH_main(int argc, char** argv)
             case 'b':
                 argument++;
                 benchmarkMode = 1;
-                specificTest = readU32FromChar(&argument); /* select one specific test */
+                selectBenchIDs = readU32FromChar(&argument); /* select one specific test */
+                if (selectBenchIDs < NB_TESTFUNC) {
+                    g_testIDs[selectBenchIDs] = 1;
+                } else
+                    selectBenchIDs = kBenchAll;
                 break;
 
             /* Modify Nb Iterations (benchmark only) */
@@ -2211,8 +2206,10 @@ static int XXH_main(int argc, char** argv)
     if (benchmarkMode) {
         DISPLAYLEVEL(2, WELCOME_MESSAGE(exename) );
         BMK_sanityCheck();
-        if (filenamesStart==0) return BMK_benchInternal(keySize, specificTest);
-        return BMK_benchFiles(argv+filenamesStart, argc-filenamesStart, specificTest);
+        if (selectBenchIDs == 0) memcpy(g_testIDs, k_testIDs_default, sizeof(g_testIDs));
+        if (selectBenchIDs == kBenchAll) memset(g_testIDs, 1, sizeof(g_testIDs));
+        if (filenamesStart==0) return BMK_benchInternal(keySize);
+        return BMK_benchFiles(argv+filenamesStart, argc-filenamesStart);
     }
 
     /* Check if input is defined as console; trigger an error in this case */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1626,8 +1626,8 @@ static int charToHex(char c)
 
 
 /*
- * Converts XXH32 canonical hexadecimal string `hashStr` to the big endian unsigned
- * char array `dst`.
+ * Converts canonical ASCII hexadecimal string `hashStr`
+ * to the big endian binary representation in unsigned char array `dst`.
  *
  * Returns CANONICAL_FROM_STRING_INVALID_FORMAT if hashStr is not well formatted.
  * Returns CANONICAL_FROM_STRING_OK if hashStr is parsed successfully.

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1925,7 +1925,7 @@ static int checkFile(const char* inFileName,
     parseFileArg->inFileName    = inFileName;
     parseFileArg->inFile        = inFile;
     parseFileArg->lineMax       = DEFAULT_LINE_LENGTH;
-    parseFileArg->lineBuf       = (char*) malloc((size_t) parseFileArg->lineMax);
+    parseFileArg->lineBuf       = (char*) malloc((size_t)parseFileArg->lineMax);
     parseFileArg->blockSize     = 64 * 1024;
     parseFileArg->blockBuf      = (char*) malloc(parseFileArg->blockSize);
     parseFileArg->strictMode    = strictMode;
@@ -1933,6 +1933,11 @@ static int checkFile(const char* inFileName,
     parseFileArg->warn          = warn;
     parseFileArg->quiet         = quiet;
 
+    if ( (parseFileArg->lineBuf == NULL)
+      || (parseFileArg->blockBuf == NULL) ) {
+        DISPLAY("Error: : memory allocation failed \n");
+        exit(1);
+    }
     parseFile1(parseFileArg);
 
     free(parseFileArg->blockBuf);


### PR DESCRIPTION
Updated the benchmark module, with following abilities : 
- by default `-b`, benchmark only `XXH32`, `XXH64`, `XXH3` and `XXH128`
   + so that casual users don't get swamped by an avalanche of results
- can get instructed to bench multiple selected variants, using `-b1,2,3,..`
- can bench all variants with `--bench-all` (previous default)
- sub-second evaluation with `-i0`, for a quick check
- added streaming variants `XXH3_stream` and `XXH128_stream`

The last bullet point coupled with `DISPATCH=1` was basically the objective.

This allowed me to observe that streaming performance with `AVX2` is massively less impressive than with one-shot API. Initially, I even thought that the dispatcher was not working, but it is (check addresses, and even enforced variants manually). After multiple tests, I get a consistent `23 GB/s` streaming performance with `SSE2` on my laptop, and a whopping `24 GB/s` with `AVX2`.
In contrast, the non-dispatch version of `xxhsum` is able to stream at ~40GB/s with `AVX2`.

I presume it's an inlining problem.
I may have to create some additional intermediate variants in order to ensure that function pointers are fully defined hence inlinable at compile time.

_edit_ : fixed performance issue of streaming variants.
Speed of `DISPATCH=1` version increased to `35 GB/s` on my `avx2` laptop.
This is still less than the non-dispatch variant (~40 GB/s), but the speed difference is now within range of the instruction alignment issue. For example, I got differences from `35 GB/s` to `45 GB/` for `XXH128()` with `avx2`, depending on how it's compiled and what other code lays around, so presumably entirely related to instruction alignment.
Maybe this topic is important enough to be worth an investigation in the future ...