### PR TITLE
fix #563

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,15 @@ environment:
     ARCH: "ARM64"
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     # note: ARM64 is not available with Visual Studio 14 2015, which is default for Appveyor
-  - COMPILER: "gcc"
-    PLATFORM: "mingw64"
-  - COMPILER: "gcc"
-    PLATFORM: "mingw32"
-  - COMPILER: "gcc"
-    PLATFORM: "clang"
+# Below tests are now disabled.
+# They are flacky on Appveyor, for various reasons.
+# Moreover, their equivalent already runs correctly on Github Actions.
+#  - COMPILER: "gcc"
+#    PLATFORM: "mingw64"
+#  - COMPILER: "gcc"
+#    PLATFORM: "mingw32"
+#  - COMPILER: "gcc"
+#    PLATFORM: "clang"
 
 install:
   - ECHO Installing %COMPILER% %PLATFORM% %ARCH%

--- a/tests/bench/Makefile
+++ b/tests/bench/Makefile
@@ -29,7 +29,8 @@
 
 CPPFLAGS += -I../..   # directory of xxHash source files
 CFLAGS   ?= -O3
-CFLAGS   += -std=c99 -Wall -Wextra -Wstrict-aliasing=1
+CFLAGS   += -Wall -Wextra -Wstrict-aliasing=1 \
+            -std=c99
 CFLAGS   += $(MOREFLAGS)   # custom way to add flags
 CXXFLAGS ?= -O3
 LDFLAGS  += $(MOREFLAGS)

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -26,9 +26,10 @@
 SRC_DIRS = ./ ../../ allcodecs/
 VPATH = $(SRC_DIRS)
 CPPFLAGS += $(addprefix -I ,$(SRC_DIRS))
-CFLAGS   ?= -std=c99 \
-            -Wall -Wextra -Wconversion
-CXXFLAGS ?= -Wall -Wextra -Wconversion -std=c++11
+CFLAGS   += -Wall -Wextra -Wconversion \
+            -std=c99
+CXXFLAGS += -Wall -Wextra -Wconversion \
+            -std=c++11
 LDFLAGS  += -pthread
 TESTHASHES = 110000000
 

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -106,7 +106,7 @@ static uint64_t avalanche64(uint64_t h64)
     return h64;
 }
 
-static unsigned char randomByte(size_t n)
+static unsigned char randomByte(uint64_t n)
 {
     uint64_t n64 = avalanche64(n+1);
     n64 *= prime64_1;
@@ -240,7 +240,7 @@ typedef struct {
     /* slab5 */
     size_t nbSlabs;
     size_t current;
-    size_t prngSeed;
+    uint64_t prngSeed;
 } sampleFactory;
 
 static void init_sampleFactory(sampleFactory* sf, uint64_t htotal)
@@ -282,7 +282,7 @@ static void free_sampleFactory(sampleFactory* sf)
 
 static void flipbit(void* buffer, uint64_t bitID)
 {
-    size_t const pos = bitID >> 3;
+    size_t const pos = (size_t)(bitID >> 3);
     unsigned char const mask = (unsigned char)(1 << (bitID & 7));
     unsigned char* const p = (unsigned char*)buffer;
     p[pos] ^= mask;
@@ -416,7 +416,7 @@ static inline int Filter_insert(Filter* bf, int bflog, uint64_t hash)
      hash >>= 8;
 
      size_t const fclmask = ((size_t)1 << (bflog-6)) - 1;
-     size_t const cacheLineNb = hash & fclmask;
+     size_t const cacheLineNb = (size_t)hash & fclmask;
 
      size_t const pos1 = (cacheLineNb << 6) + (slot1 >> 2);
      unsigned const shift1 = (slot1 & 3) * 2;
@@ -456,7 +456,7 @@ static inline int Filter_check(const Filter* bf, int bflog, uint64_t hash)
      hash >>= 8;
 
      size_t const fclmask = ((size_t)1 << (bflog-6)) - 1;
-     size_t const cacheLineNb = hash & fclmask;
+     size_t const cacheLineNb = (size_t)hash & fclmask;
 
      size_t const pos1 = (cacheLineNb << 6) + (slot1 >> 2);
      unsigned const shift1 = (slot1 & 3) * 2;
@@ -709,7 +709,7 @@ static size_t search_collisions(
 
     time_t const storeTBegin = time(NULL);
     size_t const hashByteSize = (htype == ht128) ? 16 : 8;
-    size_t const tableSize = (nbPresents+1) * hashByteSize;
+    size_t const tableSize = (size_t)((nbPresents+1) * hashByteSize);
     assert(tableSize > nbPresents);  /* check tableSize calculation overflow */
     DISPLAY(" Storing hash candidates (%i MB) \n", (int)(tableSize >> 20));
 
@@ -835,6 +835,7 @@ static size_t search_collisions(
 
 
 #if defined(__MACH__) || defined(__linux__)
+
 #include <sys/resource.h>
 static size_t getProcessMemUsage(int children)
 {
@@ -843,8 +844,9 @@ static size_t getProcessMemUsage(int children)
       return (size_t)stats.ru_maxrss;
     return 0;
 }
+
 #else
-static size_t getProcessMemUsage(int ignore) { return 0; }
+static size_t getProcessMemUsage(int ignore) { (void)ignore; return 0; }
 #endif
 
 void time_collisions(searchCollisions_parameters param)

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -432,8 +432,10 @@ static inline int Filter_insert(Filter* bf, int bflog, uint64_t hash)
      static const unsigned nextValue[4] = { 1, 2, 3, 3 };
 
      bf[pos1] &= (Filter)(~(3 << shift1)); /* erase previous value */
-     bf[pos1] |= (Filter)(MAX(ex1, nextValue[existing]) << shift1);
-     bf[pos2] |= (Filter)(MAX(ex2, nextValue[existing]) << shift2);
+     unsigned const max1 = MAX(ex1, nextValue[existing]);
+     bf[pos1] |= (Filter)(max1 << shift1);
+     unsigned const max2 = MAX(ex2, nextValue[existing]);
+     bf[pos2] |= (Filter)(max2 << shift2);
 
      return addCandidates[existing];
  }


### PR DESCRIPTION
ensure that building test tools preserves compilation flags
including `-std=c99` and `-std=c++11`
when invoked with `CFLAGS` pre-set
so that it properly compiles with `gcc` <= 4.8 .

reported by @t-mat.