### PR TITLE
Add standard static_assert()

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1501,7 +1501,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
 #    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
 #  else
-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { char XXH_sa[(c) ? 1 : -1]; (void) XXH_sa; } while(0)
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { void xxh_sa(int x[1 - 2 * ((c) ? 0 : 1)]); (void) xxh_sa; } while(0)
 #  endif
 #  define XXH_STATIC_ASSERT(c) XXH_STATIC_ASSERT_WITH_MESSAGE(c,#c)
 #endif

--- a/xxhash.h
+++ b/xxhash.h
@@ -1494,7 +1494,17 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #endif
 
 /* note: use after variable declarations */
-#define XXH_STATIC_ASSERT(c)  do { enum { XXH_sa = 1/(int)(!!(c)) }; } while (0)
+#ifndef XXH_STATIC_ASSERT
+#  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)    /* C11 */
+#    include <assert.h>
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) static_assert((c),m)
+#  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) static_assert((c),m)
+#  else
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { struct XXH_sa { char xxh_static_assert[(c) ? 1 : -1]; }; } while (0)
+#  endif
+#  define XXH_STATIC_ASSERT(c) XXH_STATIC_ASSERT_WITH_MESSAGE((c),"XXH_STATIC_ASSERT")
+#endif
 
 /*!
  * @internal

--- a/xxhash.h
+++ b/xxhash.h
@@ -1501,9 +1501,9 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
 #    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
 #  else
-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { void xxh_sa(int x[1 - 2 * ((c) ? 0 : 1)]); (void) xxh_sa; } while(0)
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { struct xxh_sa { char x[(c) ? 1 : -1]; }; } while(0)
 #  endif
-#  define XXH_STATIC_ASSERT(c) XXH_STATIC_ASSERT_WITH_MESSAGE(c,#c)
+#  define XXH_STATIC_ASSERT(c) XXH_STATIC_ASSERT_WITH_MESSAGE((c),#c)
 #endif
 
 /*!

--- a/xxhash.h
+++ b/xxhash.h
@@ -1497,13 +1497,13 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #ifndef XXH_STATIC_ASSERT
 #  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)    /* C11 */
 #    include <assert.h>
-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) static_assert((c),m)
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
 #  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) static_assert((c),m)
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
 #  else
-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { struct XXH_sa { char xxh_static_assert[(c) ? 1 : -1]; }; } while (0)
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { char XXH_sa[(c) ? 1 : -1]; (void) XXH_sa; } while(0)
 #  endif
-#  define XXH_STATIC_ASSERT(c) XXH_STATIC_ASSERT_WITH_MESSAGE((c),"XXH_STATIC_ASSERT")
+#  define XXH_STATIC_ASSERT(c) XXH_STATIC_ASSERT_WITH_MESSAGE(c,#c)
 #endif
 
 /*!


### PR DESCRIPTION
This PR resolves #567.

- Use standard `static_assert()` if available (C11, C++11).
- Change definition of non-standard XXH_STATIC_ASSERT() to support MSVC as a C compiler.

We always need `do { ... } while(0)` to support C11 compilers with `-Wdeclaration-after-statement`.
