### PR TITLE
Introduce GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,371 @@
+# Known critical issues:
+# - AVX512 related tests are disabled.  Because default environment of
+#   GitHub Actions doesn't guarantee to support AVX512.
+#   As of May 2021, they're using Xeon E5-2673 (which doesn't support
+#   AVX512) and Xeon Platinum 8171M (which supports AVX512).
+#   See also https://github.com/actions/runner/issues/1069
+#
+# Known issues:
+# - This test script ignores exit code of cppcheck which can see under
+#   Job:Linux x64 misc tests > cppcheck in the GitHub Actions report.
+#   Because xxHash project doesn't 100% follow their recommendation.
+#   Also sometimes it reports false positives.
+#
+# - GitHub Actions doesn't support Visual Studio 2015 and 2013.
+#   https://github.com/actions/virtual-environments/issues/387
+#
+# - Setup procedure for msys2 environment is painfully slow.  It takes
+#   3..5 minutes.
+#
+# - Sometimes apt-get fails to retrieve package information.
+#   I have absolutely no idea.
+#
+# Notes:
+# - You can investigate various information at the right pane of GitHub
+#   Actions report page.
+#
+#   | Item                      | Section in the right pane             |
+#   | ------------------------- | ------------------------------------- |
+#   | OS, VM                    | Set up job                            |
+#   | git repo, commit hash     | Run actions/checkout@v2               |
+#   | gcc, tools                | Environment info                      |
+#
+# - To fail earlier, oreder of tests in the same job are roughly sorted by
+#   elapsed time.
+#
+# - "ubuntu-latest" (Ubuntu 20.04) has the following software
+#   https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+#
+# Todos:
+# - [ ] Linux: Add native ARM runner.
+# - [ ] Linux: Add native ARM64 runner.
+# - [ ] Linux: Add native PPC64LE runner.
+# - [ ] Linux: Add native S390X runner.
+# - [ ] Windows: Add VS2013.
+# - [ ] Windows: Add VS2015.
+# - [ ] Windows: Add clang for msys2.
+# - [ ] Windows: Add native or emulated ARM runner.
+# - [ ] Windows: Add native or emulated ARM64 runner.
+
+
+# Name of the workflow is also displayed as a SVG badge
+name: xxHash CI tests
+
+on: [push, pull_request]
+
+jobs:
+
+  # Linux, x64
+
+  ubuntu-general:
+    name: Linux x64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 # https://github.com/actions/checkout
+
+    - name: apt-get install
+      run: |
+        sudo apt-get install gcc-multilib
+
+    - name: Environment info
+      run: |
+        echo && gcc --version
+        echo && clang --version
+        echo && make -v
+        echo && cat /proc/cpuinfo || echo /proc/cpuinfo is not present
+
+    - name: C90 + no-long-long compliance
+      run: |
+        CFLAGS="-std=c90 -pedantic -Wno-long-long -Werror" make clean xxhsum
+
+    - name: C90 + XXH_NO_LONG_LONG
+      run: |
+        # strict c90, with no long long support; resulting in no XXH64_* symbol
+        make clean c90test
+
+    - name: dispatch
+      run: |
+        # removing sign conversion warnings due to a bug in gcc-5's definition of some AVX512 intrinsics
+        CFLAGS="-Werror" MOREFLAGS="-Wno-sign-conversion" make clean dispatch
+
+    - name: DISPATCH=1
+      run: |
+        CFLAGS="-Wall -Wextra -Werror" make DISPATCH=1 clean default
+
+    - name: noxxh3test
+      run: |
+        # check library can be compiled with XXH_NO_XXH3, resulting in no XXH3_* symbol
+        make clean noxxh3test
+
+# As for AVX512, see "Known critical issues" at the top of this file
+#   - name: make avx512f
+#     run: |
+#       CFLAGS="-O1 -mavx512f -Werror" make clean default
+
+    - name: test-all
+      run: |
+        make clean test-all
+
+
+  ubuntu-consistency:
+    name: Linux x64 check results consistency
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 # https://github.com/actions/checkout
+
+    - name: Environment info
+      run: |
+        echo && gcc --version
+        echo && make -v
+        echo && cat /proc/cpuinfo || echo /proc/cpuinfo is not present
+
+    - name: Scalar code path
+      run: |
+        CPPFLAGS=-DXXH_VECTOR=XXH_SCALAR make clean check
+
+    - name: SSE2 code path
+      run: |
+        CPPFLAGS=-DXXH_VECTOR=XXH_SSE2 make clean check
+
+    - name: AVX2 code path
+      run: |
+        CPPFLAGS="-mavx2 -DXXH_VECTOR=XXH_AVX2" make clean check
+
+# As for AVX512, see "Known critical issues" at the top of this file
+#   - name: AVX512 code path
+#     run: |
+#       CPPFLAGS="-mavx512f -DXXH_VECTOR=XXH_AVX512" make clean check
+
+    - name: reroll code path (#240)
+      run: |
+        CPPFLAGS=-DXXH_REROLL=1 make clean check
+
+    - name: tests/bench
+      run: |
+        make -C tests/bench
+
+
+  ubuntu-misc:
+    name: Linux x64 misc tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 # https://github.com/actions/checkout
+
+    - name: apt-get install
+      run: |
+        sudo apt-get install valgrind cppcheck
+
+    - name: Environment info
+      run: |
+        echo && gcc --version
+        echo && clang --version
+        echo && valgrind --version
+        echo && cppcheck --version
+        echo && make -v
+        echo && cat /proc/cpuinfo || echo /proc/cpuinfo is not present
+
+    - name: cppcheck
+      run: |
+        make clean cppcheck || echo There are some cppcheck reports
+
+    - name: test-mem (valgrind)
+      run: |
+        make clean test-mem
+
+
+  ubuntu-cmake-unofficial:
+    name: Linux x64 cmake unofficial build test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 # https://github.com/actions/checkout
+
+    - name: Environment info
+      run: |
+        echo && gcc --version
+        echo && cmake --version
+        echo && make -v
+        echo && cat /proc/cpuinfo || echo /proc/cpuinfo is not present
+
+    - name: cmake
+      run: |
+        cd cmake_unofficial
+        mkdir build
+        cd build
+        cmake ..
+        CFLAGS=-Werror make
+
+
+  # Linux, { ARM, ARM64, PPC64LE, S390X }
+  # All tests are using QEMU and gcc cross compiler.
+
+  qemu-consistency:
+    name: QEMU ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
+      matrix:
+        include: [
+          { name: ARM,      xcc_pkg: gcc-arm-linux-gnueabi,     xcc: arm-linux-gnueabi-gcc,     xemu_pkg: qemu-system-arm,    xemu: qemu-arm-static     },
+          { name: ARM64,    xcc_pkg: gcc-aarch64-linux-gnu,     xcc: aarch64-linux-gnu-gcc,     xemu_pkg: qemu-system-arm,    xemu: qemu-aarch64-static },
+          { name: PPC64LE,  xcc_pkg: gcc-powerpc64le-linux-gnu, xcc: powerpc64le-linux-gnu-gcc, xemu_pkg: qemu-system-ppc,    xemu: qemu-ppc64le-static },
+          { name: S390X,    xcc_pkg: gcc-s390x-linux-gnu,       xcc: s390x-linux-gnu-gcc,       xemu_pkg: qemu-system-s390x,  xemu: qemu-s390x-static   },
+        ]
+    env:                        # Set environment variables
+      XCC: ${{ matrix.xcc }}
+      XEMU: ${{ matrix.xemu }}
+    steps:
+    - uses: actions/checkout@v2 # https://github.com/actions/checkout
+    - name: apt update & install
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib g++-multilib qemu-utils qemu-user-static
+        sudo apt-get install ${{ matrix.xcc_pkg }} ${{ matrix.xemu_pkg }} 
+
+    - name: Environment info
+      run: |
+        echo && which $XCC
+        echo && $XCC --version
+        echo && $XCC -v  # Show built-in specs
+        echo && which $XEMU
+        echo && $XEMU --version
+
+    - name: ARM (XXH_VECTOR=[ scalar, NEON ])
+      if: ${{ matrix.name == 'ARM' }}
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+        CPPFLAGS="-DXXH_VECTOR=XXH_NEON" CFLAGS="-O3 -march=armv7-a -fPIC -mfloat-abi=softfp -mfpu=neon-vfpv4" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+
+    - name: ARM64 (XXH_VECTOR=[ scalar, NEON ])
+      if: ${{ matrix.name == 'ARM64' }}
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+        CPPFLAGS="-DXXH_VECTOR=XXH_NEON" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+
+    - name: PPC64LE (XXH_VECTOR=[ scalar, VSX ])
+      if: ${{ matrix.name == 'PPC64LE' }}
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+        CPPFLAGS="-DXXH_VECTOR=XXH_VSX" CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+
+    - name: S390X (XXH_VECTOR=[ scalar, VSX ])
+      if: ${{ matrix.name == 'S390X' }}
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+        CPPFLAGS=-DXXH_VECTOR=XXH_VSX CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+
+
+  # macOS
+
+  macos-latest-general:
+    name: macOS general test
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Environment info
+      run: |
+        echo && clang --version
+        echo && sysctl -a | grep machdep.cpu   # cpuinfo
+
+    - name: make
+      run: |
+        CFLAGS="-Werror" make clean default
+
+    - name: make test
+      run: |
+        # test scenario where "stdout" is not the console
+        make clean test MOREFLAGS='-Werror' | tee
+
+
+  # Windows, { VC++2019, VC++2017 } x { x64, Win32, ARM, ARM64 }
+  #
+  # - Default shell for Windows environment is PowerShell Core.
+  #   https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+  #
+  # - "windows-2019" uses Visual Studio 2019.
+  #   https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019
+  #
+  # - "windows-2016" uses Visual Studio 2017.
+  #   https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md#visual-studio-enterprise-2017
+
+  windows-visualc-general:
+    name: ${{ matrix.system.vc }}, ${{ matrix.arch }}
+    runs-on: ${{ matrix.system.os }}   # Runs-on foreach value of strategy.matrix.system.os
+    strategy:
+      fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
+      matrix:
+        system: [
+          { os: windows-2019, vc: "VC++ 2019" },
+          { os: windows-2016, vc: "VC++ 2017" },
+        ]
+        arch: [ x64, Win32, ARM, ARM64 ]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build ${{ matrix.system.os }}, ${{ matrix.arch }}
+      run: |
+        cd cmake_unofficial
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Release -A ${{ matrix.arch }} -DXXHASH_C_FLAGS="/WX"
+        cmake --build . --config Release
+
+    - name: Test
+      # Run benchmark for testing only if target arch is x64 or Win32.
+      if: ${{ matrix.arch == 'x64' || matrix.arch == 'Win32' }}
+      run: |
+        .\cmake_unofficial\build\Release\xxhsum.exe -bi1
+
+
+  # Windows, { mingw64, mingw32 }
+  #
+  # - Shell for msys2 is sh (msys2).  defaults.run.shell is for this setting.
+  #
+  # https://github.com/msys2/MINGW-packages/blob/master/.github/workflows/main.yml
+  # https://github.com/actions/starter-workflows/issues/95
+
+  windows-msys2-general:
+    name: Windows ${{ matrix.msystem }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
+      matrix:
+        include: [
+          { msystem: mingw64, toolchain: mingw-w64-x86_64-toolchain },
+          { msystem: mingw32, toolchain: mingw-w64-i686-toolchain },
+        ]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2  # https://github.com/actions/checkout
+      - uses: msys2/setup-msys2@v2 # https://github.com/msys2/setup-msys2
+        with:
+          msystem: MSYS
+          install: mingw-w64-i686-make ${{ matrix.toolchain }}
+          update: true
+
+      - name: Update
+        run: |
+          pacman --noconfirm -Suuy
+          pacman --noconfirm -Suu
+
+      - name: mingw64
+        if: ${{ matrix.msystem == 'mingw64' }}
+        run: |
+          PATH=/mingw64/bin:$PATH /mingw32/bin/mingw32-make clean test MOREFLAGS=-Werror
+          PATH=/mingw64/bin:$PATH /mingw32/bin/mingw32-make -C tests/bench
+          # Abort if result of "file ./xxhsum.exe" doesn't contain 'x86-64'.
+          # Expected output is "./xxhsum.exe: PE32+ executable (console) x86-64, for MS Windows"
+          file ./xxhsum.exe | grep -q 'x86-64' || $(exit 1)
+          ./xxhsum.exe --version
+
+      - name: mingw32
+        if: ${{ matrix.msystem == 'mingw32' }}
+        run: |
+          PATH=/mingw32/bin:$PATH /mingw32/bin/mingw32-make.exe clean test MOREFLAGS=-Werror
+          PATH=/mingw32/bin:$PATH /mingw32/bin/mingw32-make.exe -C tests/bench
+          # Abort if result of "file ./xxhsum.exe" doesn't contain '80386'.
+          # Expected output is "./xxhsum.exe: PE32 executable (console) Intel 80386, for MS Windows"
+          file ./xxhsum.exe | grep -q '80386' || $(exit 1)
+          ./xxhsum.exe --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@
 # - Setup procedure for msys2 environment is painfully slow.  It takes
 #   3..5 minutes.
 #
-# - Sometimes apt-get fails to retrieve package information.
-#   I have absolutely no idea.
-#
 # Notes:
 # - You can investigate various information at the right pane of GitHub
 #   Actions report page.
@@ -30,11 +27,8 @@
 #   | git repo, commit hash     | Run actions/checkout@v2               |
 #   | gcc, tools                | Environment info                      |
 #
-# - To fail earlier, oreder of tests in the same job are roughly sorted by
+# - To fail earlier, order of tests in the same job are roughly sorted by
 #   elapsed time.
-#
-# - "ubuntu-latest" (Ubuntu 20.04) has the following software
-#   https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 #
 # Todos:
 # - [ ] Linux: Add native ARM runner.
@@ -56,6 +50,9 @@ on: [push, pull_request]
 jobs:
 
   # Linux, x64
+  #
+  # - "ubuntu-latest" (Ubuntu 20.04) has the following software
+  #   https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 
   ubuntu-general:
     name: Linux x64
@@ -166,6 +163,8 @@ jobs:
 
     - name: cppcheck
       run: |
+        # This test script ignores exit code of cppcheck.  See knowin issues
+        # at the top of this file.
         make clean cppcheck || echo There are some cppcheck reports
 
     - name: test-mem (valgrind)


### PR DESCRIPTION
I'd like to introduce GitHub Actions.  Since there're known issues, I don't claim it replaces travis-ci and appveyor for now.

Please take a look at the result.  https://github.com/t-mat/xxHash/actions/runs/876834438

# Good points

- Since every GitHub users can use GitHub Actions, everyone run it without other accounts.
- GitHub Actions is highly integrated to GitHub UX.


# Critical issue of this PR

- AVX512 related tests are disabled.
  Because default environment of GitHub Actions doesn't guarantee to support AVX512.
  As of May 2021, they're using Xeon E5-2673 (which doesn't support AVX512) and Xeon Platinum 8171M (which supports AVX512).
  See also https://github.com/actions/runner/issues/1069


# Known issues

- It fails for `make usan`.
  - Currently, it doesn't fail at travis-ci.  Because we're using older version of ubuntu and clang at travis-ci.
  - To understand what's happening, please run `make usan` at your local environment.
  - In short, it actually fails.

- GitHub Actions doesn't support Visual Studio 2015 and 2013.
  https://github.com/actions/virtual-environments/issues/387

- GitHub Actions doesn't have native runner for { ARM, ARM64, PPC64LE, S390X }.

- GitHub Actions doesn't have MSVC 2013 and MSVC 2015.

- I'm still not sure how properly install clang for msys2.
