### PR TITLE
Replace Unicode character U+2018, U+2019 with U+0027

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -3769,7 +3769,7 @@ XXH3_initCustomSecret_avx512(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
         XXH_ASSERT(((size_t)dest & 63) == 0);
         for (i=0; i < nbRounds; ++i) {
             /* GCC has a bug, _mm512_stream_load_si512 accepts 'void*', not 'void const*',
-             * this will warn "discards ‘const’ qualifier". */
+             * this will warn "discards 'const' qualifier". */
             union {
                 const __m512i* cp;
                 void* p;


### PR DESCRIPTION
The following characters are U+2018 and U+2019.

```
             * this will warn "discards ‘const’ qualifier". */
                                        ^     ^
```

We can safely replace it with 7bit-ASCII compatible character "'" (U+0027).

After landing of this PR, I'd like to send another PR which imports `unicode_lint.sh` and CI test from lz4/lz4#1020.
