### PR TITLE
set XXH_REROLL=1 on gcc

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1310,13 +1310,13 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
 
 /*!
  * @def XXH_REROLL
- * @brief Whether to reroll `XXH32_finalize` and `XXH64_finalize`.
+ * @brief Whether to reroll `XXH32_finalize`.
  *
- * For performance, `XXH32_finalize` and `XXH64_finalize` use an unrolled loop
+ * For performance, `XXH32_finalize` uses an unrolled loop
  * in the form of a switch statement.
  *
- * This is not always desirable, as it generates larger code, and depending on
- * the architecture, may even be slower
+ * This is not always desirable, as it generates larger code,
+ * and depending on the architecture, may even be slower
  *
  * This is automatically defined with `-Os`/`-Oz` on GCC and Clang.
  */
@@ -1379,7 +1379,9 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
 #endif
 
 #ifndef XXH_REROLL
-#  if defined(__OPTIMIZE_SIZE__)
+#  if defined(__OPTIMIZE_SIZE__) /* -Os, -Oz */ || \
+     (defined(__GNUC__) && !defined(__clang__))
+     /* The if/then loop is preferable to switch/case on gcc (on x64) */
 #    define XXH_REROLL 1
 #  else
 #    define XXH_REROLL 0


### PR DESCRIPTION
but not on `clang`.

The `switch`/`case` unrolling of the avalanche was introduced a few years ago, in attempt to speed up hash of small data.
In the relevant commit, the author states having measured a benefit for `XXH32` on its platform.

Back then, there was no tooling to properly measure performance of hashing on small data.
These tools have been created since.
And they show that, at least for `gcc` on `x64`, it's actually a net _loss_ of performance, rather than a gain.
The situation is different for `clang`, where a small gain is generally measured, though it depends on the scenario.

![image](https://user-images.githubusercontent.com/750081/130521484-4aa92820-ea7d-4b55-add6-be542fa6670d.png)

![image](https://user-images.githubusercontent.com/750081/130521550-12cfd088-6973-4597-b4e2-4010114b5c46.png)

So the situation is not clear-cut, and best trade off may depend on scenario.

For this reason, both strategies (`if` loops, `switch` jump) are preserved in the code,
and the `if` loops are preferred on `gcc` (`XXH_REROLL=1`),
while `switch` jumps are preferred for `clang` and other compilers by default.

Note that users can always manually select their preferred strategy at compilation time.