### PR TITLE
cmake script builds and installs a different version than the makefile

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -78,7 +78,7 @@ if (BUILD_SHARED_LIBS)
   target_compile_definitions(xxhash PUBLIC XXH_EXPORT)
 endif ()
 set_target_properties(xxhash PROPERTIES
-  SOVERSION "${XXHASH_VERSION_STRING}"
+  SOVERSION "${XXHASH_LIB_SOVERSION}"
   VERSION "${XXHASH_VERSION_STRING}")
 
 if(XXHASH_BUILD_XXHSUM)
@@ -100,23 +100,6 @@ include (CheckCCompilerFlag)
 if (XXHASH_C_FLAGS)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${XXHASH_C_FLAGS}")
 endif()
-foreach (flag
-    -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow
-    -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement
-    -Wstrict-prototypes -Wundef)
-  # Because https://gcc.gnu.org/wiki/FAQ#wnowarning
-  string(REGEX REPLACE "\\-Wno\\-(.+)" "-W\\1" flag_to_test "${flag}")
-  string(REGEX REPLACE "[^a-zA-Z0-9]+" "_" test_name "CFLAG_${flag_to_test}")
-
-  check_c_compiler_flag("${ADD_COMPILER_FLAGS_PREPEND} ${flag_to_test}" ${test_name})
-
-  if(${test_name})
-    set(CMAKE_C_FLAGS "${flag} ${CMAKE_C_FLAGS}")
-  endif()
-
-  unset(test_name)
-  unset(flag_to_test)
-endforeach (flag)
 
 if(NOT XXHASH_BUNDLED_MODE)
   include(GNUInstallDirs)
@@ -170,4 +153,16 @@ if(NOT XXHASH_BUNDLED_MODE)
   install(EXPORT xxHashTargets
     DESTINATION ${xxHash_CONFIG_INSTALL_DIR}
     NAMESPACE ${PROJECT_NAME}::)
+
+  # configure and install pkg-config
+  set(PREFIX ${CMAKE_INSTALL_PREFIX})
+  set(EXECPREFIX "\${prefix}")
+  set(INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  set(LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+  set(VERSION "${XXHASH_VERSION_STRING}")
+  configure_file(${XXHASH_DIR}/libxxhash.pc.in ${CMAKE_BINARY_DIR}/libxxhash.pc @ONLY)
+
+  install(FILES ${CMAKE_BINARY_DIR}/libxxhash.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 endif(NOT XXHASH_BUNDLED_MODE)


### PR DESCRIPTION
From a packaging point of view, it would be great to achieve parity between the binaries and install created by the Makefile and cmake. 3 things stand in the way

1. the SONAME is different (I consider this a copy-paste bug in the current script)
2. some additional CFLAGS get added to the compiler flags. The Makefile does not mess with that. Let's do the same! *on a minor note*: the makefile uses both: `CFLAGS` and `CPPFLAGS` which is dubious, given that we only build a C lib
3. the pkg-config file does not get created and installed
4. symlinks for `{xxh128, xxh64, xxh32} -> xxhsum` are being created by the Makefile, cmake only installs `xxhsum`

This PR solves the first 3 problems. Not sure about 4?