### PR TITLE
prevent clang's detrimental autovectorization of XXH32

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1511,7 +1511,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
  * We also use it to prevent unwanted constant folding for AArch64 in
  * XXH3_initCustomSecret_scalar().
  */
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #  define XXH_COMPILER_GUARD(var) __asm__ __volatile__("" : "+r" (var))
 #else
 #  define XXH_COMPILER_GUARD(var) ((void)0)


### PR DESCRIPTION
when clang is used as the backend compiler of MSVC.

Tested on my laptop, using MSVC 2019 with `clang-12.0` and `AVX2` enabled : 
XXH32 : 2.8 GB/s => 4.5 GB/s