### PR TITLE
fix prefetching for x86 32-bit target on MSVC

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -2481,7 +2481,7 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mule(xxh_u32x4 a, xxh_u32x4 b)
 #if defined(XXH_NO_PREFETCH)
 #  define XXH_PREFETCH(ptr)  (void)(ptr)  /* disabled */
 #else
-#  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  /* _mm_prefetch() is not defined outside of x86/x64 */
+#  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))  /* _mm_prefetch() not defined outside of x86/x64 */
 #    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
 #    define XXH_PREFETCH(ptr)  _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
 #  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )


### PR DESCRIPTION
fix a little nit in the predefined macro name.

That being said, the performance impact of prefetching on MSVC-produced binaries is low,
due to lackluster performance of `XXH3` when compiled in 32-bit mode with MSVC2019.

On my laptop, I measure `XXH3` speed at 8 GB/s with `SSE2` and 12 GB/s with `AVX2` when compiled as `x86` by MSVC2019.
Using `clang-i686` instead, I'm seeing 15 GB/s with `SSE2`, and 27 GB/s with `AVX2`. Quite a considerable difference.