### PR TITLE
update default memory access for armv6

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1135,8 +1135,8 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
  *  - `XXH_FORCE_MEMORY_ACCESS=1`: `__attribute__((packed))`
  *   @par
  *     Depends on compiler extensions and is therefore not portable.
- *     This method is safe if your compiler supports it, and *generally* as
- *     fast or faster than `memcpy`.
+ *     This method is safe _if_ your compiler supports it,
+ *     and *generally* as fast or faster than `memcpy`.
  *
  *  - `XXH_FORCE_MEMORY_ACCESS=2`: Direct cast
  *  @par
@@ -1144,7 +1144,7 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
  *     compiler, but it violates the C standard as it directly dereferences an
  *     unaligned pointer. It can generate buggy code on targets which do not
  *     support unaligned memory accesses, but in some circumstances, it's the
- *     only known way to get the most performance (example: GCC + ARMv6).
+ *     only known way to get the most performance.
  *
  *  - `XXH_FORCE_MEMORY_ACCESS=3`: Byteshift
  *  @par
@@ -1152,7 +1152,6 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
  *     inline small `memcpy()` calls, and it might also be faster on big-endian
  *     systems which lack a native byteswap instruction. However, some compilers
  *     will emit literal byteshifts even if the target supports unaligned access.
- *
  *  .
  *
  * @warning
@@ -1255,10 +1254,10 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
  */
 
 #ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
-#  if !defined(__clang__) && defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED) && defined(__ARM_ARCH) && (__ARM_ARCH == 6)
-#    define XXH_FORCE_MEMORY_ACCESS 2
-#  elif !defined(__clang__) && ((defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
-  (defined(__GNUC__) && (defined(__ARM_ARCH) && __ARM_ARCH >= 7)))
+   /* prefer __packed__ structures (method 1) for gcc on armv7 and armv8 */
+#  if !defined(__clang__) && ( \
+    (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
+    (defined(__GNUC__) && (defined(__ARM_ARCH) && __ARM_ARCH >= 7)) )
 #    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif


### PR DESCRIPTION
Now uses `memcpy()` (method 0) by default
fix #490