### PR TITLE
added XXH3 to the list of possible hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,8 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 	$(RUN_ENV) ./xxhsum$(EXT) -H0 xxhash.c
 	# 128-bit
 	$(RUN_ENV) ./xxhsum$(EXT) -H2 xxhash.c
+	# XXH3 (enforce BSD style)
+	$(RUN_ENV) ./xxhsum$(EXT) -H3 xxhash.c | grep "XXH3"
 	# request incorrect variant
 	$(RUN_ENV) ./xxhsum$(EXT) -H9 xxhash.c ; test $$? -eq 1
 	@printf "\n .......   checks completed successfully   ....... \n"
@@ -252,12 +254,18 @@ test-xxhsum-c: xxhsum
 	./xxhsum -H2 --tag $(TEST_FILES) > .test.xxh128_tag
 	./xxhsum -H2 --little-endian $(TEST_FILES) > .test.le_xxh128
 	./xxhsum -H2 --tag --little-endian $(TEST_FILES) > .test.le_xxh128_tag
+	./xxhsum -H3 $(TEST_FILES) > .test.xxh3
+	./xxhsum -H3 --tag $(TEST_FILES) > .test.xxh3_tag
+	./xxhsum -H3 --little-endian $(TEST_FILES) > .test.le_xxh3
+	./xxhsum -H3 --tag --little-endian $(TEST_FILES) > .test.le_xxh3_tag
 	./xxhsum -c .test.xxh*
 	./xxhsum -c --little-endian .test.le_xxh*
 	./xxhsum -c .test.*_tag
 	# read list of files from stdin
-	./xxhsum -c < .test.xxh64
 	./xxhsum -c < .test.xxh32
+	./xxhsum -c < .test.xxh64
+	./xxhsum -c < .test.xxh128
+	./xxhsum -c < .test.xxh3
 	cat .test.xxh* | ./xxhsum -c -
 	# check variant with '*' marker as second separator
 	$(SED) 's/  / \*/' .test.xxh32 | ./xxhsum -c
@@ -266,12 +274,15 @@ test-xxhsum-c: xxhsum
 	./xxhsum --tag -H0 xxhsum* | $(GREP) XXH32
 	./xxhsum --tag -H1 xxhsum* | $(GREP) XXH64
 	./xxhsum --tag -H2 xxhsum* | $(GREP) XXH128
+	./xxhsum --tag -H3 xxhsum* | $(GREP) XXH3
+	./xxhsum       -H3 xxhsum* | $(GREP) XXH3  # --tag is implicit for H3
 	./xxhsum --tag -H32 xxhsum* | $(GREP) XXH32
 	./xxhsum --tag -H64 xxhsum* | $(GREP) XXH64
 	./xxhsum --tag -H128 xxhsum* | $(GREP) XXH128
 	./xxhsum --tag -H0 --little-endian xxhsum* | $(GREP) XXH32_LE
 	./xxhsum --tag -H1 --little-endian xxhsum* | $(GREP) XXH64_LE
 	./xxhsum --tag -H2 --little-endian xxhsum* | $(GREP) XXH128_LE
+	./xxhsum       -H3 --little-endian xxhsum* | $(GREP) XXH3_LE
 	./xxhsum --tag -H32 --little-endian xxhsum* | $(GREP) XXH32_LE
 	./xxhsum --tag -H64 --little-endian xxhsum* | $(GREP) XXH64_LE
 	./xxhsum --tag -H128 --little-endian xxhsum* | $(GREP) XXH128_LE


### PR DESCRIPTION
using command `-H3`.
Specifying `-H3` necessarily triggers BSD-style `--tag` mode,
in order to prevent any risk of confusion with `XXH64` (same 64-bit length).

Added corresponding `--check` option, and CI test scripts.

Fix #447