### PR TITLE
add memory access method 1 for mips on gcc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,7 @@ jobs:
           { name: ARM64,    xcc_pkg: gcc-aarch64-linux-gnu,     xcc: aarch64-linux-gnu-gcc,     xemu_pkg: qemu-system-arm,    xemu: qemu-aarch64-static },
           { name: PPC64LE,  xcc_pkg: gcc-powerpc64le-linux-gnu, xcc: powerpc64le-linux-gnu-gcc, xemu_pkg: qemu-system-ppc,    xemu: qemu-ppc64le-static },
           { name: S390X,    xcc_pkg: gcc-s390x-linux-gnu,       xcc: s390x-linux-gnu-gcc,       xemu_pkg: qemu-system-s390x,  xemu: qemu-s390x-static   },
+          { name: MIPS,     xcc_pkg: gcc-mips-linux-gnu,        xcc: mips-linux-gnu-gcc,        xemu_pkg: qemu-system-mips,   xemu: qemu-mips-static    },
         ]
     env:                        # Set environment variables
       XCC: ${{ matrix.xcc }}
@@ -224,7 +225,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gcc-multilib g++-multilib qemu-utils qemu-user-static
-        sudo apt-get install ${{ matrix.xcc_pkg }} ${{ matrix.xemu_pkg }} 
+        sudo apt-get install ${{ matrix.xcc_pkg }} ${{ matrix.xemu_pkg }}
 
     - name: Environment info
       run: |
@@ -258,6 +259,10 @@ jobs:
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS=-DXXH_VECTOR=XXH_VSX CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
+    - name: MIPS (XXH_VECTOR=[ scalar ])
+      if: ${{ matrix.name == 'MIPS' }}
+      run: |
+        LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
   # macOS
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -553,11 +553,11 @@ C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
 */
 
 #if defined (__has_c_attribute)
-#   if __has_c_attribute(fallthrough) 
+#   if __has_c_attribute(fallthrough)
 #       define XXH_FALLTHROUGH [[fallthrough]]
 #   endif
 
-#elif defined(__cplusplus) && defined(__has_cpp_attribute) 
+#elif defined(__cplusplus) && defined(__has_cpp_attribute)
 #   if __has_cpp_attribute(fallthrough)
 #       define XXH_FALLTHROUGH [[fallthrough]]
 #   endif
@@ -567,7 +567,7 @@ C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
 #   if defined(__GNUC__) && __GNUC__ >= 7
 #       define XXH_FALLTHROUGH __attribute__ ((fallthrough))
 #   else
-#       define XXH_FALLTHROUGH 
+#       define XXH_FALLTHROUGH
 #	endif
 #endif
 
@@ -1288,10 +1288,21 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
  */
 
 #ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
-   /* prefer __packed__ structures (method 1) for gcc on armv7 and armv8 */
-#  if !defined(__clang__) && ( \
+   /* prefer __packed__ structures (method 1) for gcc on armv7+ and mips */
+#  if !defined(__clang__) && \
+( \
     (defined(__INTEL_COMPILER) && !defined(_WIN32)) || \
-    (defined(__GNUC__) && (defined(__ARM_ARCH) && __ARM_ARCH >= 7)) )
+    ( \
+        defined(__GNUC__) && ( \
+            (defined(__ARM_ARCH) && __ARM_ARCH >= 7) || \
+            ( \
+                defined(__mips__) && \
+                (__mips <= 5 || __mips_isa_rev < 6) && \
+                (!defined(__mips16) || defined(__mips_mips16e2)) \
+            ) \
+        ) \
+    ) \
+)
 #    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif
@@ -1897,7 +1908,7 @@ XXH32_finalize(xxh_u32 h32, const xxh_u8* ptr, size_t len, XXH_alignment align)
                          XXH_FALLTHROUGH;
            case 4:       XXH_PROCESS4;
                          return XXH32_avalanche(h32);
-                         
+
            case 13:      XXH_PROCESS4;
                          XXH_FALLTHROUGH;
            case 9:       XXH_PROCESS4;


### PR DESCRIPTION
recommended by info@mobile-stream.com

> This is designed to cover all versions since the original MIPS I ISA up
to MIPS32r5 / MIPS64r5 including microMIPS and MIPS16e2. That is, all
MIPS ISA variants with LWR/LWL/SWR/SWL etc instructions. GCC is able to
use these for efficient unaligned access for many years. For example,
see the "MIPS32 Instruction Set Quick Reference" (MD00565-2B) from 2008
for the recommendation to use method 1 for unaligned access on MIPS.
>
> MIPSXXr6 is explicitly excluded because it allows for software (slow)
implementation of unaligned load/stores.
>
> nanoMIPS is not included too due to lack of testing and because the
"nanoMIPS Subset" (NMS) omits the dedicated instructions for unaligned
access. Note this means __mips should not be used instead of __mips__
and vice versa as the latter is the architecture name and the former
is the ISA feature macro. See 4.2 in "P32 Porting Guide" (DN00184).