### PR TITLE
Fix C++ style comment

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -3857,7 +3857,7 @@ XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTR
     {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / sizeof(__m128i);
 
 #       if defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER < 1900
-        // MSVC 32bit mode does not support _mm_set_epi64x before 2015
+        /* MSVC 32bit mode does not support _mm_set_epi64x before 2015 */
         XXH_ALIGN(16) const xxh_i64 seed64x2[2] = { (xxh_i64)seed64, (xxh_i64)(0U - seed64) };
         __m128i const seed = _mm_load_si128((__m128i const*)seed64x2);
 #       else


### PR DESCRIPTION
`gcc-4.8 -pedantic` reports the following warning (as an error). Here's [error log](https://github.com/t-mat/xxHash/runs/3352258622#step:9:34).

```
gcc-4.8 -O3 -Wall -Wextra -Wconversion -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wformat-security -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wstrict-overflow=2  -Werror -pedantic -Wno-long-long   -DXXH_NO_XXH3 xxhash.c -c
In file included from xxhash.c:43:0:
xxhash.h:3860:9: error: C++ style comments are not allowed in ISO C90 [-Werror]
         // MSVC 32bit mode does not support _mm_set_epi64x before 2015
         ^
```
