### PR TITLE
Improves speed of streaming variant on small inputs

### DIFF
--- a/xxh3.h
+++ b/xxh3.h
@@ -1902,7 +1902,7 @@ static void XXH_alignedFree(void* p)
 }
 XXH_PUBLIC_API XXH3_state_t* XXH3_createState(void)
 {
-    XXH3_state_t* const state = XXH_alignedMalloc(sizeof(XXH3_state_t), 64);
+    XXH3_state_t* const state = (XXH3_state_t*)XXH_alignedMalloc(sizeof(XXH3_state_t), 64);
     if (state==NULL) return NULL;
     XXH3_INITSTATE(state);
     return state;

--- a/xxh3.h
+++ b/xxh3.h
@@ -1926,8 +1926,11 @@ XXH3_64bits_reset_internal(XXH3_state_t* statePtr,
                            const void* secret, size_t secretSize)
 {
     size_t const initStart = offsetof(XXH3_state_t, bufferedSize);
+    size_t const initLength = offsetof(XXH3_state_t, nbStripesPerBlock) - initStart;
+    XXH_ASSERT(offsetof(XXH3_state_t, nbStripesPerBlock) > initStart);
     XXH_ASSERT(statePtr != NULL);
-    memset((char*)statePtr + initStart, 0, sizeof(*statePtr) - initStart);
+    /* set members from bufferedSize to nbStripesPerBlock (excluded) to 0 */
+    memset((char*)statePtr + initStart, 0, initLength);
     statePtr->acc[0] = XXH_PRIME32_3;
     statePtr->acc[1] = XXH_PRIME64_1;
     statePtr->acc[2] = XXH_PRIME64_2;

--- a/xxhash.h
+++ b/xxhash.h
@@ -554,15 +554,15 @@ typedef struct XXH3_state_s XXH3_state_t;
 #define XXH3_SECRET_DEFAULT_SIZE 192
 struct XXH3_state_s {
    XXH_ALIGN_MEMBER(64, XXH64_hash_t acc[8]);
-  /* used to store a custom secret generated from a seed */
+   /* used to store a custom secret generated from a seed */
    XXH_ALIGN_MEMBER(64, unsigned char customSecret[XXH3_SECRET_DEFAULT_SIZE]);
    XXH_ALIGN_MEMBER(64, unsigned char buffer[XXH3_INTERNALBUFFER_SIZE]);
    XXH32_hash_t bufferedSize;
    XXH32_hash_t reserved32;
-   size_t nbStripesPerBlock;
    size_t nbStripesSoFar;
-   size_t secretLimit;
    XXH64_hash_t totalLen;
+   size_t nbStripesPerBlock;
+   size_t secretLimit;
    XXH64_hash_t seed;
    XXH64_hash_t reserved64;
    const unsigned char* extSecret;  /* reference to external secret;

--- a/xxhash.h
+++ b/xxhash.h
@@ -572,6 +572,16 @@ struct XXH3_state_s {
 
 #undef XXH_ALIGN_MEMBER
 
+/* When the XXH3_state_t structure is merely emplaced on stack,
+ * it should be initialized with XXH3_INITSTATE() or a memset()
+ * in case its first reset uses XXH3_NNbits_reset_withSeed().
+ * This init can be omitted if the first reset uses default or _withSecret mode.
+ * This operation isn't necessary when the state is created with XXH3_createState().
+ * Note that this doesn't prepare the state for a streaming operation,
+ * it's still necessary to use XXH3_NNbits_reset*() afterwards.
+ */
+#define XXH3_INITSTATE(XXH3_state_ptr)   { (XXH3_state_ptr)->seed = 0; }
+
 /*
  * Streaming requires state maintenance.
  * This operation costs memory and CPU.

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -657,11 +657,26 @@ static U32 localXXH3_stream(const void* buffer, size_t bufferSize, U32 seed)
     XXH3_64bits_update(&state, buffer, bufferSize);
     return (U32)XXH3_64bits_digest(&state);
 }
+static U32 localXXH3_stream_seeded(const void* buffer, size_t bufferSize, U32 seed)
+{
+    XXH3_state_t state;
+    XXH3_64bits_reset_withSeed(&state, (XXH64_hash_t)seed);
+    XXH3_64bits_update(&state, buffer, bufferSize);
+    return (U32)XXH3_64bits_digest(&state);
+}
 static U32 localXXH128_stream(const void* buffer, size_t bufferSize, U32 seed)
 {
     XXH3_state_t state;
     (void)seed;
     XXH3_128bits_reset(&state);
+    XXH3_128bits_update(&state, buffer, bufferSize);
+    return (U32)(XXH3_128bits_digest(&state).low64);
+}
+static U32 localXXH128_stream_seeded(const void* buffer, size_t bufferSize, U32 seed)
+{
+    XXH3_state_t state;
+    (void)seed;
+    XXH3_128bits_reset_withSeed(&state, (XXH64_hash_t)seed);
     XXH3_128bits_update(&state, buffer, bufferSize);
     return (U32)(XXH3_128bits_digest(&state).low64);
 }
@@ -672,7 +687,7 @@ typedef struct {
     hashFunction func;
 } hashInfo;
 
-#define NB_HASHFUNC 10
+#define NB_HASHFUNC 12
 static const hashInfo g_hashesToBench[NB_HASHFUNC] = {
     { "XXH32",             &localXXH32 },
     { "XXH64",             &localXXH64 },
@@ -683,7 +698,9 @@ static const hashInfo g_hashesToBench[NB_HASHFUNC] = {
     { "XXH128 w/seed",     &localXXH3_128b_seeded },
     { "XXH128 w/secret",   &localXXH3_128b_secret },
     { "XXH3_stream",       &localXXH3_stream },
+    { "XXH3_stream w/seed",&localXXH3_stream_seeded },
     { "XXH128_stream",     &localXXH128_stream },
+    { "XXH128_stream w/seed",&localXXH128_stream_seeded },
 };
 
 #define NB_TESTFUNC (1 + 2 * NB_HASHFUNC)

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -660,6 +660,7 @@ static U32 localXXH3_stream(const void* buffer, size_t bufferSize, U32 seed)
 static U32 localXXH3_stream_seeded(const void* buffer, size_t bufferSize, U32 seed)
 {
     XXH3_state_t state;
+    XXH3_INITSTATE(&state);
     XXH3_64bits_reset_withSeed(&state, (XXH64_hash_t)seed);
     XXH3_64bits_update(&state, buffer, bufferSize);
     return (U32)XXH3_64bits_digest(&state);
@@ -675,7 +676,7 @@ static U32 localXXH128_stream(const void* buffer, size_t bufferSize, U32 seed)
 static U32 localXXH128_stream_seeded(const void* buffer, size_t bufferSize, U32 seed)
 {
     XXH3_state_t state;
-    (void)seed;
+    XXH3_INITSTATE(&state);
     XXH3_128bits_reset_withSeed(&state, (XXH64_hash_t)seed);
     XXH3_128bits_update(&state, buffer, bufferSize);
     return (U32)(XXH3_128bits_digest(&state).low64);


### PR DESCRIPTION
This PR improves speed of the streaming variant for smaller inputs.

`XXH3` speed of "default" streaming variant at various input lengths: 

| Input Size | `dev` | this PR |
| --- | --- | --- |
| 1 | 30 MB/s | 45 MB/s |
| 16 | 500 MB/s | 700 MB/s |
| 256 | 4.4 GB/s | 5.2 GB/s |
| 4K | 13.1 GB/s | 13.4 GB/s |
| 100 KB | 14.1 GB/s | 14.4 GB/s |

It achieves this result by doing less work at `reset()` stage,
`memset()`ing less memory,
and re-using the generated `customSecret` for the `_withSeed()` variant _if the `seed` remains identical_ across sessions (impact is larger in this case).

`XXH3` speed of `_withSeed()` streaming variant while re-using same `seed` value, at various input lengths: 

| Input Size | `dev` | this PR |
| --- | --- | --- |
| 1 | 28 MB/s | 37 MB/s |
| 16 | 460 MB/s | 610 MB/s |
| 256 | 4.1 GB/s | 4.7 GB/s |
| 4K | 12.9 GB/s | 13.3 GB/s |
| 100 KB | 14.3 GB/s | 14.4 GB/s |

It now requires any state which is just allocated on stack to be initialized before first `reset()`, 
by using `XXH3_INITSTATE()`.

The benchmark mode can now also measure speed of streaming variant `_withSeed()`.