### PR TITLE
Support INCLUDEDIR and LIBDIR in libxxhash.pc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,8 @@ lib: libxxhash.a libxxhash
 
 pkgconfig:
 	@$(SED) -e 's|@PREFIX@|$(PREFIX)|' \
+		-e 's|@INCLUDEDIR@|$(INCLUDEDIR)|' \
+		-e 's|@LIBDIR@|$(LIBDIR)|' \
 		-e 's|@VERSION@|$(LIBVER)|' \
 		libxxhash.pc.in >libxxhash.pc
 

--- a/libxxhash.pc.in
+++ b/libxxhash.pc.in
@@ -3,8 +3,8 @@
 
 prefix=@PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+includedir=@INCLUDEDIR@
+libdir=@LIBDIR@
 
 Name: xxhash
 Description: extremely fast hash algorithm


### PR DESCRIPTION
The pkgconfig file hardcodes the default locations rather than adapting to the directories used during installation.
This means that:

$ pkg-config --libs libxxhash
-L/usr/lib -lxxhash 

even if the library is installed in /usr/lib64 by setting LIBDIR.
