### PR TITLE
Add GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Code is highly portable, and hashes are identical across all platforms (little /
 
 |Branch      |Status   |
 |------------|---------|
-|dev         | [![Build Status](https://travis-ci.org/Cyan4973/xxHash.svg?branch=dev)](https://travis-ci.org/Cyan4973/xxHash?branch=dev) |
+|dev         | [![Build Status](https://github.com/Cyan4973/xxHash/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/Cyan4973/xxHash/actions?query=branch%3Adev+) |
 
 
 Benchmarks


### PR DESCRIPTION
This PR replaces travis-ci.org status badge with GitHub Actions'.


## Removing travis-ci.org badge

Since travis-ci.org has been stopped, its badge doesn't reflect the result of latest tests.  We may add .com badge when we'll need.  But I think it's good to remove it for now.


## URL of the GH-Actions workflow badge

According to ["Adding a workflow status badge"](https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge), its URL for `dev` branch is

```
https://github.com/Cyan4973/xxHash/actions/workflows/ci.yml/badge.svg?branch=dev
```

![](https://github.com/Cyan4973/xxHash/actions/workflows/ci.yml/badge.svg?branch=dev)

We'll be able to tweak `?branch=` parameter for other branches.


## URL of the latest CI log(s)

I put `branch:dev` filter to exclude test for PR and feature branch.

https://github.com/Cyan4973/xxHash/actions?query=branch%3Adev+

## `release` branch

Since we still don't run any GH-Actions CI test for `release` branch, I'd like to leave it for now to avoid confusion.
