### PR TITLE
compatibility with turbosfv 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,10 @@
 # ################################################################
 
 # Version numbers
-LIBVER_MAJOR_SCRIPT:=`sed -n '/define XXH_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
-LIBVER_MINOR_SCRIPT:=`sed -n '/define XXH_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
-LIBVER_PATCH_SCRIPT:=`sed -n '/define XXH_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
+SED ?= sed
+LIBVER_MAJOR_SCRIPT:=`$(SED) -n '/define XXH_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
+LIBVER_MINOR_SCRIPT:=`$(SED) -n '/define XXH_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
+LIBVER_PATCH_SCRIPT:=`$(SED) -n '/define XXH_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < xxhash.h`
 LIBVER_MAJOR := $(shell echo $(LIBVER_MAJOR_SCRIPT))
 LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
 LIBVER_PATCH := $(shell echo $(LIBVER_PATCH_SCRIPT))
@@ -132,7 +133,7 @@ lib:  ## generate static and dynamic xxhash libraries
 lib: libxxhash.a libxxhash
 
 pkgconfig:
-	@sed -e 's|@PREFIX@|$(PREFIX)|' \
+	@$(SED) -e 's|@PREFIX@|$(PREFIX)|' \
 		-e 's|@VERSION@|$(LIBVER)|' \
 		libxxhash.pc.in >libxxhash.pc
 
@@ -219,6 +220,8 @@ test-xxhsum-c: xxhsum
 	# read list of files from stdin
 	./xxhsum -c < .test.xxh64
 	./xxhsum -c < .test.xxh32
+	# check variant with '*' marker as second separator
+	$(SED) 's/  / \*/' .test.xxh32 | ./xxhsum -c
 	# xxhsum -c warns improperly format lines.
 	cat .test.xxh64 .test.xxh32 | ./xxhsum -c - | $(GREP) improperly
 	cat .test.xxh32 .test.xxh64 | ./xxhsum -c - | $(GREP) improperly
@@ -289,7 +292,7 @@ namespaceTest:  ## ensure XXH_NAMESPACE redefines all public symbols
 MD2ROFF ?= ronn
 MD2ROFF_FLAGS ?= --roff --warnings --manual="User Commands" --organization="xxhsum $(XXHSUM_VERSION)"
 xxhsum.1: xxhsum.1.md xxhash.h
-	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
+	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | $(SED) -n '/^\.\\\".*/!p' > $@
 
 .PHONY: man
 man: xxhsum.1  ## generate man page from markdown source

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1676,51 +1676,49 @@ static ParseLineResult parseLine(ParsedLine* parsedLine, const char* line)
     const char* const firstSpace = strchr(line, ' ');
     if (firstSpace == NULL) return ParseLine_invalidFormat;
 
-    {   const char* const secondSpace = firstSpace + 1;
-        if (*secondSpace != ' ') return ParseLine_invalidFormat;
+    parsedLine->filename = NULL;
+    parsedLine->xxhBits = 0;
 
-        parsedLine->filename = NULL;
-        parsedLine->xxhBits = 0;
-
-        switch (firstSpace - line)
-        {
-        case 8:
-            {   XXH32_canonical_t* xxh32c = &parsedLine->canonical.xxh32;
-                if (canonicalFromString(xxh32c->digest, sizeof(xxh32c->digest), line)
-                    != CanonicalFromString_ok) {
-                    return ParseLine_invalidFormat;
-                }
-                parsedLine->xxhBits = 32;
-                break;
-            }
-
-        case 16:
-            {   XXH64_canonical_t* xxh64c = &parsedLine->canonical.xxh64;
-                if (canonicalFromString(xxh64c->digest, sizeof(xxh64c->digest), line)
-                    != CanonicalFromString_ok) {
-                    return ParseLine_invalidFormat;
-                }
-                parsedLine->xxhBits = 64;
-                break;
-            }
-
-        case 32:
-            {   XXH128_canonical_t* xxh128c = &parsedLine->canonical.xxh128;
-                if (canonicalFromString(xxh128c->digest, sizeof(xxh128c->digest), line)
-                    != CanonicalFromString_ok) {
-                    return ParseLine_invalidFormat;
-                }
-                parsedLine->xxhBits = 128;
-                break;
-            }
-
-        default:
+    switch (firstSpace - line)
+    {
+    case 8:
+        {   XXH32_canonical_t* xxh32c = &parsedLine->canonical.xxh32;
+            if (canonicalFromString(xxh32c->digest, sizeof(xxh32c->digest), line)
+                != CanonicalFromString_ok) {
                 return ParseLine_invalidFormat;
-                break;
+            }
+            parsedLine->xxhBits = 32;
+            break;
         }
 
-        parsedLine->filename = secondSpace + 1;
+    case 16:
+        {   XXH64_canonical_t* xxh64c = &parsedLine->canonical.xxh64;
+            if (canonicalFromString(xxh64c->digest, sizeof(xxh64c->digest), line)
+                != CanonicalFromString_ok) {
+                return ParseLine_invalidFormat;
+            }
+            parsedLine->xxhBits = 64;
+            break;
+        }
+
+    case 32:
+        {   XXH128_canonical_t* xxh128c = &parsedLine->canonical.xxh128;
+            if (canonicalFromString(xxh128c->digest, sizeof(xxh128c->digest), line)
+                != CanonicalFromString_ok) {
+                return ParseLine_invalidFormat;
+            }
+            parsedLine->xxhBits = 128;
+            break;
+        }
+
+    default:
+            return ParseLine_invalidFormat;
+            break;
     }
+
+    /* note : skipping second separation character, which can be anything,
+     * allowing insertion of custom markers such as '*' */
+    parsedLine->filename = firstSpace + 2;
     return ParseLine_ok;
 }
 


### PR DESCRIPTION
using a `*` separator as second character,
requested in https://github.com/Cyan4973/xxHash/issues/382#issuecomment-641978062