### PR TITLE
WIP: new -withSeed API variant for reusing the custom secret of the long input

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1832,6 +1832,24 @@ XXH3_64bits_withSeed(const void* input, size_t len, XXH64_hash_t seed)
     return XXH3_64bits_internal(input, len, seed, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_64b_withSeed);
 }
 
+XXH_NO_INLINE XXH64_hash_t
+XXH3_hashLong_64b_withSeed2(const xxh_u8* XXH_RESTRICT const input, const size_t len, const xxh_u8* XXH_RESTRICT const secret)
+{
+    return XXH3_hashLong_64b_internal(input, len, secret, XXH_SECRET_DEFAULT_SIZE, XXH3_accumulate_512, XXH3_scrambleAcc);
+}
+
+XXH_PUBLIC_API XXH64_hash_t
+XXH3_64bits_withSeed2(const void* const input, const size_t len, const XXH3_state_t* const seed_state)
+{
+    if (len <= 16)
+        return XXH3_len_0to16_64b((const xxh_u8*)input, len, XXH3_kSecret, seed_state->seed);
+    if (len <= 128)
+        return XXH3_len_17to128_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed_state->seed);
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_len_129to240_64b((const xxh_u8*)input, len, XXH3_kSecret, sizeof(XXH3_kSecret), seed_state->seed);
+    return XXH3_hashLong_64b_withSeed2((const xxh_u8*)input, len, seed_state->customSecret);
+}
+
 
 /* ===   XXH3 streaming   === */
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -482,6 +482,7 @@ struct XXH64_state_s {
 #  define XXH3_64bits XXH_NAME2(XXH_NAMESPACE, XXH3_64bits)
 #  define XXH3_64bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSecret)
 #  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
+#  define XXH3_64bits_withSeed2 XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed2)
 
 #  define XXH3_createState XXH_NAME2(XXH_NAMESPACE, XXH3_createState)
 #  define XXH3_freeState XXH_NAME2(XXH_NAMESPACE, XXH3_freeState)
@@ -509,6 +510,15 @@ XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(const void* data, size_t len);
  * Note: seed==0 produces the same results as XXH3_64bits().
  */
 XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSeed(const void* data, size_t len, XXH64_hash_t seed);
+
+/*
+ * XXH3_64bits_withSeed2():
+ * This variant try to reuse the custom secret for a seed.
+ * The seed_state is generated from XXH3_64bits_reset_withSeed().
+ * The produced results are same with XXH3_64bits_withSeed2().
+ */
+typedef struct XXH3_state_s XXH3_state_t;
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_withSeed2(const void* data, size_t len, const XXH3_state_t *seed_state);
 
 /*
  * XXH3_64bits_withSecret():


### PR DESCRIPTION
In many production scenarios using non-zero seeds, the seeds are almost compile time or runtime constants for consistent results. The new experiment api `XXH3_hashLong_64b_withSeed2` tries to improve performance of the long inputs in these cases by reusing the internal result of `initCustomSecret`.

Usage:
```c
XXH3_state_t seed_state;
XXH3_64bits_reset_withSeed(&seed_state, seed); // init once

while (len = read(data)) {
    result = XXH3_64bits_withSeed2(data, len, &seed_state); // reuse seed_state
}
```

I roughly bench the new api compared to the original one, on a CentOS 8 machine (SSE2/AVX2), compiling with gcc-9 and clang-9, with/without XXH_INLINE_ALL switch, the performance can be steadily  improved over input length from 256B to 100K. So open this WIP pr for further discussion.