### PR TITLE
Add the ability to parse BSD style --check lines.

### DIFF
--- a/xxhsum.1
+++ b/xxhsum.1
@@ -61,6 +61,10 @@ Read xxHash sums from \fIFILE\fR and check them
 Don\'t print OK for each successfully verified file
 .
 .TP
+\fB\-\-tag\fR
+Output in the BSD style.
+.
+.TP
 \fB\-\-strict\fR
 Return an error code if any line in the file is invalid, not just if some checksums are wrong\. This policy is disabled by default, though UI will prompt an informational message if any line in the file is detected invalid\.
 .

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -54,6 +54,9 @@ OPTIONS
 * `-q`, `--quiet`:
   Don't print OK for each successfully verified file
 
+* `--tag`:
+  Output in the BSD style.
+
 * `--strict`:
   Return an error code if any line in the file is invalid,
   not just if some checksums are wrong.

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1815,7 +1815,7 @@ static ParseLineResult parseLine(ParsedLine* parsedLine, char* line)
 {
     const char* const firstSpace = strchr(line, ' ');
     const char* hash_ptr;
-    int hash_len;
+    size_t hash_len;
     if (firstSpace == NULL || !firstSpace[1]) return ParseLine_invalidFormat;
 
     parsedLine->filename = NULL;

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1833,7 +1833,7 @@ static ParseLineResult parseLine(ParsedLine* parsedLine, char* line)
          * It could also be used to allow both XXH64 & XXH3_64bits to be differentiated. */
     } else {
         hash_ptr = line;
-        hash_len = firstSpace - line;
+        hash_len = (size_t)(firstSpace - line);
     }
 
     switch (hash_len)

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1816,7 +1816,7 @@ static ParseLineResult parseLine(ParsedLine* parsedLine, char* line)
     const char* const firstSpace = strchr(line, ' ');
     const char* hash_ptr;
     int hash_len;
-    if (firstSpace == NULL) return ParseLine_invalidFormat;
+    if (firstSpace == NULL || !firstSpace[1]) return ParseLine_invalidFormat;
 
     parsedLine->filename = NULL;
     parsedLine->xxhBits = 0;

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1780,12 +1780,12 @@ static int charToHex(char c)
 static CanonicalFromStringResult canonicalFromString(unsigned char* dst,
                                                      size_t dstSize,
                                                      const char* hashStr,
-                                                     int reverseDigits)
+                                                     int reverseBytes)
 {
     size_t i;
     for (i = 0; i < dstSize; ++i) {
         int h0, h1;
-        size_t j = reverseDigits ? dstSize - i - 1 : i;
+        size_t j = reverseBytes ? dstSize - i - 1 : i;
 
         h0 = charToHex(hashStr[j*2 + 0]);
         if (h0 < 0) return CanonicalFromString_invalidFormat;


### PR DESCRIPTION
Here's a simple way for the --check code to parse BSD style lines. I made the --tag option no longer hidden, since --check works fine with the output.  I also fixed a bug where the --check parser accepted a line that ended after the first space (returning a bogus filename pointer) and I enabled the combining of  --check with --little-endian.