### PR TITLE
xxh*sum: print correct default algo for symlinked helpers

### DIFF
--- a/xxhsum.c
+++ b/xxhsum.c
@@ -468,7 +468,7 @@ static size_t XXH_DEFAULT_SAMPLE_SIZE = 100 KB;
 
 static const char stdinName[] = "-";
 typedef enum { algo_xxh32=0, algo_xxh64=1, algo_xxh128=2 } AlgoSelected;
-static const AlgoSelected g_defaultAlgo = algo_xxh64;    /* required within main() & usage() */
+static AlgoSelected g_defaultAlgo = algo_xxh64;    /* required within main() & usage() */
 
 /* <16 hex char> <SPC> <SPC> <filename> <'\0'>
  * '4096' is typical Linux PATH_MAX configuration. */
@@ -2254,9 +2254,9 @@ static int XXH_main(int argc, const char* const* argv)
     Display_convention convention = display_gnu;
 
     /* special case: xxhNNsum default to NN bits checksum */
-    if (strstr(exename,  "xxh32sum") != NULL) algo = algo_xxh32;
-    if (strstr(exename,  "xxh64sum") != NULL) algo = algo_xxh64;
-    if (strstr(exename, "xxh128sum") != NULL) algo = algo_xxh128;
+    if (strstr(exename,  "xxh32sum") != NULL) algo = g_defaultAlgo = algo_xxh32;
+    if (strstr(exename,  "xxh64sum") != NULL) algo = g_defaultAlgo = algo_xxh64;
+    if (strstr(exename, "xxh128sum") != NULL) algo = g_defaultAlgo = algo_xxh128;
 
     for(i=1; i<argc; i++) {
         const char* argument = argv[i];


### PR DESCRIPTION
Printing xxh128sum's help for example would say default algo is xxh64,
which is not correct. Adjust g_defaultAlgo accordingly as well as the
currently selected algorithm.

-----
When doing a PR is just as fast as opening an issue I tend to just go ahead with it, but feel free to close this and fix it otherwise (or tell me it's a feature :P) -- removing the const attribute is a bit of a shame.

Thanks! Can't wait for 0.8 to be out.