### PR TITLE
Use `alignas()` in C++11

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -915,8 +915,11 @@ struct XXH64_state_s {
    XXH64_hash_t reserved64;   /*!< Reserved field. Do not read or write to it, it may be removed. */
 };   /* typedef'd to XXH64_state_t */
 
-#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)   /* C11+ */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* >= C11 */
 #  include <stdalign.h>
+#  define XXH_ALIGN(n)      alignas(n)
+#elif defined(__cplusplus) && (__cplusplus >= 201103L) /* >= C++11 */
+/* In C++ alignas() is a keyword */
 #  define XXH_ALIGN(n)      alignas(n)
 #elif defined(__GNUC__)
 #  define XXH_ALIGN(n)      __attribute__ ((aligned(n)))


### PR DESCRIPTION
The previous macro test only detected C11 and failed in modern C++, which
actually goes one step further and makes `alignas` a keyword. It's not clear
that this actually improves the situation with respect to #543, but it should
be slightly more correct in some sense.