### PR TITLE
Remove pre-processor already defined warning

### DIFF
--- a/xxhsum.c
+++ b/xxhsum.c
@@ -35,7 +35,9 @@
  **************************************/
 /* MS Visual */
 #if defined(_MSC_VER) || defined(_WIN32)
-#  define _CRT_SECURE_NO_WARNINGS   /* removes visual warnings */
+#  ifndef _CRT_SECURE_NO_WARNINGS
+#    define _CRT_SECURE_NO_WARNINGS   /* removes visual warnings */
+#  endif
 #endif
 
 /* Under Linux at least, pull in the *64 commands */


### PR DESCRIPTION
When including into other source code (especially when using cmake or the like) the declaration of _CRT_SECURE_NO_WARNINGS in `xxhsum.c` can cause a compiler warning about already defined pre-processor symbols. Wrap the symbol definition in a check to see if it's already defined and not try to define it again.