### PR TITLE
Support '--' to signify end of options

### DIFF
--- a/xxhsum.c
+++ b/xxhsum.c
@@ -2322,11 +2322,11 @@ static int XXH_main(int argc, const char* const* argv)
 
         if (!strcmp(argument, "--")) {
             if (filenamesStart==0 && i!=argc-1) filenamesStart=i+1; /* only supports a continuous list of filenames */
-            break;
+            break;  /* treat rest of arguments as strictly file names */
         }
         if (*argument!='-') {
             if (filenamesStart==0) filenamesStart=i;   /* only supports a continuous list of filenames */
-            break;
+            break;  /* treat rest of arguments as strictly file names */
         }
 
         /* command selection */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -2322,7 +2322,7 @@ static int XXH_main(int argc, const char* const* argv)
 
         if (*argument!='-') {
             if (filenamesStart==0) filenamesStart=i;   /* only supports a continuous list of filenames */
-            continue;
+            break;
         }
 
         /* command selection */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -2320,6 +2320,10 @@ static int XXH_main(int argc, const char* const* argv)
         if (!strcmp(argument, "--version")) { DISPLAY(FULL_WELCOME_MESSAGE(exename)); BMK_sanityCheck(); return 0; }
         if (!strcmp(argument, "--tag")) { convention = display_bsd; continue; }
 
+        if (!strcmp(argument, "--")) {
+            if (filenamesStart==0 && i!=argc-1) filenamesStart=i+1; /* only supports a continuous list of filenames */
+            break;
+        }
         if (*argument!='-') {
             if (filenamesStart==0) filenamesStart=i;   /* only supports a continuous list of filenames */
             break;


### PR DESCRIPTION
When parsing arguments, the first non-option argument is treated as the
start of a list of file names.  However, arguments continue to be
parsed, so any later arguments that look like options will have a dual
meaning as an option and file name.  Fix this by treating later
option-like arguments strictly as file names.

Also interpret a double dash (i.e. `--`) as the point where future
arguments are treated as file names.  This is useful for files that
begin with a dash (e.g. `./xxhsum -- -foo`).  Note that `--` itself can
be interpreted as a file (e.g. `./xxhsum foo --`).

Close: #428