### PR TITLE
fix P9 build

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -362,6 +362,7 @@
 #  endif
 
 #  undef vector /* Undo the pollution */
+#  undef bool
 
 typedef __vector unsigned long long xxh_u64x2;
 typedef __vector unsigned char xxh_u8x16;


### PR DESCRIPTION
This fixes an error message I encountered while trying to build a downstream package (apache arrow):

```In file included from /ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/array/dict_internal.h:35:0,
                 from /ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/array/builder_dict.cc:22:
/ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/util/hashing.h: In static member function 'static uint32_t arrow::internal::SmallScalarTraits<__vector(4) __bool int>::AsIndex(__vector(4) __bool int)':
/ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/util/hashing.h:495:60: error: cannot convert '__vector(4) int' to 'uint32_t {aka unsigned int}' in return
   static uint32_t AsIndex(bool value) { return value ? 1 : 0; }```

See  https://github.com/apache/arrow/pull/7711