### PR TITLE
Alternate approach to support no-op use of xxh_x86dispatch files on non-X86 platforms

### DIFF
--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -53,8 +53,21 @@ extern "C" {
 #endif
 
 #if !(defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
-#  error "Dispatching is currently only supported on x86 and x86_64."
-#endif
+
+/* passthrough functions, not normally called because XXH_DISPATCH_DISABLE_REPLACE is set, but available
+   for the benefit of codebases that explicitly invoke the _dispatch functions by those names */
+
+XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len)                                                  { return XXH3_64bits(input, len); }
+XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)                      { return XXH3_64bits_withSeed(input, len, seed); }
+XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen) { return XXH3_64bits_withSecret(input, len, secret, secretLen); }
+XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)                      { return XXH3_64bits_update(state, input, len); }
+
+XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len)                                                  { return XXH3_128bits(input, len); }
+XXH128_hash_t XXH3_128bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)                      { return XXH3_128bits_withSeed(input, len, seed); }
+XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret, size_t secretLen) { return XXH3_128bits_withSecret(input, len, secret, secretLen); }
+XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)                      { return XXH3_128bits_update(state, input, len); }
+
+#else
 
 /*!
  * @def XXH_X86DISPATCH_ALLOW_AVX
@@ -763,6 +776,8 @@ XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
     if (XXH_g_dispatch128.update == NULL) XXH_setDispatch();
     return XXH_g_dispatch128.update(state, (const xxh_u8*)input, len);
 }
+
+#endif
 
 #if defined (__cplusplus)
 }

--- a/xxh_x86dispatch.h
+++ b/xxh_x86dispatch.h
@@ -55,6 +55,10 @@ XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, c
 }
 #endif
 
+/* currently we only support dispatching on X86, so no reason to do an extra function call */
+#if !(defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64))
+	#define XXH_DISPATCH_DISABLE_REPLACE
+#endif
 
 /* automatic replacement of XXH3 functions.
  * can be disabled by setting XXH_DISPATCH_DISABLE_REPLACE */


### PR DESCRIPTION
Per #477, here is the other reasonable way to do it, for comparison.

Please consider merging either that one or this one :).