### PR TITLE
XXH_INLINE_ALL can be declared after XXH_NAMESPACE

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -68,7 +68,7 @@ test_multiInclude:
 	# no symbol prefixed TESTN_ should exist
 	! $(NM) multiInclude | $(GREP) TESTN_
 	$(MAKE) clean
-	# compile with XXH_NAMESPACE
+	# compile xxhash.o with XXH_NAMESPACE
 	CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude_withxxhash
 	# symbols prefixed TESTN_ should exist in xxhash.o (though not be invoked)
 	$(NM) multiInclude_withxxhash | $(GREP) TESTN_

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -63,17 +63,16 @@ test_multiInclude:
 	# compile with xxhash.o, to detect duplicated symbols
 	$(MAKE) multiInclude_withxxhash
 	@$(MAKE) clean
-	# Note: XXH_INLINE_ALL with XXH_NAMESPACE is currently disabled
+	# compile with XXH_NAMESPACE before XXH_INLINE_ALL
+	CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude
+	# no symbol prefixed TESTN_ should exist
+	! $(NM) multiInclude | $(GREP) TESTN_
+	$(MAKE) clean
 	# compile with XXH_NAMESPACE
-	# CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude_withxxhash
-	# no symbol prefixed TESTN_ should exist
-	# ! $(NM) multiInclude_withxxhash | $(GREP) TESTN_
-	#$(MAKE) clean
-	# compile with XXH_NAMESPACE and without xxhash.o
-	# CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude
-	# no symbol prefixed TESTN_ should exist
-	# ! $(NM) multiInclude | $(GREP) TESTN_
-	#@$(MAKE) clean
+	CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude_withxxhash
+	# symbols prefixed TESTN_ should exist in xxhash.o (though not be invoked)
+	$(NM) multiInclude_withxxhash | $(GREP) TESTN_
+	$(MAKE) clean
 
 .PHONY: test_ppc_redefine
 test_ppc_redefine: ppc_define.c

--- a/tests/multiInclude.c
+++ b/tests/multiInclude.c
@@ -30,21 +30,30 @@
 /* Normal include, gives access to public symbols */
 #include "../xxhash.h"
 
+/* Multiple consecutive inclusions are handled properly. */
+#include "../xxhash.h"
+
 /*
  * Advanced include, gives access to experimental symbols
- * This test ensures that xxhash.h can be included multiple times and in any
- * order. This order is more difficult: Without care, the declaration of
- * experimental symbols could be skipped.
+ * This test ensures that xxhash.h can be included multiple times
+ * and in any order. The tested order is more difficult:
+ * without care, the declaration of experimental symbols could be skipped.
  */
 #define XXH_STATIC_LINKING_ONLY
 #include "../xxhash.h"
 
 /*
- * Inlining: Re-define all identifiers, keep them private to the unit.
+ * Inlining: redefine all identifiers, keep them private to the unit.
  * Note: Without specific efforts, the identifier names would collide.
  *
- * To be linked with and without xxhash.o to test the symbol's presence and
- * naming collisions.
+ * To be linked with and without xxhash.o
+ * to test the symbol's presence and naming collisions.
+ */
+#define XXH_INLINE_ALL
+#include "../xxhash.h"
+
+/*
+ * Multiple consecutive inclusions with XXH_INLINE_ALL are handled properly.
  */
 #define XXH_INLINE_ALL
 #include "../xxhash.h"

--- a/tests/multiInclude.c
+++ b/tests/multiInclude.c
@@ -50,9 +50,9 @@
 #include "../xxhash.h"
 
 
-int main(void)
+void hash_advanced(void)
 {
-    XXH3_state_t state;   /* part of experimental API */
+    XXH3_state_t state;   /* this type is part of experimental API */
 
     XXH3_64bits_reset(&state);
     const char input[] = "Hello World !";
@@ -61,6 +61,9 @@ int main(void)
 
     XXH64_hash_t const h = XXH3_64bits_digest(&state);
     printf("hash '%s': %08x%08x \n", input, (unsigned)(h >> 32), (unsigned)h);
+}
 
-    return 0;
+int main(void)
+{
+    hash_advanced();
 }

--- a/xxhash.h
+++ b/xxhash.h
@@ -121,80 +121,76 @@ extern "C" {
 
    /*
     * This part deals with the special case where a unit wants to inline xxHash,
-    * but "xxhash.h" has previously been included without XXH_INLINE_ALL, such
-    * as part of some previously included *.h header file.
+    * but "xxhash.h" has previously been included without XXH_INLINE_ALL,
+    * such as part of some previously included *.h header file.
     * Without further action, the new include would just be ignored,
     * and functions would effectively _not_ be inlined (silent failure).
     * The following macros solve this situation by prefixing all inlined names,
     * avoiding naming collision with previous inclusions.
     */
-#  ifdef XXH_NAMESPACE
-    /* #undef all symbols, they will be redefined right after */
-#      undef XXH_versionNumber
+   /* Before that, we unconditionally #undef all symbols,
+    * in case they were already defined with XXH_NAMESPACE.
+    * They will then be redefined for XXH_INLINE_ALL
+    */
+#  undef XXH_versionNumber
     /* XXH32 */
-#      undef XXH32
-#      undef XXH32_createState
-#      undef XXH32_freeState
-#      undef XXH32_reset
-#      undef XXH32_update
-#      undef XXH32_digest
-#      undef XXH32_copyState
-#      undef XXH32_canonicalFromHash
-#      undef XXH32_hashFromCanonical
+#  undef XXH32
+#  undef XXH32_createState
+#  undef XXH32_freeState
+#  undef XXH32_reset
+#  undef XXH32_update
+#  undef XXH32_digest
+#  undef XXH32_copyState
+#  undef XXH32_canonicalFromHash
+#  undef XXH32_hashFromCanonical
     /* XXH64 */
-#      undef XXH64
-#      undef XXH64_createState
-#      undef XXH64_freeState
-#      undef XXH64_reset
-#      undef XXH64_update
-#      undef XXH64_digest
-#      undef XXH64_copyState
-#      undef XXH64_canonicalFromHash
-#      undef XXH64_hashFromCanonical
+#  undef XXH64
+#  undef XXH64_createState
+#  undef XXH64_freeState
+#  undef XXH64_reset
+#  undef XXH64_update
+#  undef XXH64_digest
+#  undef XXH64_copyState
+#  undef XXH64_canonicalFromHash
+#  undef XXH64_hashFromCanonical
     /* XXH3_64bits */
-#      undef XXH3_64bits
-#      undef XXH3_64bits_withSecret
-#      undef XXH3_64bits_withSeed
-#      undef XXH3_createState
-#      undef XXH3_freeState
-#      undef XXH3_copyState
-#      undef XXH3_64bits_reset
-#      undef XXH3_64bits_reset_withSeed
-#      undef XXH3_64bits_reset_withSecret
-#      undef XXH3_64bits_update
-#      undef XXH3_64bits_digest
-#      undef XXH3_generateSecret
+#  undef XXH3_64bits
+#  undef XXH3_64bits_withSecret
+#  undef XXH3_64bits_withSeed
+#  undef XXH3_createState
+#  undef XXH3_freeState
+#  undef XXH3_copyState
+#  undef XXH3_64bits_reset
+#  undef XXH3_64bits_reset_withSeed
+#  undef XXH3_64bits_reset_withSecret
+#  undef XXH3_64bits_update
+#  undef XXH3_64bits_digest
+#  undef XXH3_generateSecret
     /* XXH3_128bits */
-#      undef XXH128
-#      undef XXH3_128bits
-#      undef XXH3_128bits_withSeed
-#      undef XXH3_128bits_withSecret
-#      undef XXH3_128bits_reset
-#      undef XXH3_128bits_reset_withSeed
-#      undef XXH3_128bits_reset_withSecret
-#      undef XXH3_128bits_update
-#      undef XXH3_128bits_digest
-#      undef XXH128_isEqual
-#      undef XXH128_cmp
-#      undef XXH128_canonicalFromHash
-#      undef XXH128_hashFromCanonical
+#  undef XXH128
+#  undef XXH3_128bits
+#  undef XXH3_128bits_withSeed
+#  undef XXH3_128bits_withSecret
+#  undef XXH3_128bits_reset
+#  undef XXH3_128bits_reset_withSeed
+#  undef XXH3_128bits_reset_withSecret
+#  undef XXH3_128bits_update
+#  undef XXH3_128bits_digest
+#  undef XXH128_isEqual
+#  undef XXH128_cmp
+#  undef XXH128_canonicalFromHash
+#  undef XXH128_hashFromCanonical
     /* Finally, free the namespace itself */
-#      undef XXH_NAMESPACE
+#  undef XXH_NAMESPACE
 
-
-//#    error "XXH_INLINE_ALL with XXH_NAMESPACE is not supported"
-     /*
-      * Note: Alternative: #undef all symbols (it's a pretty large list).
-      * Without #error: it compiles, but functions are actually not inlined.
-      */
-#  endif
+    /* employ the namespace for XXH_INLINE_ALL */
 #  define XXH_NAMESPACE XXH_INLINE_
    /*
-    * Some identifiers (enums, type names) are not symbols, but they must
-    * still be renamed to avoid redeclaration.
+    * Some identifiers (enums, type names) are not symbols,
+    * but they must nonetheless be renamed to avoid redeclaration.
     * Alternative solution: do not redeclare them.
-    * However, this requires some #ifdefs, and is a more dispersed action.
-    * Meanwhile, renaming can be achieved in a single block
+    * However, this requires some #ifdefs, and has a more dispersed impact.
+    * Meanwhile, renaming can be achieved in a single place.
     */
 #  define XXH_IPREF(Id)   XXH_NAMESPACE ## Id
 #  define XXH_OK XXH_IPREF(XXH_OK)

--- a/xxhash.h
+++ b/xxhash.h
@@ -129,7 +129,60 @@ extern "C" {
     * avoiding naming collision with previous inclusions.
     */
 #  ifdef XXH_NAMESPACE
-#    error "XXH_INLINE_ALL with XXH_NAMESPACE is not supported"
+    /* #undef all symbols, they will be redefined right after */
+#      undef XXH_versionNumber
+    /* XXH32 */
+#      undef XXH32
+#      undef XXH32_createState
+#      undef XXH32_freeState
+#      undef XXH32_reset
+#      undef XXH32_update
+#      undef XXH32_digest
+#      undef XXH32_copyState
+#      undef XXH32_canonicalFromHash
+#      undef XXH32_hashFromCanonical
+    /* XXH64 */
+#      undef XXH64
+#      undef XXH64_createState
+#      undef XXH64_freeState
+#      undef XXH64_reset
+#      undef XXH64_update
+#      undef XXH64_digest
+#      undef XXH64_copyState
+#      undef XXH64_canonicalFromHash
+#      undef XXH64_hashFromCanonical
+    /* XXH3_64bits */
+#      undef XXH3_64bits
+#      undef XXH3_64bits_withSecret
+#      undef XXH3_64bits_withSeed
+#      undef XXH3_createState
+#      undef XXH3_freeState
+#      undef XXH3_copyState
+#      undef XXH3_64bits_reset
+#      undef XXH3_64bits_reset_withSeed
+#      undef XXH3_64bits_reset_withSecret
+#      undef XXH3_64bits_update
+#      undef XXH3_64bits_digest
+#      undef XXH3_generateSecret
+    /* XXH3_128bits */
+#      undef XXH128
+#      undef XXH3_128bits
+#      undef XXH3_128bits_withSeed
+#      undef XXH3_128bits_withSecret
+#      undef XXH3_128bits_reset
+#      undef XXH3_128bits_reset_withSeed
+#      undef XXH3_128bits_reset_withSecret
+#      undef XXH3_128bits_update
+#      undef XXH3_128bits_digest
+#      undef XXH128_isEqual
+#      undef XXH128_cmp
+#      undef XXH128_canonicalFromHash
+#      undef XXH128_hashFromCanonical
+    /* Finally, free the namespace itself */
+#      undef XXH_NAMESPACE
+
+
+//#    error "XXH_INLINE_ALL with XXH_NAMESPACE is not supported"
      /*
       * Note: Alternative: #undef all symbols (it's a pretty large list).
       * Without #error: it compiles, but functions are actually not inlined.
@@ -143,7 +196,7 @@ extern "C" {
     * However, this requires some #ifdefs, and is a more dispersed action.
     * Meanwhile, renaming can be achieved in a single block
     */
-#  define XXH_IPREF(Id)   XXH_INLINE_ ## Id
+#  define XXH_IPREF(Id)   XXH_NAMESPACE ## Id
 #  define XXH_OK XXH_IPREF(XXH_OK)
 #  define XXH_ERROR XXH_IPREF(XXH_ERROR)
 #  define XXH_errorcode XXH_IPREF(XXH_errorcode)


### PR DESCRIPTION
There is no reason to do that intentionally,
as symbols defined with `XXH_NAMESPACE` will not be public and not exist after `XXH_INLINE_ALL`.
This scenario may happen inadvertently through transitive `#include`, or by defining `XXH_NAMESPACE` as a general build macro at compilation time (`CPPFLAGS=-DXXH_NAMESPACE=something_`), thus having a value defined across all units.

This capability, which used to be compatible, is now available again,
and verified in CI using `multiInclude` test.

This scenario happens in [RocksDB](https://github.com/facebook/rocksdb/).