### PR TITLE
[xxhash_spec.md] add missed semicolon at the pseudo-code.

### DIFF
--- a/doc/xxhash_spec.md
+++ b/doc/xxhash_spec.md
@@ -227,7 +227,7 @@ Note that accumulator convergence is more complex than 32-bit variant, and requi
 
     mergeAccumulator(acc,accN):
     acc  = acc xor round(0, accN);
-    acc  = acc * PRIME64_1
+    acc  = acc * PRIME64_1;
     return acc + PRIME64_4;
 
 which is then used in the convergence formula:


### PR DESCRIPTION
Hello.

It seems that semicolon (';') was missed.
Proposed to add first one.

Thank you.
