### PR TITLE
Fix issue with XXHASH_BUILD_XXHSUM cmake setting

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -44,7 +44,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 option(BUILD_SHARED_LIBS "Build shared library" ON)
-set(XXHASH_BUILD_XXHSUM ON CACHE BOOL "Build the xxhsum binary")
+option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" ON)
 
 # If XXHASH is being bundled in another project, we don't want to
 # install anything.  However, we want to let people override this, so


### PR DESCRIPTION
Using `set(... CACHE ...)` causes `XXHASH_BUILD_XXHSUM` to be stuck `ON` even when doing a `set(XXHASH_BUILD_XXHSUM OFF)` for some cmake version/generators. Switching to `option(...)` fixes this issue and allows you to properly turn off the building of xxhsum in all situations.

Currently using `set(XXHASH_BUILD_XXHSUM OFF CACHE BOOL "" FORCE)` before including xxhash into another cmake project gets around the issue but is non-obvious.