### PR TITLE
fix #557

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ clean:  ## remove all build artifacts
 	$(Q)$(RM) xxh32sum$(EXT) xxh64sum$(EXT) xxh128sum$(EXT)
 	$(Q)$(RM) $(XXHSUM_SRC_DIR)/*.o $(XXHSUM_SRC_DIR)/*.obj
 	$(MAKE) -C tests clean
+	$(MAKE) -C tests/bench clean
+	$(MAKE) -C tests/collisions clean
 	@echo cleaning completed
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -933,6 +933,7 @@ struct XXH64_state_s {
 
 /* Old GCC versions only accept the attribute after the type in structures. */
 #if !(defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L))   /* C11+ */ \
+    && ! (defined(__cplusplus) && (__cplusplus >= 201103L)) /* >= C++11 */ \
     && defined(__GNUC__)
 #   define XXH_ALIGN_MEMBER(align, type) type XXH_ALIGN(align)
 #else


### PR DESCRIPTION
fix minor compatibility issue with `clang++`,
suggested by @t-mat .

Also ensure that `make clean` properly cleans sub-projects
such as `tests/bench` and `tests/collisions`