### PR TITLE
separate benchmark functions into their own unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ xxhsum_inlinedXXH
 dispatch
 tests/generate_unicode_test
 
-# compilation chain
+# local conf
 .clang_complete
 
 # Mac OS-X artefacts

--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,15 @@ XXHSUM_SRC_DIR = cli
 XXHSUM_SPLIT_SRCS = $(XXHSUM_SRC_DIR)/xxhsum.c \
                     $(XXHSUM_SRC_DIR)/xsum_os_specific.c \
                     $(XXHSUM_SRC_DIR)/xsum_output.c \
-                    $(XXHSUM_SRC_DIR)/xsum_sanity_check.c
+                    $(XXHSUM_SRC_DIR)/xsum_sanity_check.c \
+                    $(XXHSUM_SRC_DIR)/xsum_bench.c
 XXHSUM_SPLIT_OBJS = $(XXHSUM_SPLIT_SRCS:.c=.o)
 XXHSUM_HEADERS = $(XXHSUM_SRC_DIR)/xsum_config.h \
                  $(XXHSUM_SRC_DIR)/xsum_arch.h \
                  $(XXHSUM_SRC_DIR)/xsum_os_specific.h \
                  $(XXHSUM_SRC_DIR)/xsum_output.h \
-                 $(XXHSUM_SRC_DIR)/xsum_sanity_check.h
+                 $(XXHSUM_SRC_DIR)/xsum_sanity_check.h \
+                 $(XXHSUM_SRC_DIR)/xsum_bench.h
 
 ## generate CLI and libraries in release mode (default for `make`)
 .PHONY: default

--- a/cli/xsum_bench.c
+++ b/cli/xsum_bench.c
@@ -1,0 +1,435 @@
+/*
+ * xum_bench - Benchmark functions for xxhsum
+ * Copyright (C) 2013-2021 Yann Collet
+ *
+ * GPL v2 License
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * You can contact the author at:
+ *   - xxHash homepage: https://www.xxhash.com
+ *   - xxHash source repository: https://github.com/Cyan4973/xxHash
+ */
+
+#include "xsum_config.h"
+#include "xsum_output.h"
+#include "xsum_bench.h"
+#include "xsum_sanity_check.h" /* XSUM_fillTestBuffer */
+#include "xsum_os_specific.h"  /* XSUM_getFileSize */
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#ifndef XXH_STATIC_LINKING_ONLY
+#  define XXH_STATIC_LINKING_ONLY
+#endif
+#include "../xxhash.h"
+
+#include <stdio.h>  /* FILE */
+#include <time.h>   /* clock_t, clock, CLOCKS_PER_SEC */
+#include <errno.h>  /* errno */
+
+#define TIMELOOP_S 1
+#define TIMELOOP  (TIMELOOP_S * CLOCKS_PER_SEC)   /* target timing per iteration */
+#define TIMELOOP_MIN (TIMELOOP / 2)               /* minimum timing to validate a result */
+
+#define MAX_MEM    (2 GB - 64 MB)
+
+static clock_t XSUM_clockSpan( clock_t start )
+{
+    return clock() - start;   /* works even if overflow; Typical max span ~ 30 mn */
+}
+
+static size_t XSUM_findMaxMem(XSUM_U64 requiredMem)
+{
+    size_t const step = 64 MB;
+    void* testmem = NULL;
+
+    requiredMem = (((requiredMem >> 26) + 1) << 26);
+    requiredMem += 2*step;
+    if (requiredMem > MAX_MEM) requiredMem = MAX_MEM;
+
+    while (!testmem) {
+        if (requiredMem > step) requiredMem -= step;
+        else requiredMem >>= 1;
+        testmem = malloc ((size_t)requiredMem);
+    }
+    free (testmem);
+
+    /* keep some space available */
+    if (requiredMem > step) requiredMem -= step;
+    else requiredMem >>= 1;
+
+    return (size_t)requiredMem;
+}
+
+/*
+ * A secret buffer used for benchmarking XXH3's withSecret variants.
+ *
+ * In order for the bench to be realistic, the secret buffer would need to be
+ * pre-generated.
+ *
+ * Adding a pointer to the parameter list would be messy.
+ */
+static XSUM_U8 g_benchSecretBuf[XXH3_SECRET_SIZE_MIN];
+
+/*
+ * Wrappers for the benchmark.
+ *
+ * If you would like to add other hashes to the bench, create a wrapper and add
+ * it to the g_hashesToBench table. It will automatically be added.
+ */
+typedef XSUM_U32 (*hashFunction)(const void* buffer, size_t bufferSize, XSUM_U32 seed);
+
+static XSUM_U32 localXXH32(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return XXH32(buffer, bufferSize, seed);
+}
+static XSUM_U32 localXXH32_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH32_state_t state;
+    (void)seed;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH32_digest(&state);
+}
+static XSUM_U32 localXXH64(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return (XSUM_U32)XXH64(buffer, bufferSize, seed);
+}
+static XSUM_U32 localXXH64_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH64_state_t state;
+    (void)seed;
+    XXH64_reset(&state, seed);
+    XXH64_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH64_digest(&state);
+}
+static XSUM_U32 localXXH3_64b(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)XXH3_64bits(buffer, bufferSize);
+}
+static XSUM_U32 localXXH3_64b_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return (XSUM_U32)XXH3_64bits_withSeed(buffer, bufferSize, seed);
+}
+static XSUM_U32 localXXH3_64b_secret(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)XXH3_64bits_withSecret(buffer, bufferSize, g_benchSecretBuf, sizeof(g_benchSecretBuf));
+}
+static XSUM_U32 localXXH3_128b(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)(XXH3_128bits(buffer, bufferSize).low64);
+}
+static XSUM_U32 localXXH3_128b_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return (XSUM_U32)(XXH3_128bits_withSeed(buffer, bufferSize, seed).low64);
+}
+static XSUM_U32 localXXH3_128b_secret(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)(XXH3_128bits_withSecret(buffer, bufferSize, g_benchSecretBuf, sizeof(g_benchSecretBuf)).low64);
+}
+static XSUM_U32 localXXH3_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    (void)seed;
+    XXH3_64bits_reset(&state);
+    XXH3_64bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH3_64bits_digest(&state);
+}
+static XSUM_U32 localXXH3_stream_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    XXH3_INITSTATE(&state);
+    XXH3_64bits_reset_withSeed(&state, (XXH64_hash_t)seed);
+    XXH3_64bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH3_64bits_digest(&state);
+}
+static XSUM_U32 localXXH128_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    (void)seed;
+    XXH3_128bits_reset(&state);
+    XXH3_128bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)(XXH3_128bits_digest(&state).low64);
+}
+static XSUM_U32 localXXH128_stream_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    XXH3_INITSTATE(&state);
+    XXH3_128bits_reset_withSeed(&state, (XXH64_hash_t)seed);
+    XXH3_128bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)(XXH3_128bits_digest(&state).low64);
+}
+
+
+typedef struct {
+    const char*  name;
+    hashFunction func;
+} hashInfo;
+
+static const hashInfo g_hashesToBench[] = {
+    { "XXH32",             &localXXH32 },
+    { "XXH64",             &localXXH64 },
+    { "XXH3_64b",          &localXXH3_64b },
+    { "XXH3_64b w/seed",   &localXXH3_64b_seeded },
+    { "XXH3_64b w/secret", &localXXH3_64b_secret },
+    { "XXH128",            &localXXH3_128b },
+    { "XXH128 w/seed",     &localXXH3_128b_seeded },
+    { "XXH128 w/secret",   &localXXH3_128b_secret },
+    { "XXH32_stream",      &localXXH32_stream },
+    { "XXH64_stream",      &localXXH64_stream },
+    { "XXH3_stream",       &localXXH3_stream },
+    { "XXH3_stream w/seed",&localXXH3_stream_seeded },
+    { "XXH128_stream",     &localXXH128_stream },
+    { "XXH128_stream w/seed",&localXXH128_stream_seeded },
+};
+#define NB_HASHFUNC (sizeof(g_hashesToBench) / sizeof(*g_hashesToBench))
+
+#define NB_TESTFUNC (1 + 2 * NB_HASHFUNC)
+int const g_nbTestFunctions = NB_TESTFUNC;
+char g_testIDs[NB_TESTFUNC] = { 0 };
+const char k_testIDs_default[NB_TESTFUNC] = { 0,
+        1 /*XXH32*/, 0,
+        1 /*XXH64*/, 0,
+        1 /*XXH3*/, 0, 0, 0, 0, 0,
+        1 /*XXH128*/ };
+
+int g_nbIterations = NBLOOPS_DEFAULT;
+#define HASHNAME_MAX 29
+static void XSUM_benchHash(hashFunction h, const char* hName, int testID,
+                           const void* buffer, size_t bufferSize)
+{
+    XSUM_U32 nbh_perIteration = (XSUM_U32)((300 MB) / (bufferSize+1)) + 1;  /* first iteration conservatively aims for 300 MB/s */
+    int iterationNb, nbIterations = g_nbIterations + !g_nbIterations /* min 1 */;
+    double fastestH = 100000000.;
+    assert(HASHNAME_MAX > 2);
+    XSUM_logVerbose(2, "\r%80s\r", "");       /* Clean display line */
+
+    for (iterationNb = 1; iterationNb <= nbIterations; iterationNb++) {
+        XSUM_U32 r=0;
+        clock_t cStart;
+
+        XSUM_logVerbose(2, "%2i-%-*.*s : %10u ->\r",
+                        iterationNb,
+                        HASHNAME_MAX, HASHNAME_MAX, hName,
+                        (unsigned)bufferSize);
+        cStart = clock();
+        while (clock() == cStart);   /* starts clock() at its exact beginning */
+        cStart = clock();
+
+        {   XSUM_U32 u;
+            for (u=0; u<nbh_perIteration; u++)
+                r += h(buffer, bufferSize, u);
+        }
+        if (r==0) XSUM_logVerbose(3,".\r");  /* do something with r to defeat compiler "optimizing" hash away */
+
+        {   clock_t const nbTicks = XSUM_clockSpan(cStart);
+            double const ticksPerHash = ((double)nbTicks / TIMELOOP) / nbh_perIteration;
+            /*
+             * clock() is the only decent portable timer, but it isn't very
+             * precise.
+             *
+             * Sometimes, this lack of precision is enough that the benchmark
+             * finishes before there are enough ticks to get a meaningful result.
+             *
+             * For example, on a Core 2 Duo (without any sort of Turbo Boost),
+             * the imprecise timer caused peculiar results like so:
+             *
+             *    XXH3_64b                   4800.0 MB/s // conveniently even
+             *    XXH3_64b unaligned         4800.0 MB/s
+             *    XXH3_64b seeded            9600.0 MB/s // magical 2x speedup?!
+             *    XXH3_64b seeded unaligned  4800.0 MB/s
+             *
+             * If we sense a suspiciously low number of ticks, we increase the
+             * iterations until we can get something meaningful.
+             */
+            if (nbTicks < TIMELOOP_MIN) {
+                /* Not enough time spent in benchmarking, risk of rounding bias */
+                if (nbTicks == 0) { /* faster than resolution timer */
+                    nbh_perIteration *= 100;
+                } else {
+                    /*
+                     * update nbh_perIteration so that the next round lasts
+                     * approximately 1 second.
+                     */
+                    double nbh_perSecond = (1 / ticksPerHash) + 1;
+                    if (nbh_perSecond > (double)(4000U<<20)) nbh_perSecond = (double)(4000U<<20);   /* avoid overflow */
+                    nbh_perIteration = (XSUM_U32)nbh_perSecond;
+                }
+                /* g_nbIterations==0 => quick evaluation, no claim of accuracy */
+                if (g_nbIterations>0) {
+                    iterationNb--;   /* new round for a more accurate speed evaluation */
+                    continue;
+                }
+            }
+            if (ticksPerHash < fastestH) fastestH = ticksPerHash;
+            if (fastestH>0.) { /* avoid div by zero */
+                XSUM_logVerbose(2, "%2i-%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \r",
+                            iterationNb,
+                            HASHNAME_MAX, HASHNAME_MAX, hName,
+                            (unsigned)bufferSize,
+                            (double)1 / fastestH,
+                            ((double)bufferSize / (1 MB)) / fastestH);
+        }   }
+        {   double nbh_perSecond = (1 / fastestH) + 1;
+            if (nbh_perSecond > (double)(4000U<<20)) nbh_perSecond = (double)(4000U<<20);   /* avoid overflow */
+            nbh_perIteration = (XSUM_U32)nbh_perSecond;
+        }
+    }
+    XSUM_logVerbose(1, "%2i#%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \n",
+                    testID,
+                    HASHNAME_MAX, HASHNAME_MAX, hName,
+                    (unsigned)bufferSize,
+                    (double)1 / fastestH,
+                    ((double)bufferSize / (1 MB)) / fastestH);
+    if (XSUM_logLevel<1)
+        XSUM_logVerbose(0, "%u, ", (unsigned)((double)1 / fastestH));
+}
+
+
+/*
+ * Allocates a string containing s1 and s2 concatenated. Acts like strdup.
+ * The result must be freed.
+ */
+static char* XSUM_strcatDup(const char* s1, const char* s2)
+{
+    assert(s1 != NULL);
+    assert(s2 != NULL);
+    {   size_t len1 = strlen(s1);
+        size_t len2 = strlen(s2);
+        char* buf = (char*)malloc(len1 + len2 + 1);
+        if (buf != NULL) {
+            /* strcpy(buf, s1) */
+            memcpy(buf, s1, len1);
+            /* strcat(buf, s2) */
+            memcpy(buf + len1, s2, len2 + 1);
+        }
+        return buf;
+    }
+}
+
+
+/*!
+ * XSUM_benchMem():
+ * buffer: Must be 16-byte aligned.
+ * The real allocated size of buffer is supposed to be >= (bufferSize+3).
+ * returns: 0 on success, 1 if error (invalid mode selected)
+ */
+static void XSUM_benchMem(const void* buffer, size_t bufferSize)
+{
+    assert((((size_t)buffer) & 15) == 0);  /* ensure alignment */
+    XSUM_fillTestBuffer(g_benchSecretBuf, sizeof(g_benchSecretBuf));
+    {   int i;
+        for (i = 1; i < (int)NB_TESTFUNC; i++) {
+            int const hashFuncID = (i-1) / 2;
+            assert(g_hashesToBench[hashFuncID].name != NULL);
+            if (g_testIDs[i] == 0) continue;
+            /* aligned */
+            if ((i % 2) == 1) {
+                XSUM_benchHash(g_hashesToBench[hashFuncID].func, g_hashesToBench[hashFuncID].name, i, buffer, bufferSize);
+            }
+            /* unaligned */
+            if ((i % 2) == 0) {
+                /* Append "unaligned". */
+                char* const hashNameBuf = XSUM_strcatDup(g_hashesToBench[hashFuncID].name, " unaligned");
+                assert(hashNameBuf != NULL);
+                XSUM_benchHash(g_hashesToBench[hashFuncID].func, hashNameBuf, i, ((const char*)buffer)+3, bufferSize);
+                free(hashNameBuf);
+            }
+    }   }
+}
+
+static size_t XSUM_selectBenchedSize(const char* fileName)
+{
+    XSUM_U64 const inFileSize = XSUM_getFileSize(fileName);
+    size_t benchedSize = (size_t) XSUM_findMaxMem(inFileSize);
+    if ((XSUM_U64)benchedSize > inFileSize) benchedSize = (size_t)inFileSize;
+    if (benchedSize < inFileSize) {
+        XSUM_log("Not enough memory for '%s' full size; testing %i MB only...\n", fileName, (int)(benchedSize>>20));
+    }
+    return benchedSize;
+}
+
+
+int XSUM_benchFiles(const char* fileNamesTable[], int nbFiles)
+{
+    int fileIdx;
+    for (fileIdx=0; fileIdx<nbFiles; fileIdx++) {
+        const char* const inFileName = fileNamesTable[fileIdx];
+        assert(inFileName != NULL);
+
+        {   FILE* const inFile = XSUM_fopen( inFileName, "rb" );
+            size_t const benchedSize = XSUM_selectBenchedSize(inFileName);
+            char* const buffer = (char*)calloc(benchedSize+16+3, 1);
+            void* const alignedBuffer = (buffer+15) - (((size_t)(buffer+15)) & 0xF);  /* align on next 16 bytes */
+
+            /* Checks */
+            if (inFile==NULL){
+                XSUM_log("Error: Could not open '%s': %s.\n", inFileName, strerror(errno));
+                free(buffer);
+                exit(11);
+            }
+            if(!buffer) {
+                XSUM_log("\nError: Out of memory.\n");
+                fclose(inFile);
+                exit(12);
+            }
+
+            /* Fill input buffer */
+            {   size_t const readSize = fread(alignedBuffer, 1, benchedSize, inFile);
+                fclose(inFile);
+                if(readSize != benchedSize) {
+                    XSUM_log("\nError: Could not read '%s': %s.\n", inFileName, strerror(errno));
+                    free(buffer);
+                    exit(13);
+            }   }
+
+            /* bench */
+            XSUM_benchMem(alignedBuffer, benchedSize);
+
+            free(buffer);
+    }   }
+    return 0;
+}
+
+
+int XSUM_benchInternal(size_t keySize)
+{
+    void* const buffer = calloc(keySize+16+3, 1);
+    if (buffer == NULL) {
+        XSUM_log("\nError: Out of memory.\n");
+        exit(12);
+    }
+
+    {   const void* const alignedBuffer = ((char*)buffer+15) - (((size_t)((char*)buffer+15)) & 0xF);  /* align on next 16 bytes */
+
+        /* bench */
+        XSUM_logVerbose(1, "Sample of ");
+        if (keySize > 10 KB) {
+            XSUM_logVerbose(1, "%u KB", (unsigned)(keySize >> 10));
+        } else {
+            XSUM_logVerbose(1, "%u bytes", (unsigned)keySize);
+        }
+        XSUM_logVerbose(1, "...        \n");
+
+        XSUM_benchMem(alignedBuffer, keySize);
+        free(buffer);
+    }
+    return 0;
+}

--- a/cli/xsum_bench.c
+++ b/cli/xsum_bench.c
@@ -1,0 +1,435 @@
+/*
+ * xsum_bench - Benchmark functions for xxhsum
+ * Copyright (C) 2013-2021 Yann Collet
+ *
+ * GPL v2 License
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * You can contact the author at:
+ *   - xxHash homepage: https://www.xxhash.com
+ *   - xxHash source repository: https://github.com/Cyan4973/xxHash
+ */
+
+#include "xsum_config.h"
+#include "xsum_output.h"
+#include "xsum_bench.h"
+#include "xsum_sanity_check.h" /* XSUM_fillTestBuffer */
+#include "xsum_os_specific.h"  /* XSUM_getFileSize */
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#ifndef XXH_STATIC_LINKING_ONLY
+#  define XXH_STATIC_LINKING_ONLY
+#endif
+#include "../xxhash.h"
+
+#include <stdio.h>  /* FILE */
+#include <time.h>   /* clock_t, clock, CLOCKS_PER_SEC */
+#include <errno.h>  /* errno */
+
+#define TIMELOOP_S 1
+#define TIMELOOP  (TIMELOOP_S * CLOCKS_PER_SEC)   /* target timing per iteration */
+#define TIMELOOP_MIN (TIMELOOP / 2)               /* minimum timing to validate a result */
+
+#define MAX_MEM    (2 GB - 64 MB)
+
+static clock_t XSUM_clockSpan( clock_t start )
+{
+    return clock() - start;   /* works even if overflow; Typical max span ~ 30 mn */
+}
+
+static size_t XSUM_findMaxMem(XSUM_U64 requiredMem)
+{
+    size_t const step = 64 MB;
+    void* testmem = NULL;
+
+    requiredMem = (((requiredMem >> 26) + 1) << 26);
+    requiredMem += 2*step;
+    if (requiredMem > MAX_MEM) requiredMem = MAX_MEM;
+
+    while (!testmem) {
+        if (requiredMem > step) requiredMem -= step;
+        else requiredMem >>= 1;
+        testmem = malloc ((size_t)requiredMem);
+    }
+    free (testmem);
+
+    /* keep some space available */
+    if (requiredMem > step) requiredMem -= step;
+    else requiredMem >>= 1;
+
+    return (size_t)requiredMem;
+}
+
+/*
+ * A secret buffer used for benchmarking XXH3's withSecret variants.
+ *
+ * In order for the bench to be realistic, the secret buffer would need to be
+ * pre-generated.
+ *
+ * Adding a pointer to the parameter list would be messy.
+ */
+static XSUM_U8 g_benchSecretBuf[XXH3_SECRET_SIZE_MIN];
+
+/*
+ * Wrappers for the benchmark.
+ *
+ * If you would like to add other hashes to the bench, create a wrapper and add
+ * it to the g_hashesToBench table. It will automatically be added.
+ */
+typedef XSUM_U32 (*hashFunction)(const void* buffer, size_t bufferSize, XSUM_U32 seed);
+
+static XSUM_U32 localXXH32(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return XXH32(buffer, bufferSize, seed);
+}
+static XSUM_U32 localXXH32_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH32_state_t state;
+    (void)seed;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH32_digest(&state);
+}
+static XSUM_U32 localXXH64(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return (XSUM_U32)XXH64(buffer, bufferSize, seed);
+}
+static XSUM_U32 localXXH64_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH64_state_t state;
+    (void)seed;
+    XXH64_reset(&state, seed);
+    XXH64_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH64_digest(&state);
+}
+static XSUM_U32 localXXH3_64b(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)XXH3_64bits(buffer, bufferSize);
+}
+static XSUM_U32 localXXH3_64b_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return (XSUM_U32)XXH3_64bits_withSeed(buffer, bufferSize, seed);
+}
+static XSUM_U32 localXXH3_64b_secret(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)XXH3_64bits_withSecret(buffer, bufferSize, g_benchSecretBuf, sizeof(g_benchSecretBuf));
+}
+static XSUM_U32 localXXH3_128b(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)(XXH3_128bits(buffer, bufferSize).low64);
+}
+static XSUM_U32 localXXH3_128b_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    return (XSUM_U32)(XXH3_128bits_withSeed(buffer, bufferSize, seed).low64);
+}
+static XSUM_U32 localXXH3_128b_secret(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    (void)seed;
+    return (XSUM_U32)(XXH3_128bits_withSecret(buffer, bufferSize, g_benchSecretBuf, sizeof(g_benchSecretBuf)).low64);
+}
+static XSUM_U32 localXXH3_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    (void)seed;
+    XXH3_64bits_reset(&state);
+    XXH3_64bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH3_64bits_digest(&state);
+}
+static XSUM_U32 localXXH3_stream_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    XXH3_INITSTATE(&state);
+    XXH3_64bits_reset_withSeed(&state, (XXH64_hash_t)seed);
+    XXH3_64bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)XXH3_64bits_digest(&state);
+}
+static XSUM_U32 localXXH128_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    (void)seed;
+    XXH3_128bits_reset(&state);
+    XXH3_128bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)(XXH3_128bits_digest(&state).low64);
+}
+static XSUM_U32 localXXH128_stream_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
+{
+    XXH3_state_t state;
+    XXH3_INITSTATE(&state);
+    XXH3_128bits_reset_withSeed(&state, (XXH64_hash_t)seed);
+    XXH3_128bits_update(&state, buffer, bufferSize);
+    return (XSUM_U32)(XXH3_128bits_digest(&state).low64);
+}
+
+
+typedef struct {
+    const char*  name;
+    hashFunction func;
+} hashInfo;
+
+static const hashInfo g_hashesToBench[] = {
+    { "XXH32",             &localXXH32 },
+    { "XXH64",             &localXXH64 },
+    { "XXH3_64b",          &localXXH3_64b },
+    { "XXH3_64b w/seed",   &localXXH3_64b_seeded },
+    { "XXH3_64b w/secret", &localXXH3_64b_secret },
+    { "XXH128",            &localXXH3_128b },
+    { "XXH128 w/seed",     &localXXH3_128b_seeded },
+    { "XXH128 w/secret",   &localXXH3_128b_secret },
+    { "XXH32_stream",      &localXXH32_stream },
+    { "XXH64_stream",      &localXXH64_stream },
+    { "XXH3_stream",       &localXXH3_stream },
+    { "XXH3_stream w/seed",&localXXH3_stream_seeded },
+    { "XXH128_stream",     &localXXH128_stream },
+    { "XXH128_stream w/seed",&localXXH128_stream_seeded },
+};
+#define NB_HASHFUNC (sizeof(g_hashesToBench) / sizeof(*g_hashesToBench))
+
+#define NB_TESTFUNC (1 + 2 * NB_HASHFUNC)
+int const g_nbTestFunctions = NB_TESTFUNC;
+char g_testIDs[NB_TESTFUNC] = { 0 };
+const char k_testIDs_default[NB_TESTFUNC] = { 0,
+        1 /*XXH32*/, 0,
+        1 /*XXH64*/, 0,
+        1 /*XXH3*/, 0, 0, 0, 0, 0,
+        1 /*XXH128*/ };
+
+int g_nbIterations = NBLOOPS_DEFAULT;
+#define HASHNAME_MAX 29
+static void XSUM_benchHash(hashFunction h, const char* hName, int testID,
+                           const void* buffer, size_t bufferSize)
+{
+    XSUM_U32 nbh_perIteration = (XSUM_U32)((300 MB) / (bufferSize+1)) + 1;  /* first iteration conservatively aims for 300 MB/s */
+    int iterationNb, nbIterations = g_nbIterations + !g_nbIterations /* min 1 */;
+    double fastestH = 100000000.;
+    assert(HASHNAME_MAX > 2);
+    XSUM_logVerbose(2, "\r%80s\r", "");       /* Clean display line */
+
+    for (iterationNb = 1; iterationNb <= nbIterations; iterationNb++) {
+        XSUM_U32 r=0;
+        clock_t cStart;
+
+        XSUM_logVerbose(2, "%2i-%-*.*s : %10u ->\r",
+                        iterationNb,
+                        HASHNAME_MAX, HASHNAME_MAX, hName,
+                        (unsigned)bufferSize);
+        cStart = clock();
+        while (clock() == cStart);   /* starts clock() at its exact beginning */
+        cStart = clock();
+
+        {   XSUM_U32 u;
+            for (u=0; u<nbh_perIteration; u++)
+                r += h(buffer, bufferSize, u);
+        }
+        if (r==0) XSUM_logVerbose(3,".\r");  /* do something with r to defeat compiler "optimizing" hash away */
+
+        {   clock_t const nbTicks = XSUM_clockSpan(cStart);
+            double const ticksPerHash = ((double)nbTicks / TIMELOOP) / nbh_perIteration;
+            /*
+             * clock() is the only decent portable timer, but it isn't very
+             * precise.
+             *
+             * Sometimes, this lack of precision is enough that the benchmark
+             * finishes before there are enough ticks to get a meaningful result.
+             *
+             * For example, on a Core 2 Duo (without any sort of Turbo Boost),
+             * the imprecise timer caused peculiar results like so:
+             *
+             *    XXH3_64b                   4800.0 MB/s // conveniently even
+             *    XXH3_64b unaligned         4800.0 MB/s
+             *    XXH3_64b seeded            9600.0 MB/s // magical 2x speedup?!
+             *    XXH3_64b seeded unaligned  4800.0 MB/s
+             *
+             * If we sense a suspiciously low number of ticks, we increase the
+             * iterations until we can get something meaningful.
+             */
+            if (nbTicks < TIMELOOP_MIN) {
+                /* Not enough time spent in benchmarking, risk of rounding bias */
+                if (nbTicks == 0) { /* faster than resolution timer */
+                    nbh_perIteration *= 100;
+                } else {
+                    /*
+                     * update nbh_perIteration so that the next round lasts
+                     * approximately 1 second.
+                     */
+                    double nbh_perSecond = (1 / ticksPerHash) + 1;
+                    if (nbh_perSecond > (double)(4000U<<20)) nbh_perSecond = (double)(4000U<<20);   /* avoid overflow */
+                    nbh_perIteration = (XSUM_U32)nbh_perSecond;
+                }
+                /* g_nbIterations==0 => quick evaluation, no claim of accuracy */
+                if (g_nbIterations>0) {
+                    iterationNb--;   /* new round for a more accurate speed evaluation */
+                    continue;
+                }
+            }
+            if (ticksPerHash < fastestH) fastestH = ticksPerHash;
+            if (fastestH>0.) { /* avoid div by zero */
+                XSUM_logVerbose(2, "%2i-%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \r",
+                            iterationNb,
+                            HASHNAME_MAX, HASHNAME_MAX, hName,
+                            (unsigned)bufferSize,
+                            (double)1 / fastestH,
+                            ((double)bufferSize / (1 MB)) / fastestH);
+        }   }
+        {   double nbh_perSecond = (1 / fastestH) + 1;
+            if (nbh_perSecond > (double)(4000U<<20)) nbh_perSecond = (double)(4000U<<20);   /* avoid overflow */
+            nbh_perIteration = (XSUM_U32)nbh_perSecond;
+        }
+    }
+    XSUM_logVerbose(1, "%2i#%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \n",
+                    testID,
+                    HASHNAME_MAX, HASHNAME_MAX, hName,
+                    (unsigned)bufferSize,
+                    (double)1 / fastestH,
+                    ((double)bufferSize / (1 MB)) / fastestH);
+    if (XSUM_logLevel<1)
+        XSUM_logVerbose(0, "%u, ", (unsigned)((double)1 / fastestH));
+}
+
+
+/*
+ * Allocates a string containing s1 and s2 concatenated. Acts like strdup.
+ * The result must be freed.
+ */
+static char* XSUM_strcatDup(const char* s1, const char* s2)
+{
+    assert(s1 != NULL);
+    assert(s2 != NULL);
+    {   size_t len1 = strlen(s1);
+        size_t len2 = strlen(s2);
+        char* buf = (char*)malloc(len1 + len2 + 1);
+        if (buf != NULL) {
+            /* strcpy(buf, s1) */
+            memcpy(buf, s1, len1);
+            /* strcat(buf, s2) */
+            memcpy(buf + len1, s2, len2 + 1);
+        }
+        return buf;
+    }
+}
+
+
+/*!
+ * XSUM_benchMem():
+ * buffer: Must be 16-byte aligned.
+ * The real allocated size of buffer is supposed to be >= (bufferSize+3).
+ * returns: 0 on success, 1 if error (invalid mode selected)
+ */
+static void XSUM_benchMem(const void* buffer, size_t bufferSize)
+{
+    assert((((size_t)buffer) & 15) == 0);  /* ensure alignment */
+    XSUM_fillTestBuffer(g_benchSecretBuf, sizeof(g_benchSecretBuf));
+    {   int i;
+        for (i = 1; i < (int)NB_TESTFUNC; i++) {
+            int const hashFuncID = (i-1) / 2;
+            assert(g_hashesToBench[hashFuncID].name != NULL);
+            if (g_testIDs[i] == 0) continue;
+            /* aligned */
+            if ((i % 2) == 1) {
+                XSUM_benchHash(g_hashesToBench[hashFuncID].func, g_hashesToBench[hashFuncID].name, i, buffer, bufferSize);
+            }
+            /* unaligned */
+            if ((i % 2) == 0) {
+                /* Append "unaligned". */
+                char* const hashNameBuf = XSUM_strcatDup(g_hashesToBench[hashFuncID].name, " unaligned");
+                assert(hashNameBuf != NULL);
+                XSUM_benchHash(g_hashesToBench[hashFuncID].func, hashNameBuf, i, ((const char*)buffer)+3, bufferSize);
+                free(hashNameBuf);
+            }
+    }   }
+}
+
+static size_t XSUM_selectBenchedSize(const char* fileName)
+{
+    XSUM_U64 const inFileSize = XSUM_getFileSize(fileName);
+    size_t benchedSize = (size_t) XSUM_findMaxMem(inFileSize);
+    if ((XSUM_U64)benchedSize > inFileSize) benchedSize = (size_t)inFileSize;
+    if (benchedSize < inFileSize) {
+        XSUM_log("Not enough memory for '%s' full size; testing %i MB only...\n", fileName, (int)(benchedSize>>20));
+    }
+    return benchedSize;
+}
+
+
+int XSUM_benchFiles(const char* fileNamesTable[], int nbFiles)
+{
+    int fileIdx;
+    for (fileIdx=0; fileIdx<nbFiles; fileIdx++) {
+        const char* const inFileName = fileNamesTable[fileIdx];
+        assert(inFileName != NULL);
+
+        {   FILE* const inFile = XSUM_fopen( inFileName, "rb" );
+            size_t const benchedSize = XSUM_selectBenchedSize(inFileName);
+            char* const buffer = (char*)calloc(benchedSize+16+3, 1);
+            void* const alignedBuffer = (buffer+15) - (((size_t)(buffer+15)) & 0xF);  /* align on next 16 bytes */
+
+            /* Checks */
+            if (inFile==NULL){
+                XSUM_log("Error: Could not open '%s': %s.\n", inFileName, strerror(errno));
+                free(buffer);
+                exit(11);
+            }
+            if(!buffer) {
+                XSUM_log("\nError: Out of memory.\n");
+                fclose(inFile);
+                exit(12);
+            }
+
+            /* Fill input buffer */
+            {   size_t const readSize = fread(alignedBuffer, 1, benchedSize, inFile);
+                fclose(inFile);
+                if(readSize != benchedSize) {
+                    XSUM_log("\nError: Could not read '%s': %s.\n", inFileName, strerror(errno));
+                    free(buffer);
+                    exit(13);
+            }   }
+
+            /* bench */
+            XSUM_benchMem(alignedBuffer, benchedSize);
+
+            free(buffer);
+    }   }
+    return 0;
+}
+
+
+int XSUM_benchInternal(size_t keySize)
+{
+    void* const buffer = calloc(keySize+16+3, 1);
+    if (buffer == NULL) {
+        XSUM_log("\nError: Out of memory.\n");
+        exit(12);
+    }
+
+    {   const void* const alignedBuffer = ((char*)buffer+15) - (((size_t)((char*)buffer+15)) & 0xF);  /* align on next 16 bytes */
+
+        /* bench */
+        XSUM_logVerbose(1, "Sample of ");
+        if (keySize > 10 KB) {
+            XSUM_logVerbose(1, "%u KB", (unsigned)(keySize >> 10));
+        } else {
+            XSUM_logVerbose(1, "%u bytes", (unsigned)keySize);
+        }
+        XSUM_logVerbose(1, "...        \n");
+
+        XSUM_benchMem(alignedBuffer, keySize);
+        free(buffer);
+    }
+    return 0;
+}

--- a/cli/xsum_bench.c
+++ b/cli/xsum_bench.c
@@ -23,20 +23,18 @@
  *   - xxHash source repository: https://github.com/Cyan4973/xxHash
  */
 
-#include "xsum_config.h"
-#include "xsum_output.h"
+#include "xsum_output.h"  /* XSUM_logLevel */
 #include "xsum_bench.h"
 #include "xsum_sanity_check.h" /* XSUM_fillTestBuffer */
 #include "xsum_os_specific.h"  /* XSUM_getFileSize */
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>
 #ifndef XXH_STATIC_LINKING_ONLY
 #  define XXH_STATIC_LINKING_ONLY
 #endif
 #include "../xxhash.h"
 
-#include <stdio.h>  /* FILE */
+#include <stdlib.h>  /* malloc, free */
+#include <assert.h>
+#include <string.h>  /* strlen, memcpy */
 #include <time.h>   /* clock_t, clock, CLOCKS_PER_SEC */
 #include <errno.h>  /* errno */
 

--- a/cli/xsum_bench.h
+++ b/cli/xsum_bench.h
@@ -1,0 +1,51 @@
+/*
+ * xsum_bench - Benchmark functions for xxhsum
+ * Copyright (C) 2013-2021 Yann Collet
+ *
+ * GPL v2 License
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * You can contact the author at:
+ *   - xxHash homepage: https://www.xxhash.com
+ *   - xxHash source repository: https://github.com/Cyan4973/xxHash
+ */
+
+#ifndef XSUM_BENCH_H
+#define XSUM_BENCH_H
+
+#include <stddef.h>  /* size_t */
+
+#define NBLOOPS_DEFAULT    3    /* Default number of benchmark iterations */
+
+extern int const g_nbTestFunctions;
+extern char g_testIDs[];  /* size : g_nbTestFunctions */
+extern const char k_testIDs_default[];
+extern int g_nbIterations;
+
+int XSUM_benchInternal(size_t keySize);
+int XSUM_benchFiles(const char* fileNamesTable[], int nbFiles);
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XSUM_BENCH_H */

--- a/cli/xsum_config.h
+++ b/cli/xsum_config.h
@@ -1,6 +1,6 @@
 /*
  * xxhsum - Command line interface for xxhash algorithms
- * Copyright (C) 2013-2020 Yann Collet
+ * Copyright (C) 2013-2021 Yann Collet
  *
  * GPL v2 License
  *
@@ -201,5 +201,14 @@
 #   endif
     typedef unsigned long long XSUM_U64;
 #endif /* not C++/C99 */
+
+/* ***************************
+ * Common constants
+ * ***************************/
+
+#define KB *( 1<<10)
+#define MB *( 1<<20)
+#define GB *(1U<<30)
+
 
 #endif /* XSUM_CONFIG_H */

--- a/cli/xsum_os_specific.c
+++ b/cli/xsum_os_specific.c
@@ -112,7 +112,7 @@ static int XSUM_stat(const char* infilename, XSUM_stat_t* statbuf)
 }
 
 #ifndef XSUM_NO_MAIN
-int main(int argc, char* argv[])
+int main(int argc, const char* argv[])
 {
     return XSUM_main(argc, argv);
 }

--- a/cli/xsum_os_specific.c
+++ b/cli/xsum_os_specific.c
@@ -383,7 +383,7 @@ static int XSUM_wmain(int argc, wchar_t* utf16_argv[])
         setvbuf(stderr, NULL, _IONBF, 0);
 
         /* Call our real main function */
-        ret = XSUM_main(argc, utf8_argv);
+        ret = XSUM_main(argc, (void*)utf8_argv);
 
         /* Cleanup */
         XSUM_freeArgv(argc, utf8_argv);
@@ -439,7 +439,7 @@ int __cdecl __wgetmainargs(
     _startupinfo* StartInfo
 );
 
-int main(int ansi_argc, char* ansi_argv[])
+int main(int ansi_argc, const char* ansi_argv[])
 {
     int       utf16_argc;
     wchar_t** utf16_argv;

--- a/cli/xsum_os_specific.c
+++ b/cli/xsum_os_specific.c
@@ -23,12 +23,7 @@
  *   - xxHash source repository: https://github.com/Cyan4973/xxHash
  */
 
-#include "xsum_config.h"
-#include "xsum_os_specific.h"
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <sys/types.h>  /* struct stat / __wstat64 */
+#include "xsum_os_specific.h"  /* XSUM_API */
 #include <sys/stat.h>   /* stat() / _stat64() */
 
 /*

--- a/cli/xsum_os_specific.h
+++ b/cli/xsum_os_specific.h
@@ -39,7 +39,7 @@ extern "C" {
  *
  * Functions like main(), but is passed UTF-8 arguments even on Windows.
  */
-XSUM_API int XSUM_main(int argc, char* argv[]);
+XSUM_API int XSUM_main(int argc, const char* argv[]);
 
 /*
  * Returns whether stream is a console.

--- a/cli/xsum_output.c
+++ b/cli/xsum_output.c
@@ -23,9 +23,7 @@
  *   - xxHash source repository: https://github.com/Cyan4973/xxHash
  */
 
-#include "xsum_output.h"
-#include "xsum_os_specific.h"
-#include <stdio.h>
+#include "xsum_os_specific.h"  /* XSUM_API */
 
 int XSUM_logLevel = 2;
 

--- a/cli/xsum_sanity_check.c
+++ b/cli/xsum_sanity_check.c
@@ -23,16 +23,16 @@
  *   - xxHash source repository: https://github.com/Cyan4973/xxHash
  */
 
-#include "xsum_config.h"
 #include "xsum_sanity_check.h"
-#include "xsum_output.h"
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>
+#include "xsum_output.h"  /* XSUM_log */
 #ifndef XXH_STATIC_LINKING_ONLY
 #  define XXH_STATIC_LINKING_ONLY
 #endif
 #include "../xxhash.h"
+
+#include <stdlib.h>  /* exit */
+#include <assert.h>
+#include <string.h>  /* memcmp */
 
 /* use #define to make them constant, required for initialization */
 #define PRIME32 2654435761U

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -35,10 +35,12 @@
 #include "xsum_os_specific.h"
 #include "xsum_output.h"
 #include "xsum_sanity_check.h"
+#include "xsum_bench.h"
 #ifdef XXH_INLINE_ALL
 #  include "xsum_os_specific.c"
 #  include "xsum_output.c"
 #  include "xsum_sanity_check.c"
+#  include "xsum_bench.c"
 #endif
 
 /* ************************************
@@ -50,7 +52,6 @@
 #include <stdio.h>      /* fprintf, fopen, ftello64, fread, stdin, stdout, _fileno (when present) */
 #include <sys/types.h>  /* stat, stat64, _stat64 */
 #include <sys/stat.h>   /* stat, stat64, _stat64 */
-#include <time.h>       /* clock_t, clock, CLOCKS_PER_SEC */
 #include <assert.h>     /* assert */
 #include <errno.h>      /* errno */
 
@@ -78,19 +79,6 @@ static const char author[] = "Yann Collet";
                     exename, XSUM_PROGRAM_VERSION, author, \
                     g_nbBits, XSUM_ARCH, ENDIAN_NAME, XSUM_CC_VERSION
 
-#define KB *( 1<<10)
-#define MB *( 1<<20)
-#define GB *(1U<<30)
-
-static size_t XSUM_DEFAULT_SAMPLE_SIZE = 100 KB;
-#define NBLOOPS    3                              /* Default number of benchmark iterations */
-#define TIMELOOP_S 1
-#define TIMELOOP  (TIMELOOP_S * CLOCKS_PER_SEC)   /* target timing per iteration */
-#define TIMELOOP_MIN (TIMELOOP / 2)               /* minimum timing to validate a result */
-#define XXHSUM32_DEFAULT_SEED 0                   /* Default seed for algo_xxh32 */
-#define XXHSUM64_DEFAULT_SEED 0                   /* Default seed for algo_xxh64 */
-
-#define MAX_MEM    (2 GB - 64 MB)
 
 static const char stdinName[] = "-";
 static const char stdinFileName[] = "stdin";
@@ -104,405 +92,15 @@ static AlgoSelected g_defaultAlgo = algo_xxh64;    /* required within main() & X
 /* Maximum acceptable line length. */
 #define MAX_LINE_LENGTH (32 KB)
 
+static size_t XSUM_DEFAULT_SAMPLE_SIZE = 100 KB;
 
-/* ************************************
- *  Local variables
- **************************************/
-static XSUM_U32 g_nbIterations = NBLOOPS;
-
-
-/* ************************************
- *  Benchmark Functions
- **************************************/
-static clock_t XSUM_clockSpan( clock_t start )
-{
-    return clock() - start;   /* works even if overflow; Typical max span ~ 30 mn */
-}
-
-static size_t XSUM_findMaxMem(XSUM_U64 requiredMem)
-{
-    size_t const step = 64 MB;
-    void* testmem = NULL;
-
-    requiredMem = (((requiredMem >> 26) + 1) << 26);
-    requiredMem += 2*step;
-    if (requiredMem > MAX_MEM) requiredMem = MAX_MEM;
-
-    while (!testmem) {
-        if (requiredMem > step) requiredMem -= step;
-        else requiredMem >>= 1;
-        testmem = malloc ((size_t)requiredMem);
-    }
-    free (testmem);
-
-    /* keep some space available */
-    if (requiredMem > step) requiredMem -= step;
-    else requiredMem >>= 1;
-
-    return (size_t)requiredMem;
-}
-
-/*
- * Allocates a string containing s1 and s2 concatenated. Acts like strdup.
- * The result must be freed.
- */
-static char* XSUM_strcatDup(const char* s1, const char* s2)
-{
-    assert(s1 != NULL);
-    assert(s2 != NULL);
-    {   size_t len1 = strlen(s1);
-        size_t len2 = strlen(s2);
-        char* buf = (char*)malloc(len1 + len2 + 1);
-        if (buf != NULL) {
-            /* strcpy(buf, s1) */
-            memcpy(buf, s1, len1);
-            /* strcat(buf, s2) */
-            memcpy(buf + len1, s2, len2 + 1);
-        }
-        return buf;
-    }
-}
-
-
-/*
- * A secret buffer used for benchmarking XXH3's withSecret variants.
- *
- * In order for the bench to be realistic, the secret buffer would need to be
- * pre-generated.
- *
- * Adding a pointer to the parameter list would be messy.
- */
-static XSUM_U8 g_benchSecretBuf[XXH3_SECRET_SIZE_MIN];
-
-/*
- * Wrappers for the benchmark.
- *
- * If you would like to add other hashes to the bench, create a wrapper and add
- * it to the g_hashesToBench table. It will automatically be added.
- */
-typedef XSUM_U32 (*hashFunction)(const void* buffer, size_t bufferSize, XSUM_U32 seed);
-
-static XSUM_U32 localXXH32(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    return XXH32(buffer, bufferSize, seed);
-}
-static XSUM_U32 localXXH32_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    XXH32_state_t state;
-    (void)seed;
-    XXH32_reset(&state, seed);
-    XXH32_update(&state, buffer, bufferSize);
-    return (XSUM_U32)XXH32_digest(&state);
-}
-static XSUM_U32 localXXH64(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    return (XSUM_U32)XXH64(buffer, bufferSize, seed);
-}
-static XSUM_U32 localXXH64_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    XXH64_state_t state;
-    (void)seed;
-    XXH64_reset(&state, seed);
-    XXH64_update(&state, buffer, bufferSize);
-    return (XSUM_U32)XXH64_digest(&state);
-}
-static XSUM_U32 localXXH3_64b(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    (void)seed;
-    return (XSUM_U32)XXH3_64bits(buffer, bufferSize);
-}
-static XSUM_U32 localXXH3_64b_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    return (XSUM_U32)XXH3_64bits_withSeed(buffer, bufferSize, seed);
-}
-static XSUM_U32 localXXH3_64b_secret(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    (void)seed;
-    return (XSUM_U32)XXH3_64bits_withSecret(buffer, bufferSize, g_benchSecretBuf, sizeof(g_benchSecretBuf));
-}
-static XSUM_U32 localXXH3_128b(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    (void)seed;
-    return (XSUM_U32)(XXH3_128bits(buffer, bufferSize).low64);
-}
-static XSUM_U32 localXXH3_128b_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    return (XSUM_U32)(XXH3_128bits_withSeed(buffer, bufferSize, seed).low64);
-}
-static XSUM_U32 localXXH3_128b_secret(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    (void)seed;
-    return (XSUM_U32)(XXH3_128bits_withSecret(buffer, bufferSize, g_benchSecretBuf, sizeof(g_benchSecretBuf)).low64);
-}
-static XSUM_U32 localXXH3_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    XXH3_state_t state;
-    (void)seed;
-    XXH3_64bits_reset(&state);
-    XXH3_64bits_update(&state, buffer, bufferSize);
-    return (XSUM_U32)XXH3_64bits_digest(&state);
-}
-static XSUM_U32 localXXH3_stream_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    XXH3_state_t state;
-    XXH3_INITSTATE(&state);
-    XXH3_64bits_reset_withSeed(&state, (XXH64_hash_t)seed);
-    XXH3_64bits_update(&state, buffer, bufferSize);
-    return (XSUM_U32)XXH3_64bits_digest(&state);
-}
-static XSUM_U32 localXXH128_stream(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    XXH3_state_t state;
-    (void)seed;
-    XXH3_128bits_reset(&state);
-    XXH3_128bits_update(&state, buffer, bufferSize);
-    return (XSUM_U32)(XXH3_128bits_digest(&state).low64);
-}
-static XSUM_U32 localXXH128_stream_seeded(const void* buffer, size_t bufferSize, XSUM_U32 seed)
-{
-    XXH3_state_t state;
-    XXH3_INITSTATE(&state);
-    XXH3_128bits_reset_withSeed(&state, (XXH64_hash_t)seed);
-    XXH3_128bits_update(&state, buffer, bufferSize);
-    return (XSUM_U32)(XXH3_128bits_digest(&state).low64);
-}
-
-
-typedef struct {
-    const char*  name;
-    hashFunction func;
-} hashInfo;
-
-static const hashInfo g_hashesToBench[] = {
-    { "XXH32",             &localXXH32 },
-    { "XXH64",             &localXXH64 },
-    { "XXH3_64b",          &localXXH3_64b },
-    { "XXH3_64b w/seed",   &localXXH3_64b_seeded },
-    { "XXH3_64b w/secret", &localXXH3_64b_secret },
-    { "XXH128",            &localXXH3_128b },
-    { "XXH128 w/seed",     &localXXH3_128b_seeded },
-    { "XXH128 w/secret",   &localXXH3_128b_secret },
-    { "XXH32_stream",      &localXXH32_stream },
-    { "XXH64_stream",      &localXXH64_stream },
-    { "XXH3_stream",       &localXXH3_stream },
-    { "XXH3_stream w/seed",&localXXH3_stream_seeded },
-    { "XXH128_stream",     &localXXH128_stream },
-    { "XXH128_stream w/seed",&localXXH128_stream_seeded },
-};
-#define NB_HASHFUNC (sizeof(g_hashesToBench) / sizeof(*g_hashesToBench))
-
-#define NB_TESTFUNC (1 + 2 * NB_HASHFUNC)
-static char g_testIDs[NB_TESTFUNC] = { 0 };
-static const char k_testIDs_default[NB_TESTFUNC] = { 0,
-        1 /*XXH32*/, 0,
-        1 /*XXH64*/, 0,
-        1 /*XXH3*/, 0, 0, 0, 0, 0,
-        1 /*XXH128*/ };
-
-#define HASHNAME_MAX 29
-static void XSUM_benchHash(hashFunction h, const char* hName, int testID,
-                           const void* buffer, size_t bufferSize)
-{
-    XSUM_U32 nbh_perIteration = (XSUM_U32)((300 MB) / (bufferSize+1)) + 1;  /* first iteration conservatively aims for 300 MB/s */
-    unsigned iterationNb, nbIterations = g_nbIterations + !g_nbIterations /* min 1 */;
-    double fastestH = 100000000.;
-    assert(HASHNAME_MAX > 2);
-    XSUM_logVerbose(2, "\r%80s\r", "");       /* Clean display line */
-
-    for (iterationNb = 1; iterationNb <= nbIterations; iterationNb++) {
-        XSUM_U32 r=0;
-        clock_t cStart;
-
-        XSUM_logVerbose(2, "%2u-%-*.*s : %10u ->\r",
-                        iterationNb,
-                        HASHNAME_MAX, HASHNAME_MAX, hName,
-                        (unsigned)bufferSize);
-        cStart = clock();
-        while (clock() == cStart);   /* starts clock() at its exact beginning */
-        cStart = clock();
-
-        {   XSUM_U32 u;
-            for (u=0; u<nbh_perIteration; u++)
-                r += h(buffer, bufferSize, u);
-        }
-        if (r==0) XSUM_logVerbose(3,".\r");  /* do something with r to defeat compiler "optimizing" hash away */
-
-        {   clock_t const nbTicks = XSUM_clockSpan(cStart);
-            double const ticksPerHash = ((double)nbTicks / TIMELOOP) / nbh_perIteration;
-            /*
-             * clock() is the only decent portable timer, but it isn't very
-             * precise.
-             *
-             * Sometimes, this lack of precision is enough that the benchmark
-             * finishes before there are enough ticks to get a meaningful result.
-             *
-             * For example, on a Core 2 Duo (without any sort of Turbo Boost),
-             * the imprecise timer caused peculiar results like so:
-             *
-             *    XXH3_64b                   4800.0 MB/s // conveniently even
-             *    XXH3_64b unaligned         4800.0 MB/s
-             *    XXH3_64b seeded            9600.0 MB/s // magical 2x speedup?!
-             *    XXH3_64b seeded unaligned  4800.0 MB/s
-             *
-             * If we sense a suspiciously low number of ticks, we increase the
-             * iterations until we can get something meaningful.
-             */
-            if (nbTicks < TIMELOOP_MIN) {
-                /* Not enough time spent in benchmarking, risk of rounding bias */
-                if (nbTicks == 0) { /* faster than resolution timer */
-                    nbh_perIteration *= 100;
-                } else {
-                    /*
-                     * update nbh_perIteration so that the next round lasts
-                     * approximately 1 second.
-                     */
-                    double nbh_perSecond = (1 / ticksPerHash) + 1;
-                    if (nbh_perSecond > (double)(4000U<<20)) nbh_perSecond = (double)(4000U<<20);   /* avoid overflow */
-                    nbh_perIteration = (XSUM_U32)nbh_perSecond;
-                }
-                /* g_nbIterations==0 => quick evaluation, no claim of accuracy */
-                if (g_nbIterations>0) {
-                    iterationNb--;   /* new round for a more accurate speed evaluation */
-                    continue;
-                }
-            }
-            if (ticksPerHash < fastestH) fastestH = ticksPerHash;
-            if (fastestH>0.) { /* avoid div by zero */
-                XSUM_logVerbose(2, "%2u-%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \r",
-                            iterationNb,
-                            HASHNAME_MAX, HASHNAME_MAX, hName,
-                            (unsigned)bufferSize,
-                            (double)1 / fastestH,
-                            ((double)bufferSize / (1 MB)) / fastestH);
-        }   }
-        {   double nbh_perSecond = (1 / fastestH) + 1;
-            if (nbh_perSecond > (double)(4000U<<20)) nbh_perSecond = (double)(4000U<<20);   /* avoid overflow */
-            nbh_perIteration = (XSUM_U32)nbh_perSecond;
-        }
-    }
-    XSUM_logVerbose(1, "%2i#%-*.*s : %10u -> %8.0f it/s (%7.1f MB/s) \n",
-                    testID,
-                    HASHNAME_MAX, HASHNAME_MAX, hName,
-                    (unsigned)bufferSize,
-                    (double)1 / fastestH,
-                    ((double)bufferSize / (1 MB)) / fastestH);
-    if (XSUM_logLevel<1)
-        XSUM_logVerbose(0, "%u, ", (unsigned)((double)1 / fastestH));
-}
-
-
-/*!
- * XSUM_benchMem():
- * buffer: Must be 16-byte aligned.
- * The real allocated size of buffer is supposed to be >= (bufferSize+3).
- * returns: 0 on success, 1 if error (invalid mode selected)
- */
-static void XSUM_benchMem(const void* buffer, size_t bufferSize)
-{
-    assert((((size_t)buffer) & 15) == 0);  /* ensure alignment */
-    XSUM_fillTestBuffer(g_benchSecretBuf, sizeof(g_benchSecretBuf));
-    {   int i;
-        for (i = 1; i < (int)NB_TESTFUNC; i++) {
-            int const hashFuncID = (i-1) / 2;
-            assert(g_hashesToBench[hashFuncID].name != NULL);
-            if (g_testIDs[i] == 0) continue;
-            /* aligned */
-            if ((i % 2) == 1) {
-                XSUM_benchHash(g_hashesToBench[hashFuncID].func, g_hashesToBench[hashFuncID].name, i, buffer, bufferSize);
-            }
-            /* unaligned */
-            if ((i % 2) == 0) {
-                /* Append "unaligned". */
-                char* const hashNameBuf = XSUM_strcatDup(g_hashesToBench[hashFuncID].name, " unaligned");
-                assert(hashNameBuf != NULL);
-                XSUM_benchHash(g_hashesToBench[hashFuncID].func, hashNameBuf, i, ((const char*)buffer)+3, bufferSize);
-                free(hashNameBuf);
-            }
-    }   }
-}
-
-static size_t XSUM_selectBenchedSize(const char* fileName)
-{
-    XSUM_U64 const inFileSize = XSUM_getFileSize(fileName);
-    size_t benchedSize = (size_t) XSUM_findMaxMem(inFileSize);
-    if ((XSUM_U64)benchedSize > inFileSize) benchedSize = (size_t)inFileSize;
-    if (benchedSize < inFileSize) {
-        XSUM_log("Not enough memory for '%s' full size; testing %i MB only...\n", fileName, (int)(benchedSize>>20));
-    }
-    return benchedSize;
-}
-
-
-static int XSUM_benchFiles(char*const* fileNamesTable, int nbFiles)
-{
-    int fileIdx;
-    for (fileIdx=0; fileIdx<nbFiles; fileIdx++) {
-        const char* const inFileName = fileNamesTable[fileIdx];
-        assert(inFileName != NULL);
-
-        {   FILE* const inFile = XSUM_fopen( inFileName, "rb" );
-            size_t const benchedSize = XSUM_selectBenchedSize(inFileName);
-            char* const buffer = (char*)calloc(benchedSize+16+3, 1);
-            void* const alignedBuffer = (buffer+15) - (((size_t)(buffer+15)) & 0xF);  /* align on next 16 bytes */
-
-            /* Checks */
-            if (inFile==NULL){
-                XSUM_log("Error: Could not open '%s': %s.\n", inFileName, strerror(errno));
-                free(buffer);
-                exit(11);
-            }
-            if(!buffer) {
-                XSUM_log("\nError: Out of memory.\n");
-                fclose(inFile);
-                exit(12);
-            }
-
-            /* Fill input buffer */
-            {   size_t const readSize = fread(alignedBuffer, 1, benchedSize, inFile);
-                fclose(inFile);
-                if(readSize != benchedSize) {
-                    XSUM_log("\nError: Could not read '%s': %s.\n", inFileName, strerror(errno));
-                    free(buffer);
-                    exit(13);
-            }   }
-
-            /* bench */
-            XSUM_benchMem(alignedBuffer, benchedSize);
-
-            free(buffer);
-    }   }
-    return 0;
-}
-
-
-static int XSUM_benchInternal(size_t keySize)
-{
-    void* const buffer = calloc(keySize+16+3, 1);
-    if (buffer == NULL) {
-        XSUM_log("\nError: Out of memory.\n");
-        exit(12);
-    }
-
-    {   const void* const alignedBuffer = ((char*)buffer+15) - (((size_t)((char*)buffer+15)) & 0xF);  /* align on next 16 bytes */
-
-        /* bench */
-        XSUM_logVerbose(1, "Sample of ");
-        if (keySize > 10 KB) {
-            XSUM_logVerbose(1, "%u KB", (unsigned)(keySize >> 10));
-        } else {
-            XSUM_logVerbose(1, "%u bytes", (unsigned)keySize);
-        }
-        XSUM_logVerbose(1, "...        \n");
-
-        XSUM_benchMem(alignedBuffer, keySize);
-        free(buffer);
-    }
-    return 0;
-}
 
 /* ********************************************************
 *  File Hashing
 **********************************************************/
+
+#define XXHSUM32_DEFAULT_SEED 0                   /* Default seed for algo_xxh32 */
+#define XXHSUM64_DEFAULT_SEED 0                   /* Default seed for algo_xxh64 */
 
 /* for support of --little-endian display mode */
 static void XSUM_display_LittleEndian(const void* ptr, size_t length)
@@ -729,7 +327,7 @@ static int XSUM_hashFile(const char* fileName,
  * XSUM_hashFiles:
  * If fnTotal==0, read from stdin instead.
  */
-static int XSUM_hashFiles(char*const * fnList, int fnTotal,
+static int XSUM_hashFiles(const char* fnList[], int fnTotal,
                           AlgoSelected hashType,
                           Display_endianess displayEndianess,
                           Display_convention convention)
@@ -1241,7 +839,7 @@ static int XSUM_checkFile(const char* inFileName,
 }
 
 
-static int XSUM_checkFiles(char*const* fnList, int fnTotal,
+static int XSUM_checkFiles(const char* fnList[], int fnTotal,
                            const Display_endianess displayEndianess,
                            XSUM_U32 strictMode,
                            XSUM_U32 statusOnly,
@@ -1290,7 +888,7 @@ static int XSUM_usage_advanced(const char* exename)
     XSUM_log( "      --little-endian  Checksum values use little endian convention (default: big endian) \n");
     XSUM_log( "  -b                   Run benchmark \n");
     XSUM_log( "  -b#                  Bench only algorithm variant # \n");
-    XSUM_log( "  -i#                  Number of times to run the benchmark (default: %u) \n", (unsigned)g_nbIterations);
+    XSUM_log( "  -i#                  Number of times to run the benchmark (default: %u) \n", NBLOOPS_DEFAULT);
     XSUM_log( "  -q, --quiet          Don't display version header in benchmark mode \n");
     XSUM_log( "\n");
     XSUM_log( "The following four options are useful only when verifying checksums (-c): \n");
@@ -1371,7 +969,7 @@ static XSUM_U32 XSUM_readU32FromChar(const char** stringPtr) {
     return result;
 }
 
-XSUM_API int XSUM_main(int argc, char* argv[])
+XSUM_API int XSUM_main(int argc, const char* argv[])
 {
     int i, filenamesStart = 0;
     const char* const exename = XSUM_lastNameFromPath(argv[0]);
@@ -1387,6 +985,7 @@ XSUM_API int XSUM_main(int argc, char* argv[])
     AlgoSelected algo     = g_defaultAlgo;
     Display_endianess displayEndianess = big_endian;
     Display_convention convention = display_gnu;
+    int nbIterations = NBLOOPS_DEFAULT;
 
     /* special case: xxhNNsum default to NN bits checksum */
     if (strstr(exename,  "xxh32sum") != NULL) algo = g_defaultAlgo = algo_xxh32;
@@ -1468,17 +1067,18 @@ XSUM_API int XSUM_main(int argc, char* argv[])
                 do {
                     if (*argument == ',') argument++;
                     selectBenchIDs = XSUM_readU32FromChar(&argument); /* select one specific test */
-                    if (selectBenchIDs < NB_TESTFUNC) {
+                    if ((int)selectBenchIDs < g_nbTestFunctions) {
                         g_testIDs[selectBenchIDs] = 1;
-                    } else
+                    } else {
                         selectBenchIDs = kBenchAll;
+                    }
                 } while (*argument == ',');
                 break;
 
             /* Modify Nb Iterations (benchmark only) */
             case 'i':
                 argument++;
-                g_nbIterations = XSUM_readU32FromChar(&argument);
+                nbIterations = (int)XSUM_readU32FromChar(&argument);
                 break;
 
             /* Modify Block size (benchmark only) */
@@ -1503,8 +1103,9 @@ XSUM_API int XSUM_main(int argc, char* argv[])
     if (benchmarkMode) {
         XSUM_logVerbose(2, FULL_WELCOME_MESSAGE(exename) );
         XSUM_sanityCheck();
-        if (selectBenchIDs == 0) memcpy(g_testIDs, k_testIDs_default, sizeof(g_testIDs));
-        if (selectBenchIDs == kBenchAll) memset(g_testIDs, 1, sizeof(g_testIDs));
+        g_nbIterations = nbIterations;
+        if (selectBenchIDs == 0) memcpy(g_testIDs, k_testIDs_default, g_nbTestFunctions);
+        if (selectBenchIDs == kBenchAll) memset(g_testIDs, 1, g_nbTestFunctions);
         if (filenamesStart==0) return XSUM_benchInternal(keySize);
         return XSUM_benchFiles(argv+filenamesStart, argc-filenamesStart);
     }

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -30,12 +30,11 @@
  */
 
 /* Transitional headers */
-#include "xsum_config.h"
-#include "xsum_arch.h"
-#include "xsum_os_specific.h"
-#include "xsum_output.h"
-#include "xsum_sanity_check.h"
-#include "xsum_bench.h"
+#include "xsum_arch.h"         /* XSUM_PROGRAM_VERSION */
+#include "xsum_os_specific.h"  /* XSUM_setBinaryMode */
+#include "xsum_output.h"       /* XSUM_output */
+#include "xsum_sanity_check.h" /* XSUM_sanityCheck */
+#include "xsum_bench.h"        /* NBLOOPS_DEFAULT */
 #ifdef XXH_INLINE_ALL
 #  include "xsum_os_specific.c"
 #  include "xsum_output.c"
@@ -46,12 +45,8 @@
 /* ************************************
  *  Includes
  **************************************/
-#include <limits.h>
 #include <stdlib.h>     /* malloc, calloc, free, exit */
-#include <string.h>     /* strcmp, memcpy */
-#include <stdio.h>      /* fprintf, fopen, ftello64, fread, stdin, stdout, _fileno (when present) */
-#include <sys/types.h>  /* stat, stat64, _stat64 */
-#include <sys/stat.h>   /* stat, stat64, _stat64 */
+#include <string.h>     /* strerror, strcmp, memcpy */
 #include <assert.h>     /* assert */
 #include <errno.h>      /* errno */
 

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1104,8 +1104,8 @@ XSUM_API int XSUM_main(int argc, const char* argv[])
         XSUM_logVerbose(2, FULL_WELCOME_MESSAGE(exename) );
         XSUM_sanityCheck();
         g_nbIterations = nbIterations;
-        if (selectBenchIDs == 0) memcpy(g_testIDs, k_testIDs_default, g_nbTestFunctions);
-        if (selectBenchIDs == kBenchAll) memset(g_testIDs, 1, g_nbTestFunctions);
+        if (selectBenchIDs == 0) memcpy(g_testIDs, k_testIDs_default, (size_t)g_nbTestFunctions);
+        if (selectBenchIDs == kBenchAll) memset(g_testIDs, 1, (size_t)g_nbTestFunctions);
         if (filenamesStart==0) return XSUM_benchInternal(keySize);
         return XSUM_benchFiles(argv+filenamesStart, argc-filenamesStart);
     }

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -92,6 +92,7 @@ if(XXHASH_BUILD_XXHSUM)
                         "${XXHSUM_DIR}/xsum_os_specific.c"
                         "${XXHSUM_DIR}/xsum_output.c"
                         "${XXHSUM_DIR}/xsum_sanity_check.c"
+                        "${XXHSUM_DIR}/xsum_bench.c"
                 )
   add_executable(${PROJECT_NAME}::xxhsum ALIAS xxhsum)
 


### PR DESCRIPTION
Supersedes #454,
though with a more limited scope
(just benchmark functions, no attempt to change timer functions).