### PR TITLE
Switch mixer to XXH128

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1754,7 +1754,7 @@ XXH3_hashLong_64b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
 {
     XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[XXH_ACC_NB] = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, XXH3_acc_64bits, f_acc512, f_scramble);
+    XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, XXH3_acc_128bits, f_acc512, f_scramble);
 
     /* converge into final hash */
     XXH_STATIC_ASSERT(sizeof(acc) == 64);

--- a/xxh3.h
+++ b/xxh3.h
@@ -931,8 +931,6 @@ XXH3_len_129to240_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
 #  define ACC_NB XXH_ACC_NB
 #endif
 
-typedef enum { XXH3_acc_64bits, XXH3_acc_128bits } XXH3_accWidth_e;
-
 XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
 {
     if (!XXH_CPU_LITTLE_ENDIAN) v64 = XXH_swap64(v64);
@@ -985,8 +983,7 @@ XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
 XXH_FORCE_INLINE XXH_TARGET_AVX512 void
 XXH3_accumulate_512_avx512(void* XXH_RESTRICT acc,
                      const void* XXH_RESTRICT input,
-                     const void* XXH_RESTRICT secret,
-                     XXH3_accWidth_e accWidth)
+                     const void* XXH_RESTRICT secret)
 {
     XXH_ALIGN(64) __m512i* const xacc = (__m512i *) acc;
     XXH_ASSERT((((size_t)acc) & 63) == 0);
@@ -1003,18 +1000,11 @@ XXH3_accumulate_512_avx512(void* XXH_RESTRICT acc,
         __m512i const data_key_lo = _mm512_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
         /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
         __m512i const product     = _mm512_mul_epu32     (data_key, data_key_lo);
-        if (accWidth == XXH3_acc_128bits) {
-            /* xacc[0] += swap(data_vec); */
-            __m512i const data_swap = _mm512_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
-            __m512i const sum       = _mm512_add_epi64(*xacc, data_swap);
-            /* xacc[0] += product; */
-            *xacc = _mm512_add_epi64(product, sum);
-        } else {  /* XXH3_acc_64bits */
-            /* xacc[0] += data_vec; */
-            __m512i const sum = _mm512_add_epi64(*xacc, data_vec);
-            /* xacc[0] += product; */
-            *xacc = _mm512_add_epi64(product, sum);
-        }
+        /* xacc[0] += swap(data_vec); */
+        __m512i const data_swap = _mm512_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
+        __m512i const sum       = _mm512_add_epi64(*xacc, data_swap);
+        /* xacc[0] += product; */
+        *xacc = _mm512_add_epi64(product, sum);
     }
 }
 
@@ -1098,8 +1088,7 @@ XXH3_initCustomSecret_avx512(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
 XXH_FORCE_INLINE XXH_TARGET_AVX2 void
 XXH3_accumulate_512_avx2( void* XXH_RESTRICT acc,
                     const void* XXH_RESTRICT input,
-                    const void* XXH_RESTRICT secret,
-                    XXH3_accWidth_e accWidth)
+                    const void* XXH_RESTRICT secret)
 {
     XXH_ASSERT((((size_t)acc) & 31) == 0);
     {   XXH_ALIGN(32) __m256i* const xacc    =       (__m256i *) acc;
@@ -1122,18 +1111,11 @@ XXH3_accumulate_512_avx2( void* XXH_RESTRICT acc,
             __m256i const data_key_lo = _mm256_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
             /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
             __m256i const product     = _mm256_mul_epu32     (data_key, data_key_lo);
-            if (accWidth == XXH3_acc_128bits) {
-                /* xacc[i] += swap(data_vec); */
-                __m256i const data_swap = _mm256_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
-                __m256i const sum       = _mm256_add_epi64(xacc[i], data_swap);
-                /* xacc[i] += product; */
-                xacc[i] = _mm256_add_epi64(product, sum);
-            } else {  /* XXH3_acc_64bits */
-                /* xacc[i] += data_vec; */
-                __m256i const sum = _mm256_add_epi64(xacc[i], data_vec);
-                /* xacc[i] += product; */
-                xacc[i] = _mm256_add_epi64(product, sum);
-            }
+            /* xacc[i] += swap(data_vec); */
+            __m256i const data_swap = _mm256_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
+            __m256i const sum       = _mm256_add_epi64(xacc[i], data_swap);
+            /* xacc[i] += product; */
+            xacc[i] = _mm256_add_epi64(product, sum);
     }   }
 }
 
@@ -1212,8 +1194,7 @@ XXH_FORCE_INLINE XXH_TARGET_AVX2 void XXH3_initCustomSecret_avx2(void* XXH_RESTR
 XXH_FORCE_INLINE XXH_TARGET_SSE2 void
 XXH3_accumulate_512_sse2( void* XXH_RESTRICT acc,
                     const void* XXH_RESTRICT input,
-                    const void* XXH_RESTRICT secret,
-                    XXH3_accWidth_e accWidth)
+                    const void* XXH_RESTRICT secret)
 {
     /* SSE2 is just a half-scale version of the AVX2 version. */
     XXH_ASSERT((((size_t)acc) & 15) == 0);
@@ -1237,18 +1218,11 @@ XXH3_accumulate_512_sse2( void* XXH_RESTRICT acc,
             __m128i const data_key_lo = _mm_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
             /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
             __m128i const product     = _mm_mul_epu32     (data_key, data_key_lo);
-            if (accWidth == XXH3_acc_128bits) {
-                /* xacc[i] += swap(data_vec); */
-                __m128i const data_swap = _mm_shuffle_epi32(data_vec, _MM_SHUFFLE(1,0,3,2));
-                __m128i const sum       = _mm_add_epi64(xacc[i], data_swap);
-                /* xacc[i] += product; */
-                xacc[i] = _mm_add_epi64(product, sum);
-            } else {  /* XXH3_acc_64bits */
-                /* xacc[i] += data_vec; */
-                __m128i const sum = _mm_add_epi64(xacc[i], data_vec);
-                /* xacc[i] += product; */
-                xacc[i] = _mm_add_epi64(product, sum);
-            }
+            /* xacc[i] += swap(data_vec); */
+            __m128i const data_swap = _mm_shuffle_epi32(data_vec, _MM_SHUFFLE(1,0,3,2));
+            __m128i const sum       = _mm_add_epi64(xacc[i], data_swap);
+            /* xacc[i] += product; */
+            xacc[i] = _mm_add_epi64(product, sum);
     }   }
 }
 
@@ -1319,8 +1293,7 @@ XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTR
 XXH_FORCE_INLINE void
 XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
                     const void* XXH_RESTRICT input,
-                    const void* XXH_RESTRICT secret,
-                    XXH3_accWidth_e accWidth)
+                    const void* XXH_RESTRICT secret)
 {
     XXH_ASSERT((((size_t)acc) & 15) == 0);
     {
@@ -1337,15 +1310,10 @@ XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
             uint8x16_t key_vec     = vld1q_u8(xsecret + (i * 16));
             uint64x2_t data_key;
             uint32x2_t data_key_lo, data_key_hi;
-            if (accWidth == XXH3_acc_64bits) {
-                /* xacc[i] += data_vec; */
-                xacc[i] = vaddq_u64 (xacc[i], vreinterpretq_u64_u8(data_vec));
-            } else {  /* XXH3_acc_128bits */
-                /* xacc[i] += swap(data_vec); */
-                uint64x2_t const data64  = vreinterpretq_u64_u8(data_vec);
-                uint64x2_t const swapped = vextq_u64(data64, data64, 1);
-                xacc[i] = vaddq_u64 (xacc[i], swapped);
-            }
+            /* xacc[i] += swap(data_vec); */
+            uint64x2_t const data64  = vreinterpretq_u64_u8(data_vec);
+            uint64x2_t const swapped = vextq_u64(data64, data64, 1);
+            xacc[i] = vaddq_u64 (xacc[i], swapped);
             /* data_key = data_vec ^ key_vec; */
             data_key = vreinterpretq_u64_u8(veorq_u8(data_vec, key_vec));
             /* data_key_lo = (uint32x2_t) (data_key & 0xFFFFFFFF);
@@ -1419,8 +1387,7 @@ XXH3_scrambleAcc_neon(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 XXH_FORCE_INLINE void
 XXH3_accumulate_512_vsx(  void* XXH_RESTRICT acc,
                     const void* XXH_RESTRICT input,
-                    const void* XXH_RESTRICT secret,
-                    XXH3_accWidth_e accWidth)
+                    const void* XXH_RESTRICT secret)
 {
           xxh_u64x2* const xacc     =       (xxh_u64x2*) acc;    /* presumed aligned */
     xxh_u64x2 const* const xinput   = (xxh_u64x2 const*) input;   /* no alignment restriction */
@@ -1439,17 +1406,13 @@ XXH3_accumulate_512_vsx(  void* XXH_RESTRICT acc,
         xxh_u64x2 const product  = XXH_vec_mulo((xxh_u32x4)data_key, shuffled);
         xacc[i] += product;
 
-        if (accWidth == XXH3_acc_64bits) {
-            xacc[i] += data_vec;
-        } else {  /* XXH3_acc_128bits */
-            /* swap high and low halves */
+        /* swap high and low halves */
 #ifdef __s390x__
-            xxh_u64x2 const data_swapped = vec_permi(data_vec, data_vec, 2);
+        xxh_u64x2 const data_swapped = vec_permi(data_vec, data_vec, 2);
 #else
-            xxh_u64x2 const data_swapped = vec_xxpermdi(data_vec, data_vec, 2);
+        xxh_u64x2 const data_swapped = vec_xxpermdi(data_vec, data_vec, 2);
 #endif
-            xacc[i] += data_swapped;
-        }
+        xacc[i] += data_swapped;
     }
 }
 
@@ -1490,8 +1453,7 @@ XXH3_scrambleAcc_vsx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 XXH_FORCE_INLINE void
 XXH3_accumulate_512_scalar(void* XXH_RESTRICT acc,
                      const void* XXH_RESTRICT input,
-                     const void* XXH_RESTRICT secret,
-                     XXH3_accWidth_e accWidth)
+                     const void* XXH_RESTRICT secret)
 {
     XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64* const xacc = (xxh_u64*) acc; /* presumed aligned */
     const xxh_u8* const xinput  = (const xxh_u8*) input;  /* no alignment restriction */
@@ -1501,12 +1463,7 @@ XXH3_accumulate_512_scalar(void* XXH_RESTRICT acc,
     for (i=0; i < XXH_ACC_NB; i++) {
         xxh_u64 const data_val = XXH_readLE64(xinput + 8*i);
         xxh_u64 const data_key = data_val ^ XXH_readLE64(xsecret + i*8);
-
-        if (accWidth == XXH3_acc_64bits) {
-            xacc[i] += data_val;
-        } else {
-            xacc[i ^ 1] += data_val; /* swap adjacent lanes */
-        }
+        xacc[i ^ 1] += data_val; /* swap adjacent lanes */
         xacc[i] += XXH_mult32to64(data_key & 0xFFFFFFFF, data_key >> 32);
     }
 }
@@ -1593,7 +1550,7 @@ XXH3_initCustomSecret_scalar(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
 }
 
 
-typedef void (*XXH3_f_accumulate_512)(void* XXH_RESTRICT, const void*, const void*, XXH3_accWidth_e);
+typedef void (*XXH3_f_accumulate_512)(void* XXH_RESTRICT, const void*, const void*);
 typedef void (*XXH3_f_scrambleAcc)(void* XXH_RESTRICT, const void*);
 typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
 
@@ -1660,7 +1617,6 @@ XXH3_accumulate(     xxh_u64* XXH_RESTRICT acc,
                 const xxh_u8* XXH_RESTRICT input,
                 const xxh_u8* XXH_RESTRICT secret,
                       size_t nbStripes,
-                      XXH3_accWidth_e accWidth,
                       XXH3_f_accumulate_512 f_acc512)
 {
     size_t n;
@@ -1669,8 +1625,7 @@ XXH3_accumulate(     xxh_u64* XXH_RESTRICT acc,
         XXH_PREFETCH(in + XXH_PREFETCH_DIST);
         f_acc512(acc,
                  in,
-                 secret + n*XXH_SECRET_CONSUME_RATE,
-                 accWidth);
+                 secret + n*XXH_SECRET_CONSUME_RATE);
     }
 }
 
@@ -1678,7 +1633,6 @@ XXH_FORCE_INLINE void
 XXH3_hashLong_internal_loop(xxh_u64* XXH_RESTRICT acc,
                       const xxh_u8* XXH_RESTRICT input, size_t len,
                       const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
-                            XXH3_accWidth_e accWidth,
                             XXH3_f_accumulate_512 f_acc512,
                             XXH3_f_scrambleAcc f_scramble)
 {
@@ -1691,7 +1645,7 @@ XXH3_hashLong_internal_loop(xxh_u64* XXH_RESTRICT acc,
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
 
     for (n = 0; n < nb_blocks; n++) {
-        XXH3_accumulate(acc, input + n*block_len, secret, nbStripesPerBlock, accWidth, f_acc512);
+        XXH3_accumulate(acc, input + n*block_len, secret, nbStripesPerBlock, f_acc512);
         f_scramble(acc, secret + secretSize - XXH_STRIPE_LEN);
     }
 
@@ -1699,12 +1653,12 @@ XXH3_hashLong_internal_loop(xxh_u64* XXH_RESTRICT acc,
     XXH_ASSERT(len > XXH_STRIPE_LEN);
     {   size_t const nbStripes = ((len - 1) - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
         XXH_ASSERT(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
-        XXH3_accumulate(acc, input + nb_blocks*block_len, secret, nbStripes, accWidth, f_acc512);
+        XXH3_accumulate(acc, input + nb_blocks*block_len, secret, nbStripes, f_acc512);
 
         /* last stripe */
         {   const xxh_u8* const p = input + len - XXH_STRIPE_LEN;
 #define XXH_SECRET_LASTACC_START 7  /* not aligned on 8, last secret is different from acc & scrambler */
-            f_acc512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START, accWidth);
+            f_acc512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START);
     }   }
 }
 
@@ -1754,7 +1708,7 @@ XXH3_hashLong_64b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
 {
     XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[XXH_ACC_NB] = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, XXH3_acc_128bits, f_acc512, f_scramble);
+    XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
     XXH_STATIC_ASSERT(sizeof(acc) == 64);
@@ -2021,7 +1975,6 @@ XXH3_consumeStripes(xxh_u64* XXH_RESTRICT acc,
                     size_t* XXH_RESTRICT nbStripesSoFarPtr, size_t nbStripesPerBlock,
                     const xxh_u8* XXH_RESTRICT input, size_t nbStripes,
                     const xxh_u8* XXH_RESTRICT secret, size_t secretLimit,
-                    XXH3_accWidth_e accWidth,
                     XXH3_f_accumulate_512 f_acc512,
                     XXH3_f_scrambleAcc f_scramble)
 {
@@ -2031,12 +1984,12 @@ XXH3_consumeStripes(xxh_u64* XXH_RESTRICT acc,
         /* need a scrambling operation */
         size_t const nbStripesToEndofBlock = nbStripesPerBlock - *nbStripesSoFarPtr;
         size_t const nbStripesAfterBlock = nbStripes - nbStripesToEndofBlock;
-        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripesToEndofBlock, accWidth, f_acc512);
+        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripesToEndofBlock, f_acc512);
         f_scramble(acc, secret + secretLimit);
-        XXH3_accumulate(acc, input + nbStripesToEndofBlock * XXH_STRIPE_LEN, secret, nbStripesAfterBlock, accWidth, f_acc512);
+        XXH3_accumulate(acc, input + nbStripesToEndofBlock * XXH_STRIPE_LEN, secret, nbStripesAfterBlock, f_acc512);
         *nbStripesSoFarPtr = nbStripesAfterBlock;
     } else {
-        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, accWidth, f_acc512);
+        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, f_acc512);
         *nbStripesSoFarPtr += nbStripes;
     }
 }
@@ -2047,7 +2000,6 @@ XXH3_consumeStripes(xxh_u64* XXH_RESTRICT acc,
 XXH_FORCE_INLINE XXH_errorcode
 XXH3_update(XXH3_state_t* state,
             const xxh_u8* input, size_t len,
-            XXH3_accWidth_e accWidth,
             XXH3_f_accumulate_512 f_acc512,
             XXH3_f_scrambleAcc f_scramble)
 {
@@ -2085,7 +2037,7 @@ XXH3_update(XXH3_state_t* state,
                                &state->nbStripesSoFar, state->nbStripesPerBlock,
                                 state->buffer, XXH3_INTERNALBUFFER_STRIPES,
                                 secret, state->secretLimit,
-                                accWidth, f_acc512, f_scramble);
+                                f_acc512, f_scramble);
             state->bufferedSize = 0;
         }
         XXH_ASSERT(input < bEnd);
@@ -2098,7 +2050,7 @@ XXH3_update(XXH3_state_t* state,
                                    &state->nbStripesSoFar, state->nbStripesPerBlock,
                                     input, XXH3_INTERNALBUFFER_STRIPES,
                                     secret, state->secretLimit,
-                                    accWidth, f_acc512, f_scramble);
+                                    f_acc512, f_scramble);
                 input += XXH3_INTERNALBUFFER_SIZE;
             } while (input<limit);
             /* for last partial stripe */
@@ -2118,15 +2070,14 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_64bits_update(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_64bits, XXH3_accumulate_512, XXH3_scrambleAcc);
+                       XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
 
 XXH_FORCE_INLINE void
 XXH3_digest_long (XXH64_hash_t* acc,
                   const XXH3_state_t* state,
-                  const unsigned char* secret,
-                  XXH3_accWidth_e accWidth)
+                  const unsigned char* secret)
 {
     /*
      * Digest on a local copy. This way, the state remains unaltered, and it can
@@ -2140,12 +2091,11 @@ XXH3_digest_long (XXH64_hash_t* acc,
                            &nbStripesSoFar, state->nbStripesPerBlock,
                             state->buffer, nbStripes,
                             secret, state->secretLimit,
-                            accWidth, XXH3_accumulate_512, XXH3_scrambleAcc);
+                            XXH3_accumulate_512, XXH3_scrambleAcc);
         /* last stripe */
         XXH3_accumulate_512(acc,
                             state->buffer + state->bufferedSize - XXH_STRIPE_LEN,
-                            secret + state->secretLimit - XXH_SECRET_LASTACC_START,
-                            accWidth);
+                            secret + state->secretLimit - XXH_SECRET_LASTACC_START);
     } else {  /* bufferedSize < XXH_STRIPE_LEN */
         xxh_u8 lastStripe[XXH_STRIPE_LEN];
         size_t const catchupSize = XXH_STRIPE_LEN - state->bufferedSize;
@@ -2154,8 +2104,7 @@ XXH3_digest_long (XXH64_hash_t* acc,
         memcpy(lastStripe + catchupSize, state->buffer, state->bufferedSize);
         XXH3_accumulate_512(acc,
                             lastStripe,
-                            secret + state->secretLimit - XXH_SECRET_LASTACC_START,
-                            accWidth);
+                            secret + state->secretLimit - XXH_SECRET_LASTACC_START);
     }
 }
 
@@ -2164,7 +2113,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
     const unsigned char* const secret = (state->extSecret == NULL) ? state->customSecret : state->extSecret;
     if (state->totalLen > XXH3_MIDSIZE_MAX) {
         XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[XXH_ACC_NB];
-        XXH3_digest_long(acc, state, secret, XXH3_acc_64bits);
+        XXH3_digest_long(acc, state, secret);
         return XXH3_mergeAccs(acc,
                               secret + XXH_SECRET_MERGEACCS_START,
                               (xxh_u64)state->totalLen * XXH_PRIME64_1);
@@ -2491,7 +2440,7 @@ XXH3_hashLong_128b_internal(const xxh_u8* XXH_RESTRICT input, size_t len,
 {
     XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[XXH_ACC_NB] = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, XXH3_acc_128bits, f_acc512, f_scramble);
+    XXH3_hashLong_internal_loop(acc, input, len, secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
     XXH_STATIC_ASSERT(sizeof(acc) == 64);
@@ -2668,7 +2617,7 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_128bits, XXH3_accumulate_512, XXH3_scrambleAcc);
+                       XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
 XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
@@ -2676,7 +2625,7 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
     const unsigned char* const secret = (state->extSecret == NULL) ? state->customSecret : state->extSecret;
     if (state->totalLen > XXH3_MIDSIZE_MAX) {
         XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[XXH_ACC_NB];
-        XXH3_digest_long(acc, state, secret, XXH3_acc_128bits);
+        XXH3_digest_long(acc, state, secret);
         XXH_ASSERT(state->secretLimit + XXH_STRIPE_LEN >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
         {   XXH128_hash_t h128;
             h128.low64  = XXH3_mergeAccs(acc,

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -389,28 +389,28 @@ XXH_NO_INLINE XXH_errorcode
 XXH3_64bits_update_scalar(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_64bits, XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
+                       XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
 }
 
 XXH_NO_INLINE XXH_TARGET_SSE2 XXH_errorcode
 XXH3_64bits_update_sse2(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_64bits, XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
+                       XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
 }
 
 XXH_NO_INLINE XXH_TARGET_AVX2 XXH_errorcode
 XXH3_64bits_update_avx2(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_64bits, XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2);
+                       XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2);
 }
 
 XXH_NO_INLINE XXH_TARGET_AVX512 XXH_errorcode
 XXH3_64bits_update_avx512(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_64bits, XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512);
+                       XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512);
 }
 
 
@@ -512,28 +512,28 @@ XXH_NO_INLINE XXH_errorcode
 XXH3_128bits_update_scalar(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_128bits, XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
+                       XXH3_accumulate_512_scalar, XXH3_scrambleAcc_scalar);
 }
 
 XXH_NO_INLINE XXH_TARGET_SSE2 XXH_errorcode
 XXH3_128bits_update_sse2(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_128bits, XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
+                       XXH3_accumulate_512_sse2, XXH3_scrambleAcc_sse2);
 }
 
 XXH_NO_INLINE XXH_TARGET_AVX2 XXH_errorcode
 XXH3_128bits_update_avx2(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_128bits, XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2);
+                       XXH3_accumulate_512_avx2, XXH3_scrambleAcc_avx2);
 }
 
 XXH_NO_INLINE XXH_TARGET_AVX512 XXH_errorcode
 XXH3_128bits_update_avx512(XXH3_state_t* state, const void* input, size_t len)
 {
     return XXH3_update(state, (const xxh_u8*)input, len,
-                       XXH3_acc_128bits, XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512);
+                       XXH3_accumulate_512_avx512, XXH3_scrambleAcc_avx512);
 }
 
 /* ====    Dispatchers    ==== */


### PR DESCRIPTION
So far, `XXH3` and `XXH128` have been using a related yet slightly different mixer.
The main reason is that `XXH128` must spread ingestion over a 128-bit accumulator width, 
while `XXH3` only needs 64-bit, which is easier and slightly faster.

This PR simplifies the mixer, by always using `XXH128` mixer.
This choice comes at the cost of a bit of top speed performance for `XXH3` (~10%).

However, it also provides the following benefits : 
- There was a small gradual degradation in `XXH3` collision ratio, from 64-bit towards 62-bit, when input length increases beyond > 1 KB (it was previously believed that collision ratio would remain stable whatever the input length beyond 256). This PR fixes it.
- Simpler code
- Smaller produced binary (variable impact, depending on compiler settings).
- Improves performance for small binaries (`-Oz`), by removing a branch within the critical loop (most visible in `arm`).