### PR TITLE
Increase the hero text's line height for better readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
       <div class="page-header jumbotron text-justify" style="padding-top:1em;padding-bottom:2em;">
         <h1>xxHash</h1>
         <iframe src="https://ghbtns.com/github-btn.html?user=Cyan4973&repo=xxHash&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
-        <p>
+        <p style="line-height: 1.5; font-weight: 400">
         xxHash is an extremely fast non-cryptographic hash algorithm, working at RAM speed limit.
         It is proposed in four flavors (XXH32, XXH64, XXH3_64bits and XXH3_128bits).
         The latest variant, XXH3, offers improved performance across the board, especially on small data.


### PR DESCRIPTION
Follow-up to https://github.com/facebook/zstd/pull/2429.

The font weight was also forced to 400 (Regular). This is because some browsers may display a font in a lower weight, which is difficult to read.