### PR TITLE
Allow reading stdin in console mode

### DIFF
--- a/xxhsum.1
+++ b/xxhsum.1
@@ -1,29 +1,20 @@
 .
-.TH "XXHSUM" "1" "December 2019" "xxhsum 0.7.2" "User Commands"
+.TH "XXHSUM" "1" "July 2020" "xxhsum 0.7.4" "User Commands"
 .
 .SH "NAME"
 \fBxxhsum\fR \- print or check xxHash non\-cryptographic checksums
 .
 .SH "SYNOPSIS"
-\fBxxhsum [<OPTION>]\.\.\. [<FILE>]\.\.\.\fR
-.
-.br
-\fBxxhsum \-b [<OPTION>]\.\.\.\fR
+\fBxxhsum [<OPTION>] \.\.\. [<FILE>] \.\.\.\fR \fBxxhsum \-b [<OPTION>] \.\.\.\fR
 .
 .P
-\fBxxh32sum\fR is equivalent to \fBxxhsum \-H0\fR
-.
-.br
-\fBxxh64sum\fR is equivalent to \fBxxhsum \-H1\fR
-.
-.br
-\fBxxh128sum\fR is equivalent to \fBxxhsum \-H2\fR
+\fBxxh32sum\fR is equivalent to \fBxxhsum \-H0\fR \fBxxh64sum\fR is equivalent to \fBxxhsum \-H1\fR \fBxxh128sum\fR is equivalent to \fBxxhsum \-H2\fR
 .
 .SH "DESCRIPTION"
-Print or check xxHash (32, 64 or 128 bits) checksums\. When \fIFILE\fR is \fB\-\fR, read standard input\.
+Print or check xxHash (32, 64 or 128 bits) checksums\. When no \fIFILE\fR, read standard input, except if it\'s the console\. When \fIFILE\fR is \fB\-\fR, read standard input even if it\'s the console\.
 .
 .P
-\fBxxhsum\fR supports a command line syntax similar but not identical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch (\fB\-b\fR, \fB\-t\fR); \fBxxhsum\fR always treats files as binary files; \fBxxhsum\fR has a hash bit width switch (\fB\-H\fR);
+\fBxxhsum\fR supports a command line syntax similar but not identical to md5sum(1)\. Differences are: \fBxxhsum\fR doesn\'t have text/binary mode switch (\fB\-b\fR, \fB\-t\fR); \fBxxhsum\fR always treats files as binary file; \fBxxhsum\fR has a hash bit width switch (\fB\-H\fR);
 .
 .P
 As xxHash is a fast non\-cryptographic checksum algorithm, \fBxxhsum\fR should not be used for security related purposes\.
@@ -39,7 +30,11 @@ Displays xxhsum version and exits
 .
 .TP
 \fB\-H\fR\fIHASHTYPE\fR
-Hash selection\. \fIHASHTYPE\fR means \fB0\fR=32bits, \fB1\fR=64bits, \fB2\fR=128bits\. Default value is \fB1\fR (64bits)
+Hash selection\. \fIHASHTYPE\fR means \fB0\fR=32bits, \fB1\fR=64bits, \fB2\fR=128bits\. Alternatively, \fIHASHTYPE\fR \fB32\fR=32bits, \fB64\fR=64bits, \fB128\fR=128bits\. Default value is \fB1\fR (64bits)
+.
+.TP
+\fB\-\-tag\fR
+Output in the BSD style\.
 .
 .TP
 \fB\-\-little\-endian\fR
@@ -61,10 +56,6 @@ Read xxHash sums from \fIFILE\fR and check them
 Don\'t print OK for each successfully verified file
 .
 .TP
-\fB\-\-tag\fR
-Output in the BSD style.
-.
-.TP
 \fB\-\-strict\fR
 Return an error code if any line in the file is invalid, not just if some checksums are wrong\. This policy is disabled by default, though UI will prompt an informational message if any line in the file is detected invalid\.
 .
@@ -82,6 +73,10 @@ Emit a warning message about each improperly formatted checksum line\.
 .TP
 \fB\-b\fR
 Benchmark mode\. See \fIEXAMPLES\fR for details\.
+.
+.TP
+\fB\-b#\fR
+Specify ID of variant to be tested\. Multiple variants can be selected, separated by a \',\' comma\.
 .
 .TP
 \fB\-B\fR\fIBLOCKSIZE\fR
@@ -135,16 +130,26 @@ $ xxhsum \-c xyz\.xxh32 qux\.xxh64
 .IP "" 0
 .
 .P
-Benchmark xxHash algorithm for 16384 bytes data in 10 times\. \fBxxhsum\fR benchmarks all xxHash variants and output results to standard output\.
-.
-.br
-The first column is the algorithm, the second column is the source data size in bytes, the third column is the number of hashes generated per second (throughput), and finally, the last column translates speed in megabytes per second\.
+Benchmark xxHash algorithm\. By default, \fBxxhsum\fR benchmarks xxHash main variants on a synthetic sample of 100 KB, and print results into standard output\. The first column is the algorithm, the second column is the source data size in bytes, the third column is the number of hashes generated per second (throughput), and finally the last column translates speed in megabytes per second\.
 .
 .IP "" 4
 .
 .nf
 
-$ xxhsum \-b \-i10 \-B16384
+$ xxhsum \-b
+.
+.fi
+.
+.IP "" 0
+.
+.P
+In the following example, the sample to hash is set to 16384 bytes, the variants to be benched are selected by their IDs, and each benchmark test is repeated 10 times, for increased accuracy\.
+.
+.IP "" 4
+.
+.nf
+
+$ xxhsum \-b1,2,3 \-i10 \-B16384
 .
 .fi
 .

--- a/xxhsum.1.md
+++ b/xxhsum.1.md
@@ -15,11 +15,12 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-Print or check xxHash (32, 64 or 128 bits) checksums.  When <FILE> is `-`, read
-standard input.
+Print or check xxHash (32, 64 or 128 bits) checksums.
+When no <FILE>, read standard input, except if it's the console.
+When <FILE> is `-`, read standard input even if it's the console.
 
-`xxhsum` supports a command line syntax similar but not identical to
-md5sum(1).  Differences are:
+`xxhsum` supports a command line syntax similar but not identical to md5sum(1).
+Differences are:
 `xxhsum` doesn't have text/binary mode switch (`-b`, `-t`);
 `xxhsum` always treats files as binary file;
 `xxhsum` has a hash bit width switch (`-H`);
@@ -37,7 +38,11 @@ OPTIONS
 
 * `-H`<HASHTYPE>:
   Hash selection. <HASHTYPE> means `0`=32bits, `1`=64bits, `2`=128bits.
+  Alternatively, <HASHTYPE> `32`=32bits, `64`=64bits, `128`=128bits.
   Default value is `1` (64bits)
+
+* `--tag`:
+  Output in the BSD style.
 
 * `--little-endian`:
   Set output hexadecimal checksum value as little endian convention.
@@ -53,9 +58,6 @@ OPTIONS
 
 * `-q`, `--quiet`:
   Don't print OK for each successfully verified file
-
-* `--tag`:
-  Output in the BSD style.
 
 * `--strict`:
   Return an error code if any line in the file is invalid,


### PR DESCRIPTION
when `stdin` is requested explicitly, with `xxhsum -`.
`xxhsum` (no argument) still default to error message when console mode is detected.

updated man page.

Requested in #429