### PR TITLE
Various dispatcher improvements

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -20,7 +20,7 @@ QUIET                  = YES
 WARN_IF_UNDOCUMENTED   = NO
 
 # TODO: Add the other files. It is just xxhash.h for now.
-FILE_PATTERNS          = xxhash.h
+FILE_PATTERNS          = xxhash.h xxh_x86dispatch.c
 # Note: xxHash's source files are technically ASCII only.
 INPUT_ENCODING         = UTF-8
 TAB_SIZE               = 4

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -40,6 +40,10 @@
  *
  * Optional add-on.
  *
+ * **Compile this file with the default flags for your target.** Do not compile
+ * with flags like `-mavx*`, `-march=native`, or `/arch:AVX*`, there will be
+ * an error. See @ref XXH_X86DISPATCH_ALLOW_AVX for details.
+ *
  * @defgroup dispatch x86 Dispatcher
  * @{
  */
@@ -50,6 +54,35 @@ extern "C" {
 
 #if !(defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
 #  error "Dispatching is currently only supported on x86 and x86_64."
+#endif
+
+/*!
+ * @def XXH_X86DISPATCH_ALLOW_AVX
+ * @brief Disables the AVX sanity check.
+ *
+ * Don't compile xxh_x86dispatch.c with options like `-mavx*`, `-march=native`,
+ * or `/arch:AVX*`. It is intended to be compiled for the minumum target, and
+ * it selectively enables SSE2, AVX2, and AVX512 when it is needed.
+ *
+ * Using this option _globally_ allows this feature, and therefore makes it
+ * undefined behavior to execute on any CPU without said feature.
+ *
+ * Even if the source code isn't directly using AVX intrinsics in a function,
+ * the compiler can still generate AVX code from autovectorization and by
+ * "upgrading" SSE2 intrinsics to use the VEX prefixes (a.k.a. AVX128).
+ *
+ * Use the same flags that you use to compile the rest of the program; this
+ * file will safely generate SSE2, AVX2, and AVX512 without these flags.
+ *
+ * Define XXH_X86DISPATCH_ALLOW_AVX to ignore this check, and feel free to open
+ * an issue if there is a target in the future where AVX is a default feature.
+ */
+#ifdef XXH_DOXYGEN
+#  define XXH_X86DISPATCH_ALLOW_AVX
+#endif
+
+#if defined(__AVX__) && !defined(XXH_X86DISPATCH_ALLOW_AVX)
+#  error "Do not compile xxh_x86dispatch.c with AVX enabled! See the comment above."
 #endif
 
 #ifdef __has_include

--- a/xxhash.h
+++ b/xxhash.h
@@ -3678,7 +3678,8 @@ XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
  * Both XXH3_64bits and XXH3_128bits use this subroutine.
  */
 
-#if (XXH_VECTOR == XXH_AVX512) || defined(XXH_X86DISPATCH)
+#if (XXH_VECTOR == XXH_AVX512) \
+     || (defined(XXH_DISPATCH_AVX512) && XXH_DISPATCH_AVX512 != 0)
 
 #ifndef XXH_TARGET_AVX512
 # define XXH_TARGET_AVX512  /* disable attribute target */
@@ -3784,7 +3785,8 @@ XXH3_initCustomSecret_avx512(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
 
 #endif
 
-#if (XXH_VECTOR == XXH_AVX2) || defined(XXH_X86DISPATCH)
+#if (XXH_VECTOR == XXH_AVX2) \
+    || (defined(XXH_DISPATCH_AVX2) && XXH_DISPATCH_AVX2 != 0)
 
 #ifndef XXH_TARGET_AVX2
 # define XXH_TARGET_AVX2  /* disable attribute target */
@@ -3890,6 +3892,7 @@ XXH_FORCE_INLINE XXH_TARGET_AVX2 void XXH3_initCustomSecret_avx2(void* XXH_RESTR
 
 #endif
 
+/* x86dispatch always generates SSE2 */
 #if (XXH_VECTOR == XXH_SSE2) || defined(XXH_X86DISPATCH)
 
 #ifndef XXH_TARGET_SSE2


### PR DESCRIPTION
 - Test the compiler for AVX2/AVX512 support instead of unconditionally defining `XXH_DISPATCH_*` (fixes #464)
   - Can also be enabled/disabled on the command line
 - Use a macro template to reduce code repetition
 - Don't dispatch the scalar path when we don't need it. It can be rather wasteful, especially on 32-bit.
   - Specifically, don't dispatch when SSE2 is globally enabled on the compiler or when it is guaranteed on the platform.
 - Add some Doxygen documentation for xxh_x86dispatch.c.