### PR TITLE
Fix `fallthrough` attribute

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -601,7 +601,7 @@ CPP17 : https://en.cppreference.com/w/cpp/language/attributes/fallthrough
 C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
 */
 
-#if defined (__has_c_attribute)
+#if defined (__has_c_attribute) && defined (__STDC_VERSION__) && (__STDC_VERSION__ > 201710L) /* C2x */
 #   if __has_c_attribute(fallthrough)
 #       define XXH_FALLTHROUGH [[fallthrough]]
 #   endif

--- a/xxhash.h
+++ b/xxhash.h
@@ -615,7 +615,7 @@ C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
 #ifndef XXH_FALLTHROUGH
 #   if defined(__GNUC__) && __GNUC__ >= 7
 #       define XXH_FALLTHROUGH __attribute__ ((fallthrough))
-#   elif defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__  >= 9))
+#   elif defined(__clang__) && (__clang_major__ >= 10)
 #       define XXH_FALLTHROUGH __attribute__ ((fallthrough))
 #   else
 #       define XXH_FALLTHROUGH


### PR DESCRIPTION
There're 2 trivial changes

(1) Fix clang version checking.

Only `clang-10` and later supports GNU style attribute `__attribute__((fallthrough))`.

Without this change, `CC=clang-9 make clean all` fails with the following warning.

```
clang-9 -O3     -c -o xxhash.o xxhash.c
In file included from xxhash.c:43:
./xxhash.h:1959:26: warning: declaration does not declare anything [-Wmissing-declarations]
                         XXH_FALLTHROUGH;
                         ^
./xxhash.h:619:32: note: expanded from macro 'XXH_FALLTHROUGH'
#       define XXH_FALLTHROUGH __attribute__ ((fallthrough))
                               ^
```

Please refer the following Clang documentations for `fallthrough`.

- https://releases.llvm.org/10.0.0/tools/clang/docs/AttributeReference.html#fallthrough
- https://releases.llvm.org/9.0.0/tools/clang/docs/AttributeReference.html#fallthrough
- https://releases.llvm.org/3.9.0/tools/clang/docs/AttributeReference.html#fallthrough-clang-fallthrough


(2) Add `__STDC_VERSION__` checking for `gcc-11 -std=c90 -pedantic`.

`CC=gcc-11 make clean all` reports the following warning as an error.

```
gcc-11 -std=c90 -pedantic -Wno-long-long -Werror -Wall -Wextra -Wconversion -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wformat-security -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wstrict-overflow=2 -c -o xxhash.o xxhash.c

In file included from xxhash.c:43:
xxhash.h: In function ‘XXH32_finalize’:
xxhash.h:557:32: error: ISO C does not support ‘[[]]’ attributes before C2X [-Werror=pedantic]
557 | # define XXH_FALLTHROUGH [[fallthrough]]
```
