### PR TITLE
docs: fix simple typo, minumum -> minimum

### DIFF
--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -61,7 +61,7 @@ extern "C" {
  * @brief Disables the AVX sanity check.
  *
  * Don't compile xxh_x86dispatch.c with options like `-mavx*`, `-march=native`,
- * or `/arch:AVX*`. It is intended to be compiled for the minumum target, and
+ * or `/arch:AVX*`. It is intended to be compiled for the minimum target, and
  * it selectively enables SSE2, AVX2, and AVX512 when it is needed.
  *
  * Using this option _globally_ allows this feature, and therefore makes it

--- a/xxhash.h
+++ b/xxhash.h
@@ -2824,7 +2824,7 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 };
 /*!
  * @ingroup tuning
- * @brief Selects the minumum alignment for XXH3's accumulators.
+ * @brief Selects the minimum alignment for XXH3's accumulators.
  *
  * When using SIMD, this should match the alignment reqired for said vector
  * type, so, for example, 32 for AVX2.


### PR DESCRIPTION
There is a small typo in xxh_x86dispatch.c, xxhash.h.

Should read `minimum` rather than `minumum`.

