### PR TITLE
Remove uninitialized local variable warning

### DIFF
--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1463,7 +1463,7 @@ XSUM_hashStream(FILE* inFile,
             exit(1);
     }   }
 
-    {   Multihash finalHash;
+    {   Multihash finalHash = {0};
         switch(hashType)
         {
         case algo_xxh32:


### PR DESCRIPTION
Can generate a `potentially uninitialized local variable 'finalHash' used` warning.