### PR TITLE
update generateSecret for customSeedSize==8

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -4183,6 +4183,12 @@ XXH3_generateSecret(void* secretBuffer, const void* customSeed, size_t customSee
         return;
     }
     XXH_ASSERT(customSeed != NULL);
+    if (customSeedSize == 8) {
+        const XXH64_canonical_t* const seedCanon = (const XXH64_canonical_t*)customSeed;
+        XXH64_hash_t const seed64 = XXH64_hashFromCanonical(seedCanon);
+        XXH3_initCustomSecret(secretBuffer, seed64);
+        return;
+    }
 
     {   size_t const segmentSize = sizeof(XXH128_hash_t);
         size_t const nbSegments = XXH_SECRET_DEFAULT_SIZE / segmentSize;

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -1400,6 +1400,10 @@ static void BMK_sanityCheck(void)
         BMK_testSecretGenerator(sanityBuffer, 1, expected);
     }
 
+    {   verifSample_t const expected = { { 0xDC, 0xD3, 0x3A, 0x7D } };
+        BMK_testSecretGenerator(sanityBuffer, 8, expected);
+    }
+
     {   verifSample_t const expected = { { 0xDA, 0x2A, 0x12, 0x11 } };
         BMK_testSecretGenerator(sanityBuffer, XXH3_SECRET_SIZE_MIN - 1, expected);
     }


### PR DESCRIPTION
Change the generated secret when `customSeed` has a size of 8 bytes.
In which case, uses the same initialization function as the `_withSeed()` variant.

Worth noting : for reproducibility across platforms,
the buffer must be interpreted with a specified endianness.
The format selected is the Canonical format, aka big-endian.

This is a preparation step towards a potential solution for #416 .