### PR TITLE
added compilation flag XXH_NO_XXH3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ matrix:
         - make clean
         - CFLAGS="-Wall -Wextra -Werror" make DISPATCH=1
         - make clean
-        - CFLAGS="-std=c90 -pedantic -Wno-long-long -Werror" make xxhsum  # check C90 compliance
-        - make clean
-        - CFLAGS="-std=c90 -pedantic -Werror" CPPFLAGS="-DXXH_NO_LONG_LONG" make libxxhash  # do not use long-long type, effectively reduced to XXH32
+        - CFLAGS="-std=c90 -pedantic -Wno-long-long -Werror" make xxhsum  # check C90 + long long compliance
+        - make c90test # strict c90, with no long long support; resulting in no XXH64_* symbol
+        - make noxxh3test # check library can be compiled with XXH_NO_XXH3, resulting in no XXH3_* symbol
 
 
     - name: Check results consistency on x64

--- a/Makefile
+++ b/Makefile
@@ -151,9 +151,10 @@ lib: libxxhash.a libxxhash
 
 # helper targets
 
-AWK = awk
+AWK  = awk
 GREP = grep
 SORT = sort
+NM   = nm
 
 .PHONY: list
 list:  ## list all Makefile targets
@@ -305,9 +306,19 @@ c90test: CFLAGS += -std=c90 -Werror -pedantic
 c90test: xxhash.c
 	@echo ---- test strict C90 compilation [xxh32 only] ----
 	$(RM) xxhash.o
-	$(CC) $(FLAGS) $^ $(LDFLAGS) -c
+	$(CC) $(FLAGS) $^ -c
+	$(NM) xxhash.o | $(GREP) XXH64 ; test $$? -eq 1
 	$(RM) xxhash.o
 endif
+
+noxxh3test: CPPFLAGS += -DXXH_NO_XXH3
+noxxh3test: CFLAGS += -Werror -pedantic
+noxxh3test: xxhash.c
+	@echo ---- test compilation without XXH3 ----
+	$(RM) xxhash.o
+	$(CC) $(FLAGS) $^ -c
+	$(NM) xxhash.o | $(GREP) XXH3_ ; test $$? -eq 1
+	$(RM) xxhash.o
 
 .PHONY: usan
 usan: CC=clang

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ The following macros can be set at compilation time to modify libxxhash's behavi
                                    Adds one branch at the beginning of each hash.
 - `XXH_STATIC_LINKING_ONLY`: gives access to the state declaration for static allocation.
                              Incompatible with dynamic linking, due to risks of ABI changes.
+- `XXH_NO_XXH3` : removes symbols related to `XXH3` (both 64 & 128 bits) from generated binary.
+                  Useful to reduce binary size, notably for applications which do not use `XXH3`.
 - `XXH_NO_LONG_LONG`: removes compilation of algorithms relying on 64-bit types (XXH3 and XXH64). Only XXH32 will be compiled.
                       Useful for targets (architectures and compilers) without 64-bit support.
 - `XXH_IMPORT`: MSVC specific: should only be defined for dynamic linking, as it prevents linkage errors.

--- a/xxhash.h
+++ b/xxhash.h
@@ -2546,7 +2546,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
     return XXH_readBE64(src);
 }
 
-
+#ifndef XXH_NO_XXH3
 
 /* *********************************************************************
 *  XXH3
@@ -5311,6 +5311,8 @@ XXH128_hashFromCanonical(const XXH128_canonical_t* src)
 #endif
 
 #endif  /* XXH_NO_LONG_LONG */
+
+#endif  /* XXH_NO_XXH3 */
 
 /*!
  * @}


### PR DESCRIPTION
which removes generation of `XXH3` symbols from library
resulting in smaller binary size.

This makes it more compelling to update xxHash to a version `>= v0.7.0` 
for existing applications which do not use `XXH3`.