### PR TITLE
Enable AVX512 tests on GH-Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 # Known critical issues:
-# - AVX512 related tests are disabled.  Because default environment of
+# - AVX512 related tests are incomplete.  Because default environment of
 #   GitHub Actions doesn't guarantee to support AVX512.
 #   As of May 2021, they're using Xeon E5-2673 (which doesn't support
 #   AVX512) and Xeon Platinum 8171M (which supports AVX512).
 #   See also https://github.com/actions/runner/issues/1069
+#
+#   In this CI script, it always run `make default` which compiles xxHash
+#   with AVX512 intrinsics.  But if test runner doesn't support AVX512,
+#   it doesn't run `make check` which tests runtime error/consistency.
+#   It means that this test stochastically detects a failure in AVX512
+#   code path.
 #
 # Known issues:
 # - This test script ignores exit code of cppcheck which can see under
@@ -94,10 +100,9 @@ jobs:
         # check library can be compiled with XXH_NO_XXH3, resulting in no XXH3_* symbol
         make clean noxxh3test
 
-# As for AVX512, see "Known critical issues" at the top of this file
-#   - name: make avx512f
-#     run: |
-#       CFLAGS="-O1 -mavx512f -Werror" make clean default
+    - name: make avx512f
+      run: |
+        CFLAGS="-O1 -mavx512f -Werror" make clean default
 
     - name: test-all
       run: |
@@ -128,10 +133,11 @@ jobs:
       run: |
         CPPFLAGS="-mavx2 -DXXH_VECTOR=XXH_AVX2" make clean check
 
-# As for AVX512, see "Known critical issues" at the top of this file
-#   - name: AVX512 code path
-#     run: |
-#       CPPFLAGS="-mavx512f -DXXH_VECTOR=XXH_AVX512" make clean check
+    # As for AVX512, see "Known critical issues" at the top of this file
+    - name: AVX512 code path
+      run: |
+        # Run "make check" if /proc/cpuinfo has flags for avx512.
+        grep -q "^flags.*\bavx512\b" /proc/cpuinfo && CPPFLAGS="-mavx512f -DXXH_VECTOR=XXH_AVX512" make clean check || (echo This test runner does not support AVX512. && $(exit 0))
 
     - name: reroll code path (#240)
       run: |


### PR DESCRIPTION
This PR eases AVX512 issue of GitHub Actions.

## The problem

- AVX512 is relatively minor so far, but important.  This code path must be checked by CI.
- Currently, GitHub Actions' test runner system doesn't guarantee to support AVX512.
- Actually, some GH-Actions test runner has AVX512.  But AFAIK, there's no method which requests spec of the test runner.


## Possible solutions

(a) Provide private test runner which supports AVX512.  This test runner is placed outside of GitHub.  GitHub Actions recommends this solution.

(b) Use other CI which fully supports AVX512 (travis-ci, etc).  And invoke them from GitHub Actions.

(c) Invoke runtime AVX512 test only if test runner supports AVX512, in luck.

This PR uses method (c).


## This PR

(1) Always builds AVX512 code.
- CI script always indicates compile time errors and warnings such as invalid pointer aliases, etc.

(2) Runs AVX512 runtime test if test runner supports AVX512.
- Yes, it's unreliable.  But hopefully, better than nothing.

AVX512 detection logic is implemented by `grep` for `/proc/cpuinfo`.  For example:

```sh
grep -q "^flags.*\bfpu\b" /proc/cpuinfo && echo fpu-enabled || echo fpu-disabled
grep -q "^flags.*\bavx512\b" /proc/cpuinfo && echo avx512-enabled || echo avx512-disabled
grep -q "^flags.*\bavx1024\b" /proc/cpuinfo && echo avx1024-enabled || echo avx1024-disabled
```

- `-q` suppresses all normal output.
- `\b` matches space or end of line.


If test runner doesn't support AVX512, CI script shows [the following log](https://github.com/t-mat/xxHash/runs/2674150206?check_suite_focus=true#step:7:5) at "Linux x64 check results consistency > AVX512 code path".

```
This test runner does not support AVX512.
```

When something wrong, you can investigate [actual `/proc/cpuinfo`](https://github.com/t-mat/xxHash/runs/2674150206?check_suite_focus=true#step:3:39) at "Environment info" log.


## Possible issues

- Suppose we'll find actual AVX512 runtime error which is detected by GH-Actions CI.  In this case, follow up commits/PRs aren't able to rely on GH-Actions.  Because it reports AVX512 runtime error stochastically.
