### PR TITLE
removed XXH_ACCEPT_NULL_INPUT_POINTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,6 @@ The following macros can be set at compilation time to modify libxxhash's behavi
                          This may also increase performance depending on compiler and architecture.
 - `XXH_REROLL`: Reduces the size of the generated code by not unrolling some loops.
                 Impact on performance may vary, depending on platform and algorithm.
-- `XXH_ACCEPT_NULL_INPUT_POINTER`: if set to `1`, when input is a `NULL` pointer,
-                                   xxHash'd result is the same as a zero-length input
-                                   (instead of a dereference segfault).
-                                   Adds one branch at the beginning of each hash.
 - `XXH_STATIC_LINKING_ONLY`: gives access to the state declaration for static allocation.
                              Incompatible with dynamic linking, due to risks of ABI changes.
 - `XXH_NO_XXH3` : removes symbols related to `XXH3` (both 64 & 128 bits) from generated binary.

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1414,7 +1414,9 @@ XSUM_API int XSUM_main(int argc, char* argv[])
             {
             /* Display version */
             case 'V':
-                XSUM_log(FULL_WELCOME_MESSAGE(exename)); return 0;
+                XSUM_log(FULL_WELCOME_MESSAGE(exename));
+                XSUM_sanityCheck(); 
+                return 0;
 
             /* Display help on XSUM_usage */
             case 'h':


### PR DESCRIPTION
All variants are now directly compatible with `input_ptr==NULL`,
with no extra check nor indirection,
though it now *requires* that, in this case, `len == 0`.