### PR TITLE
remove redudant tests from Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,6 @@ environment:
     ARCH: "x64"
     TEST_XXHSUM: "true"
   - COMPILER: "visual"
-    ARCH: "x64"
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    TEST_XXHSUM: "true"
-  - COMPILER: "visual"
     ARCH: "Win32"
     TEST_XXHSUM: "true"
   - COMPILER: "visual"
@@ -26,13 +22,18 @@ environment:
     TEST_XXHSUM: "true"
   - COMPILER: "visual"
     ARCH: "ARM"
-  - COMPILER: "visual"
-    ARCH: "ARM64"
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    # note: ARM64 is not available with Visual Studio 14 2015, which is default for Appveyor
-# Below tests are now disabled.
-# They are flacky on Appveyor, for various reasons.
-# Moreover, their equivalent already runs correctly on Github Actions.
+# Below tests are now disabled due to redundancy.
+# Their equivalent already runs correctly on Github Actions.
+#  - COMPILER: "visual"
+#    ARCH: "x64"
+#    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#    TEST_XXHSUM: "true"
+#  - COMPILER: "visual"
+#    ARCH: "ARM64"
+#    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#    # note: ARM64 is not available with Visual Studio 14 2015, which is default for Appveyor
+
+# The following tests were also flacky on Appveyor, for various reasons.
 #  - COMPILER: "gcc"
 #    PLATFORM: "mingw64"
 #  - COMPILER: "gcc"


### PR DESCRIPTION
VS 2017 tests are already run on Github Actions.

This reduce the time spent in Appveyor,
which remains the limiting bottleneck for CI test speed.