### PR TITLE
solaris restrict keyword fix

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -2679,8 +2679,9 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 
 /* ===   Compiler specifics   === */
 
-/* ===   Compiler specifics   === */
-#if defined(sun) || defined(__sun)
+#if ((defined(sun) || defined(__sun)) && __cplusplus) /* Solaris includes __STDC_VERSION__ with C++. Tested with GCC 5.5 */
+#  define XXH_RESTRICT /* disable */
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
 #  define XXH_RESTRICT /* disable */
 #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
 #  define XXH_RESTRICT   restrict

--- a/xxhash.h
+++ b/xxhash.h
@@ -2679,7 +2679,10 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 
 /* ===   Compiler specifics   === */
 
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
+/* ===   Compiler specifics   === */
+#if defined(sun) || defined(__sun)
+#  define XXH_RESTRICT /* disable */
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
 #  define XXH_RESTRICT   restrict
 #else
 /* Note: it might be useful to define __restrict or __restrict__ for some C++ compilers */


### PR DESCRIPTION
Does not compile on Solaris due to the restrict keyword. 

I believe it is the same issue as: https://bugzilla.mozilla.org/show_bug.cgi?id=1158444

A simple fix is to disable restrict on Solaris. 