### PR TITLE
Support no-op use of xxh_x86dispatch files on non-X86 platforms

### DIFF
--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -52,9 +52,7 @@
 extern "C" {
 #endif
 
-#if !(defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
-#  error "Dispatching is currently only supported on x86 and x86_64."
-#endif
+#if (defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
 
 /*!
  * @def XXH_X86DISPATCH_ALLOW_AVX
@@ -763,6 +761,8 @@ XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
     if (XXH_g_dispatch128.update == NULL) XXH_setDispatch();
     return XXH_g_dispatch128.update(state, (const xxh_u8*)input, len);
 }
+
+#endif
 
 #if defined (__cplusplus)
 }

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -52,7 +52,12 @@
 extern "C" {
 #endif
 
-#if (defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
+#if !(defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
+
+/* some build systems complain about empty units, so define this to save trouble */
+extern int __xxh_x86dispatch_non_empty_unit;
+
+#else
 
 /*!
  * @def XXH_X86DISPATCH_ALLOW_AVX

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -41,15 +41,21 @@
 extern "C" {
 #endif
 
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len);
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
-XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
-XXH_PUBLIC_API XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
+#if (defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
 
-XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len);
-XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
-XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
-XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
+	XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len);
+	XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
+	XXH_PUBLIC_API XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
+	XXH_PUBLIC_API XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
+
+	XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len);
+	XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed);
+	XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen);
+	XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len);
+
+#else
+	#define XXH_DISPATCH_DISABLE_REPLACE
+#endif
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
Currently the core xxhash.{h,c} files are globally usable and take care of all platform-specific logic.

xxh_x86dispatch.c on the other hand can currently only be compiled on x86 so the user's build system needs to detect the platform and include or exclude it from compilation, and the code that will call the dispatch functions needs to also detect the platform and determine whether to enable/use the dispatch code or not.

So right now the x86 logic needs to be in 3 places - xxh_x86dispatch.c, the build system, and the code including xxh_x86dispatch.h. I don't think this is beneficial, even if currently dispatching is only actually useful on X86.

In this PR I have changed the logic so that compilation of xxh_x86dispatch.c on non-X86 is legal but a no-op, so the build system doesn't need to know, and changed xxh_x86dispatch.h to automatically set XXH_DISPATCH_DISABLE_REPLACE so the including code doesn't need to know.

This isn't the only way to do it; the other obvious option would be to not mess around with XXH_DISPATCH_DISABLE_REPLACE and instead define passthrough *_dispatch functions on non-X86 platforms. That approach would have the advantage of supporting users who prefer to specifically invoke the functions with *_dispatch names, but would have the cost of one unnecessary indirection (function call) for each call on non-X86 platforms. I can't think of the use case for preferring calling _dispatch names, so I have instead gone the route I describe above.

After this commit, IMHO it would also make sense to rename these two files to something more generic, but that's a separate decision.