### PR TITLE
Fix make usan runtime error

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1920,7 +1920,7 @@ XXH32_finalize(xxh_u32 h32, const xxh_u8* ptr, size_t len, XXH_alignment align)
 XXH_FORCE_INLINE xxh_u32
 XXH32_endian_align(const xxh_u8* input, size_t len, xxh_u32 seed, XXH_alignment align)
 {
-    const xxh_u8* bEnd = input + len;
+    const xxh_u8* bEnd = input ? input + len : NULL;
     xxh_u32 h32;
 
 #if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)
@@ -2348,7 +2348,7 @@ XXH64_finalize(xxh_u64 h64, const xxh_u8* ptr, size_t len, XXH_alignment align)
 XXH_FORCE_INLINE xxh_u64
 XXH64_endian_align(const xxh_u8* input, size_t len, xxh_u64 seed, XXH_alignment align)
 {
-    const xxh_u8* bEnd = input + len;
+    const xxh_u8* bEnd = input ? input + len : NULL;
     xxh_u64 h64;
 
 #if defined(XXH_ACCEPT_NULL_INPUT_POINTER) && (XXH_ACCEPT_NULL_INPUT_POINTER>=1)


### PR DESCRIPTION
This PR fixes `make usan` runtime errors.

When we use recent version of `clang`, `make usan` reports the following runtime errors

```
xxhash.h:1923:32: runtime error: applying zero offset to null pointer
```

```
xxhash.h:2351:32: runtime error: applying zero offset to null pointer
```

These errors are caused by the following statement

```C
const xxh_u8* bEnd = input + len;
```

Here, if `input == NULL`, `input + len` causes runtime error of usan.  This PR replaces them with the following

```C
- const xxh_u8* bEnd = input + len;
+ const xxh_u8* bEnd = input ? input + len : NULL;
```
