### PR TITLE
Fix compiler warning for 32 bit architectures

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -2275,7 +2275,7 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
              * On 32-bit, it removes an ADC and delays a dependency between the two
              * halves of m128.high64, but it generates an extra mask on 64-bit.
              */
-            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64((xxh_u32)input_hi, XXH_PRIME32_2);
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000ULL) + XXH_mult32to64((xxh_u32)input_hi, XXH_PRIME32_2);
         } else {
             /*
              * 64-bit optimized (albeit more confusing) version.


### PR DESCRIPTION
In file included from xxhash.h:2065,
                 from xxhash.c:43:
xxh3.h: In function 'XXH3_len_9to16_128b':
xxh3.h:2278: warning: integer constant is too large for 'long' type