### PR TITLE
Add hash-wasm to ports list

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@ The following versions produce xxHash-compatible results in different languages.
 |__C#__ (port)              |Melnik Alexander   |https://github.com/uranium62/xxHash
 |__C#__ (7.0)               |Otaku              |https://github.com/differentrain/YYProject.XXHash
 |__C#__ (.net std 2.0)      |Sedat Kapanoğlu    |https://github.com/ssg/HashDepot#xxhash
+|__JavaScript__ (WebAssembly)|Dani Biró         |https://www.npmjs.com/package/hash-wasm
 |__JavaScript__ (port)      |Pierre Curto       |https://npmjs.org/package/xxhashjs
 |__JavaScript__ (nodeJS)    |Brian White        |https://npmjs.org/package/xxhash
 |__JavaScript__ (nodeJS, xxh3)|Nhan Khong       |https://github.com/ktrongnhan/xxhash-addon


### PR DESCRIPTION
Adds @Daninet's hash-wasm library. It uses WebAssembly, which makes it much faster than the other popular xxHash JavaScript library (https://npmjs.org/package/xxhashjs) which uses regular JavaScript code.