### PR TITLE
Expose XXH_alignedMalloc, XXH3_state_t new/delete

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -838,6 +838,59 @@ typedef struct { unsigned char digest[sizeof(XXH128_hash_t)]; } XXH128_canonical
 XXH_PUBLIC_API void XXH128_canonicalFromHash(XXH128_canonical_t* dst, XXH128_hash_t hash);
 XXH_PUBLIC_API XXH128_hash_t XXH128_hashFromCanonical(const XXH128_canonical_t* src);
 
+/*!
+ * @ingroup public
+ * @brief Mallocs a pointer that is aligned to a certain power of 2.
+ *
+ * Acts like malloc() but takes an @p align parameter.
+ *
+ * malloc() typically guarantees 16 byte alignment on 64-bit systems and 8 byte
+ * alignment on 32-bit. This isn't enough for the 32 byte aligned loads in AVX2
+ * or on 32-bit, the 16 byte aligned loads in SSE2 and NEON.
+ *
+ * This underalignment previously caused a rather obvious crash which went
+ * completely unnoticed due to XXH3_createState() not actually being tested.
+ * Credit to RedSpah for noticing this bug.
+ *
+ * The alignment is done manually: Functions like posix_memalign() or
+ * _mm_malloc() are avoided: To maintain portability, we would have to write a
+ * fallback like this anyways, and besides, testing for the existence of
+ * library functions without relying on external build tools is impossible.
+ *
+ * The method is simple: Overallocate, manually align, and store the offset
+ * to the original in a byte behind the returned pointer.
+ *
+ * @param size The number of bytes to allocate.
+ * @param align The minimum alignment.
+ *
+ * @note
+ *   @p align will be rounded down to the nearest power of 2, then clamped from
+ *   8 to 128, inclusive.
+ *
+ * @note
+ *   Always free with @ref XXH_alignedFree().
+ * @pre
+ *   @p size must not be zero.
+ * @pre
+ *   @p size + clamp(@p align) must not overflow.
+ * @return The aligned allocated pointer, or NULL on failure.
+ * @see XXH_alignedFree(), XXH3_state_s::operator new
+ */
+XXH_PUBLIC_API void* XXH_alignedMalloc(size_t size, size_t align);
+/*!
+ * @ingroup public
+ * @brief Deallocation function for @ref XXH_alignedMalloc().
+ *
+ * Use like free().
+ *
+ * @param ptr The nullable pointer allocated by @p XXH_alignedMalloc().
+ * @pre
+ *    @p ptr must be allocated by @p XXH_alignedMalloc(). It uses a specific
+ *    layout.
+ *
+ * @see XXH_alignedMalloc(), XXH3_state_s::operator delete
+ */
+XXH_PUBLIC_API void XXH_alignedFree(void* ptr);
 
 #endif  /* XXH_NO_LONG_LONG */
 
@@ -952,6 +1005,12 @@ struct XXH64_state_s {
  */
 #define XXH3_SECRET_DEFAULT_SIZE 192
 
+#ifdef __cplusplus
+}
+#  include <new> /* operator new, operator delete, std::bad_alloc */
+extern "C" {
+#endif
+
 /*!
  * @internal
  * @brief Structure for XXH3 streaming API.
@@ -961,9 +1020,9 @@ struct XXH64_state_s {
  * an opaque type. This allows fields to safely be changed.
  *
  * @note **This structure has a strict alignment requirement of 64 bytes.** Do
- * not allocate this with `malloc()` or `new`, it will not be sufficiently
- * aligned. Use @ref XXH3_createState() and @ref XXH3_freeState(), or stack
- * allocation.
+ * not allocate this with `malloc()`, it will not be sufficiently aligned. Use
+ * @ref XXH3_createState() and @ref XXH3_freeState(), operator new/delete, or
+ * stack allocation.
  *
  * Typedef'd to @ref XXH3_state_t.
  * Do not access the members of this struct directly.
@@ -973,31 +1032,67 @@ struct XXH64_state_s {
  * @see XXH32_state_s, XXH64_state_s
  */
 struct XXH3_state_s {
-   XXH_ALIGN_MEMBER(64, XXH64_hash_t acc[8]);
-       /*!< The 8 accumulators. Similar to `vN` in @ref XXH32_state_s::v1 and @ref XXH64_state_s */
-   XXH_ALIGN_MEMBER(64, unsigned char customSecret[XXH3_SECRET_DEFAULT_SIZE]);
-       /*!< Used to store a custom secret generated from a seed. */
-   XXH_ALIGN_MEMBER(64, unsigned char buffer[XXH3_INTERNALBUFFER_SIZE]);
-       /*!< The internal buffer. @see XXH32_state_s::mem32 */
-   XXH32_hash_t bufferedSize;
-       /*!< The amount of memory in @ref buffer, @see XXH32_state_s::memsize */
-   XXH32_hash_t reserved32;
-       /*!< Reserved field. Needed for padding on 64-bit. */
-   size_t nbStripesSoFar;
-       /*!< Number or stripes processed. */
-   XXH64_hash_t totalLen;
-       /*!< Total length hashed. 64-bit even on 32-bit targets. */
-   size_t nbStripesPerBlock;
-       /*!< Number of stripes per block. */
-   size_t secretLimit;
-       /*!< Size of @ref customSecret or @ref extSecret */
-   XXH64_hash_t seed;
-       /*!< Seed for _withSeed variants. Must be zero otherwise, @see XXH3_INITSTATE() */
-   XXH64_hash_t reserved64;
-       /*!< Reserved field. */
-   const unsigned char* extSecret;
-       /*!< Reference to an external secret for the _withSecret variants, NULL
-        *   for other variants. */
+    XXH_ALIGN_MEMBER(64, XXH64_hash_t acc[8]);
+        /*!< The 8 accumulators. Similar to `vN` in @ref XXH32_state_s::v1 and @ref XXH64_state_s */
+    XXH_ALIGN_MEMBER(64, unsigned char customSecret[XXH3_SECRET_DEFAULT_SIZE]);
+        /*!< Used to store a custom secret generated from a seed. */
+    XXH_ALIGN_MEMBER(64, unsigned char buffer[XXH3_INTERNALBUFFER_SIZE]);
+        /*!< The internal buffer. @see XXH32_state_s::mem32 */
+    XXH32_hash_t bufferedSize;
+        /*!< The amount of memory in @ref buffer, @see XXH32_state_s::memsize */
+    XXH32_hash_t reserved32;
+        /*!< Reserved field. Needed for padding on 64-bit. */
+    size_t nbStripesSoFar;
+        /*!< Number or stripes processed. */
+    XXH64_hash_t totalLen;
+        /*!< Total length hashed. 64-bit even on 32-bit targets. */
+    size_t nbStripesPerBlock;
+        /*!< Number of stripes per block. */
+    size_t secretLimit;
+        /*!< Size of @ref customSecret or @ref extSecret */
+    XXH64_hash_t seed;
+        /*!< Seed for _withSeed variants. Must be zero otherwise, @see XXH3_INITSTATE() */
+    XXH64_hash_t reserved64;
+        /*!< Reserved field. */
+    const unsigned char* extSecret;
+        /*!< Reference to an external secret for the _withSecret variants, NULL
+         *   for other variants. */
+#if defined(__cplusplus) || defined(XXH_DOXYGEN)
+    /*!
+     * @brief C++ overload for operator new that ensures alignment.
+     *
+     * operator new only supports automatic alignment in C++17. This works in
+     * C++98.
+     *
+     * These are just wrappers for @ref XXH_alignedMalloc() and
+     * @ref XXH_alignedFree().
+     * @throws std::bad_alloc if allocation failed
+     * @see XXH_alignedMalloc(), XXH3_state_s::operator delete(void*)
+     */
+    static void* operator new(size_t sz)
+    {
+        void* ret = XXH_alignedMalloc(sz, 64);
+#ifdef __cpp_exceptions
+        if (ret == NULL) throw std::bad_alloc();
+#endif
+        return ret;
+    }
+    static void* operator new[](size_t sz)
+    {
+        void* ret = XXH_alignedMalloc(sz, 64);
+#ifdef __cpp_exceptions
+        if (ret == NULL) throw std::bad_alloc();
+#endif
+        return ret;
+    }
+    /*!
+     * @brief C++ overload for operator delete.
+     *
+     * @see XXH_alignedFree(), XXH3_state_s::operator new(size_t)
+     */
+    static void operator delete(void* ptr) { XXH_alignedFree(ptr); }
+    static void operator delete[](void* ptr) { XXH_alignedFree(ptr); }
+#endif /* __cplusplus || XXH_DOXYGEN */
    /* note: there may be some padding at the end due to alignment on 64 bytes */
 }; /* typedef'd to XXH3_state_t */
 
@@ -1054,7 +1149,6 @@ XXH_PUBLIC_API void XXH3_generateSecret(void* secretBuffer, const void* customSe
 
 /* simple short-cut to pre-selected XXH3_128bits variant */
 XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed);
-
 
 #endif  /* XXH_NO_LONG_LONG */
 #if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
@@ -4541,31 +4635,13 @@ XXH3_64bits_withSeed(const void* input, size_t len, XXH64_hash_t seed)
 
 /* ===   XXH3 streaming   === */
 
-/*
- * Malloc's a pointer that is always aligned to align.
- *
- * This must be freed with `XXH_alignedFree()`.
- *
- * malloc typically guarantees 16 byte alignment on 64-bit systems and 8 byte
- * alignment on 32-bit. This isn't enough for the 32 byte aligned loads in AVX2
- * or on 32-bit, the 16 byte aligned loads in SSE2 and NEON.
- *
- * This underalignment previously caused a rather obvious crash which went
- * completely unnoticed due to XXH3_createState() not actually being tested.
- * Credit to RedSpah for noticing this bug.
- *
- * The alignment is done manually: Functions like posix_memalign or _mm_malloc
- * are avoided: To maintain portability, we would have to write a fallback
- * like this anyways, and besides, testing for the existence of library
- * functions without relying on external build tools is impossible.
- *
- * The method is simple: Overallocate, manually align, and store the offset
- * to the original behind the returned pointer.
- *
- * Align must be a power of 2 and 8 <= align <= 128.
- */
-static void* XXH_alignedMalloc(size_t s, size_t align)
+/*! @ingroup public */
+XXH_PUBLIC_API void*
+XXH_alignedMalloc(size_t s, size_t align)
 {
+    align &= ~(align - 1);                  /* Round down to power of 2 */
+    if (align > 128) align = 128;
+    if (align < 8) align = 8;
     XXH_ASSERT(align <= 128 && align >= 8); /* range check */
     XXH_ASSERT((align & (align-1)) == 0);   /* power of 2 */
     XXH_ASSERT(s != 0 && s < (s + align));  /* empty/overflow */
@@ -4591,11 +4667,8 @@ static void* XXH_alignedMalloc(size_t s, size_t align)
         return NULL;
     }
 }
-/*
- * Frees an aligned pointer allocated by XXH_alignedMalloc(). Don't pass
- * normal malloc'd pointers, XXH_alignedMalloc has a specific data layout.
- */
-static void XXH_alignedFree(void* p)
+/*! @ingroup public */
+XXH_PUBLIC_API void XXH_alignedFree(void* p)
 {
     if (p != NULL) {
         xxh_u8* ptr = (xxh_u8*)p;

--- a/xxhash.h
+++ b/xxhash.h
@@ -281,6 +281,12 @@ extern "C" {
  */
 XXH_PUBLIC_API unsigned XXH_versionNumber (void);
 
+/* ****************************
+*  Definitions
+******************************/
+#include <stddef.h>   /* size_t */
+typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
+
 /*!
  * @ingroup public
  * @brief Mallocs a pointer that is aligned to a certain power of 2.
@@ -334,13 +340,6 @@ XXH_PUBLIC_API void* XXH_alignedMalloc(size_t size, size_t align);
  * @see XXH_alignedMalloc(), XXH3_state_s::operator delete
  */
 XXH_PUBLIC_API void XXH_alignedFree(void* ptr);
-
-/* ****************************
-*  Definitions
-******************************/
-#include <stddef.h>   /* size_t */
-typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
-
 
 /*-**********************************************************************
 *  32-bit hash


### PR DESCRIPTION
`XXH_alignedMalloc` and `XXH_alignedFree` are now exposed because they may be helpful. They autoclamp their arguments instead of asserting.

Additionally, when compiled in C++, `XXH3_state_t` now has overloads for `operator new` and `operator delete` so it can safely be used in containers without any alignment issues. They simply call `XXH_alignedMalloc` and `XXH_alignedFree`.

These are static member functions, so they don't change the layout of `XXH3_state_t`, they are just inlines.