### PR TITLE
Fix XXH3 streaming performance

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -4711,7 +4711,7 @@ XXH3_update(XXH3_state_t* XXH_RESTRICT const state,
          * when operating accumulators directly into state.
          * Operating into stack space seems to enable proper optimization.
          * clang, on the other hand, doesn't seem to need this trick */
-        xxh_u64 acc[8]; memcpy(acc, state->acc, sizeof(acc));
+        XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[8]; memcpy(acc, state->acc, sizeof(acc));
 #else
         xxh_u64* XXH_RESTRICT const acc = state->acc;
 #endif


### PR DESCRIPTION
Fix #516 

XXH3 streaming was significantly slower than one-shot hashing, especially for non-`clang` compilers, such as `gcc` and `MSVC`.
This PR largely fixes the performance difference for large ingestion scenarios.

test : `xxhsum -b21` (`XXH3_stream`)

| platform | compiler | **dev** | **this PR** |
| --- | --- | --- | --- |
| macos laptop | Apple Clang 12.0.5 | 25.9 GB/s | 28.3 GB/s |
| macos laptop | GCC 11.2.0 | 18.8 GB/s | 27.7 GB/s |
| WinVM laptop | Clang 13.0.0 | 23.8 GB/s | 26.2 GB/s |
| WinVM laptop | GCC 11.2.0 | 17.4 GB/s | 25.6 GB/s |
| WinVM laptop | MSVC 19.29 | 14.3 GB/s | 23.2 GB/s |
| Ubu20 desktop | GCC 9.3.0 | 26.1 GB/s | 38.2 GB/s |
| Ubu20 desktop | Clang 10.0.0 | 31.1 GB/s | 33.8 GB/s |
| Win10 desktop | GCC 11.2.0 | 26.8 GB/s | 38.8 GB/s |
| Win10 desktop | Clang 13.0.0 | 37.2 GB/s | 39.8 GB/s |
| Win10 desktop | MSVC 19.16 | 21.5 GB/s | 32.2 GB/s |
