### PR TITLE
Some Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ libxxhash.a: xxhash.o
 	$(AR) $(ARFLAGS) $@ $^
 
 $(LIBXXH): LDFLAGS += -shared
-ifneq ($(UNAME), Windows)
+ifeq (,$(filter Windows%,$(OS)))
 $(LIBXXH): CFLAGS += -fPIC
 endif
 $(LIBXXH): xxhash.c

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ trailingWhitespace:
 # =========================================================
 # make install is validated only for the following targets
 # =========================================================
-ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS CYGWIN% , $(shell uname)))
+ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS CYGWIN% , $(UNAME)))
 
 DESTDIR     ?=
 # directory variables: GNU conventions prefer lowercase


### PR DESCRIPTION
- Fix identification of Cygwin/MSYS/MINGW "OS" that have $(OS) of
  Windows% but shouldn't obey the Windows rules.
- Add Cygwin to the list of validated installs. I ran install as:
  `PREFIX=/usr make install`
- The uninstall target now removes the xxh3.h file.