### PR TITLE
[WIP] XXH3 multithreading

### DIFF
--- a/cli/xsum_arch.h
+++ b/cli/xsum_arch.h
@@ -149,5 +149,10 @@
 #  define XSUM_ARCH "unknown"
 #endif
 
+#if defined(XXH_THREADS) && (defined(_WIN32) || (defined(_REENTRANT) && !defined(__EMSCRIPTEN__) && !defined(__wasm__)))
+#  define XSUM_THREADED " (multithreaded)"
+#else
+#  define XSUM_THREADED ""
+#endif
 
 #endif /* XSUM_ARCH_H */

--- a/xxhash.h
+++ b/xxhash.h
@@ -3766,15 +3766,17 @@ XXH3_accumulate(     xxh_u64* XXH_RESTRICT acc,
  *     3. When we are done, we check if the thread spawned successfully.
  *       - If it succeeded, we merge the accs and mark the second half as done.
  *       - If it failed, we just let the main thread process the second half.
- *         This followas the same path that it would if the length did not meet
+ *         This follows the same path that it would if the length did not meet
  *         the threshold.
  *    However, if we add more threads, we have to track *which* section we
  *    processed which is not as simple.
  *  - The "performance formula" is basically this:
- *        benefit = ((R * L) / T) - (C * (T - 1)); T >= 1.
- *    where T is the number of threads, C is the constant cost of setting up a
- *    thread, R is the constant time it takes to process a length of input, and
- *    L is the length of the input.
+ *        benefit = ((R * L) / T) - (C * (T - 1))
+ *    where:
+ *      - R is the constant time it takes to process a length of input
+ *      - L is the length of the input.
+ *      - T is the number of threads, and is greater than zero
+ *      - C is the constant cost of setting up a thread
  *    XXH3 is very fast, so R is a very small number.
  *    Threading is only beneficial if (C * (T - 1)) < ((R * L) / T). Increasing
  *    T makes the point where ((R * L) / T) intersects with (C * (T - 1))

--- a/xxhash.h
+++ b/xxhash.h
@@ -3857,9 +3857,7 @@ XXH_joinThread(xxh_thread_t thread)
  * slower than single threaded, so we warn (because 99% of the time it is just
  * forgetting -pthread) and disable.
  */
-#  warning "No compatible threading implementations for XXH3 found. \
-You may need to add `-pthread` or `-D_REENTRANT` to your compiler flags. \
-Note that WebAssembly and asm.js threads are not supported at this time."
+#  warning "No compatible threading implementations for XXH3 found. You may need to add `-pthread` or `-D_REENTRANT` to your compiler flags. Note that WebAssembly and asm.js threads are not supported at this time."
 #  undef XXH_THREADS
 #endif /* not Windows or pthreads */
 #endif /* XXH_THREADS */

--- a/xxhsum.c
+++ b/xxhsum.c
@@ -74,9 +74,9 @@ static const char g_bename[] = "big endian";
 static const char author[] = "Yann Collet";
 #define WELCOME_MESSAGE(exename) "%s %s by %s \n", exename, XSUM_PROGRAM_VERSION, author
 #define FULL_WELCOME_MESSAGE(exename) "%s %s by %s \n" \
-                    "compiled as %i-bit %s %s with " XSUM_CC_VERSION_FMT " \n", \
+                    "compiled as %i-bit %s %s with " XSUM_CC_VERSION_FMT "%s\n", \
                     exename, XSUM_PROGRAM_VERSION, author, \
-                    g_nbBits, XSUM_ARCH, ENDIAN_NAME, XSUM_CC_VERSION
+                    g_nbBits, XSUM_ARCH, ENDIAN_NAME, XSUM_CC_VERSION, XSUM_THREADED
 
 #define KB *( 1<<10)
 #define MB *( 1<<20)


### PR DESCRIPTION
With this code, XXH3 will spawn a second thread when the length >= `XXH_THREADS_THRESHOLD` and `XXH_THREADS` is defined.

See details in the code comment.

TODO:
 - [X] Write basic implementation
 - [X] Test pthread implementation
 - [ ] Test Win32 implementation
 - [ ] Verify if all possible errors are handled
 - [ ] Find good default for `XXH_THREADS_THRESHOLD`. The current default is 8MB. I'd rather have an overestimate than an underestimate.
 - [ ] Add Makefile and CMake support
 - [ ] Add CI tests
 - [ ] Add implementation for WebAssembly?
 - [ ] Perhaps simplify `XXH3_threadData_t`
 - [ ] Reduce duplicate code

Please post your benchmarks if possible so we can find a decent default for `XXH_THREADS_THRESHOLD`.

Build instructions:
 - pthreads: `make CFLAGS="-O2 -g -DXXH_THREADS -pthread"`
 - Win32: `cmake . -DCMAKE_C_FLAGS="-O2 -DXXH_THREADS"`
