### PR TITLE
Fix technical UB negating signed

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -3649,7 +3649,7 @@ XXH3_initCustomSecret_avx512(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
     XXH_ASSERT(((size_t)customSecret & 63) == 0);
     (void)(&XXH_writeLE64);
     {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / sizeof(__m512i);
-        __m512i const seed = _mm512_mask_set1_epi64(_mm512_set1_epi64((xxh_i64)seed64), 0xAA, -(xxh_i64)seed64);
+        __m512i const seed = _mm512_mask_set1_epi64(_mm512_set1_epi64((xxh_i64)seed64), 0xAA, (xxh_i64)(0U - seed64));
 
         XXH_ALIGN(64) const __m512i* const src  = (const __m512i*) XXH3_kSecret;
         XXH_ALIGN(64)       __m512i* const dest = (      __m512i*) customSecret;
@@ -3745,7 +3745,7 @@ XXH_FORCE_INLINE XXH_TARGET_AVX2 void XXH3_initCustomSecret_avx2(void* XXH_RESTR
     XXH_STATIC_ASSERT(XXH_SEC_ALIGN <= 64);
     (void)(&XXH_writeLE64);
     XXH_PREFETCH(customSecret);
-    {   __m256i const seed = _mm256_set_epi64x(-(xxh_i64)seed64, (xxh_i64)seed64, -(xxh_i64)seed64, (xxh_i64)seed64);
+    {   __m256i const seed = _mm256_set_epi64x((xxh_i64)(0U - seed64), (xxh_i64)seed64, (xxh_i64)(0U - seed64), (xxh_i64)seed64);
 
         XXH_ALIGN(64) const __m256i* const src  = (const __m256i*) XXH3_kSecret;
         XXH_ALIGN(64)       __m256i*       dest = (      __m256i*) customSecret;
@@ -3850,10 +3850,10 @@ XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTR
 
 #       if defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER < 1900
         // MSVC 32bit mode does not support _mm_set_epi64x before 2015
-        XXH_ALIGN(16) const xxh_i64 seed64x2[2] = { (xxh_i64)seed64, -(xxh_i64)seed64 };
+        XXH_ALIGN(16) const xxh_i64 seed64x2[2] = { (xxh_i64)seed64, (xxh_i64)(0U - seed64) };
         __m128i const seed = _mm_load_si128((__m128i const*)seed64x2);
 #       else
-        __m128i const seed = _mm_set_epi64x(-(xxh_i64)seed64, (xxh_i64)seed64);
+        __m128i const seed = _mm_set_epi64x((xxh_i64)(0U - seed64), (xxh_i64)seed64);
 #       endif
         int i;
 


### PR DESCRIPTION
Summary: UBSAN run reported on using seed 1<<63 with XXH3 because of
`-(xxh_i64)seed64` overflow. Seen in CI for
https://github.com/facebook/rocksdb/pull/8634

To fix, negate as unsigned (well defined under/overflow) and then cast
to signed.

Test Plan: same patch fixes the report in RocksDB