### PR TITLE
New secret generator

### DIFF
--- a/cli/xsum_sanity_check.c
+++ b/cli/xsum_sanity_check.c
@@ -90,9 +90,10 @@ typedef struct {
     XXH128_hash_t Nresult;
 } XSUM_testdata128_t;
 
-#define SECRET_SAMPLE_NBBYTES 4
+#define SECRET_SAMPLE_NBBYTES 5
 typedef struct {
-    XSUM_U32 len;
+    XSUM_U32 seedLen;
+    XSUM_U32 secretLen;
     XSUM_U8 byte[SECRET_SAMPLE_NBBYTES];
 } XSUM_testdata_sample_t;
 
@@ -213,11 +214,12 @@ static const XSUM_testdata128_t XSUM_XXH128_withSecret_testdata[] = {
     { 12, 0, { 0xAF82F6EBA263D7D8ULL, 0x90A3C2D839F57D0FULL } }   /*  9 - 16 */
 };
 
+#define SECRET_SIZE_MAX 9867
 static const XSUM_testdata_sample_t XSUM_XXH3_generateSecret_testdata[] = {
-    {                              0, { 0xE7, 0x8C, 0x77, 0x77 } },
-    {                              1, { 0x2B, 0x3E, 0xDE, 0x67 } },
-    {     XXH3_SECRET_SIZE_MIN -   1, { 0xE8, 0x39, 0x6C, 0x16 } },
-    { XXH3_SECRET_DEFAULT_SIZE + 500, { 0xD6, 0x1C, 0x41, 0x69 } }
+    {                              0, 192, { 0xE7, 0x8C, 0x77, 0x77, 0x00 } },
+    {                              1, 240, { 0x2B, 0x3E, 0xDE, 0xC1, 0x00 } },
+    {     XXH3_SECRET_SIZE_MIN -   1, 277, { 0xE8, 0x39, 0x6C, 0xCC, 0x7B } },
+    { XXH3_SECRET_DEFAULT_SIZE + 500, SECRET_SIZE_MAX, { 0xD6, 0x1C, 0x41, 0x17, 0xB3 } }
 };
 
 static void XSUM_checkResult32(XXH32_hash_t r1, XXH32_hash_t r2)
@@ -616,20 +618,21 @@ static void XSUM_testXXH128_withSecret(const void* data, const void* secret, siz
 static void XSUM_testSecretGenerator(const void* customSeed, const XSUM_testdata_sample_t* testData)
 {
     static int nbTests = 1;
-    const int sampleIndex[SECRET_SAMPLE_NBBYTES] = { 0, 62, 131, 191};  /* position of sampled bytes */
-    XSUM_U8 secretBuffer[XXH3_SECRET_DEFAULT_SIZE] = {0};
+    const int sampleIndex[SECRET_SAMPLE_NBBYTES] = { 0, 62, 131, 191, 241 };  /* position of sampled bytes */
+    XSUM_U8 secretBuffer[SECRET_SIZE_MAX] = {0};
     XSUM_U8 samples[SECRET_SAMPLE_NBBYTES];
     int i;
 
-    XXH3_generateSecret(secretBuffer, sizeof(secretBuffer), customSeed, testData->len);
+    assert(testData->secretLen <= SECRET_SIZE_MAX);
+    XXH3_generateSecret(secretBuffer, testData->secretLen, customSeed, testData->seedLen);
     for (i=0; i<SECRET_SAMPLE_NBBYTES; i++) {
         samples[i] = secretBuffer[sampleIndex[i]];
     }
     if (memcmp(samples, testData->byte, sizeof(testData->byte))) {
         XSUM_log("\rError: Secret generation test %i: Internal sanity check failed. \n", nbTests);
-        XSUM_log("\rGot { 0x%02X, 0x%02X, 0x%02X, 0x%02X }, expected { 0x%02X, 0x%02X, 0x%02X, 0x%02X } \n",
-                samples[0], samples[1], samples[2], samples[3],
-                testData->byte[0], testData->byte[1], testData->byte[2], testData->byte[3] );
+        XSUM_log("\rGot { 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X }, expected { 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X } \n",
+                samples[0], samples[1], samples[2], samples[3], samples[4],
+                testData->byte[0], testData->byte[1], testData->byte[2], testData->byte[3], testData->byte[4] );
         exit(1);
     }
     nbTests++;
@@ -678,6 +681,7 @@ XSUM_API void XSUM_sanityCheck(void)
     }
     /* secret generator */
     for (i = 0; i < (sizeof(XSUM_XXH3_generateSecret_testdata)/sizeof(XSUM_XXH3_generateSecret_testdata[0])); i++) {
+        assert(XSUM_XXH3_generateSecret_testdata[i].seedLen <= SANITY_BUFFER_SIZE);
         XSUM_testSecretGenerator(sanityBuffer, &XSUM_XXH3_generateSecret_testdata[i]);
     }
 

--- a/cli/xsum_sanity_check.c
+++ b/cli/xsum_sanity_check.c
@@ -214,10 +214,10 @@ static const XSUM_testdata128_t XSUM_XXH128_withSecret_testdata[] = {
 };
 
 static const XSUM_testdata_sample_t XSUM_XXH3_generateSecret_testdata[] = {
-    {                              0, { 0xB8, 0x26, 0x83, 0x7E } },
-    {                              1, { 0xA6, 0x16, 0x06, 0x7B } },
-    {     XXH3_SECRET_SIZE_MIN -   1, { 0xDA, 0x2A, 0x12, 0x11 } },
-    { XXH3_SECRET_DEFAULT_SIZE + 500, { 0x7E, 0x48, 0x0C, 0xA7 } }
+    {                              0, { 0xE7, 0x8C, 0x77, 0x77 } },
+    {                              1, { 0x2B, 0x3E, 0xDE, 0x67 } },
+    {     XXH3_SECRET_SIZE_MIN -   1, { 0xE8, 0x39, 0x6C, 0x16 } },
+    { XXH3_SECRET_DEFAULT_SIZE + 500, { 0xD6, 0x1C, 0x41, 0x69 } }
 };
 
 static void XSUM_checkResult32(XXH32_hash_t r1, XXH32_hash_t r2)
@@ -616,12 +616,12 @@ static void XSUM_testXXH128_withSecret(const void* data, const void* secret, siz
 static void XSUM_testSecretGenerator(const void* customSeed, const XSUM_testdata_sample_t* testData)
 {
     static int nbTests = 1;
-    const int sampleIndex[SECRET_SAMPLE_NBBYTES] = { 0, 62, 131, 191};
+    const int sampleIndex[SECRET_SAMPLE_NBBYTES] = { 0, 62, 131, 191};  /* position of sampled bytes */
     XSUM_U8 secretBuffer[XXH3_SECRET_DEFAULT_SIZE] = {0};
     XSUM_U8 samples[SECRET_SAMPLE_NBBYTES];
     int i;
 
-    XXH3_generateSecret(secretBuffer, customSeed, testData->len);
+    XXH3_generateSecret(secretBuffer, sizeof(secretBuffer), customSeed, testData->len);
     for (i=0; i<SECRET_SAMPLE_NBBYTES; i++) {
         samples[i] = secretBuffer[sampleIndex[i]];
     }

--- a/xxhash.h
+++ b/xxhash.h
@@ -5514,12 +5514,15 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_generateSecret(void* secretBuffer, size_t secretSize, const void* customSeed, size_t customSeedSize)
 {
     XXH_ASSERT(secretBuffer != NULL);
+    if (secretBuffer == NULL) return XXH_ERROR;
     XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
     if (customSeedSize == 0) {
         customSeed = XXH3_kSecret;
         customSeedSize = XXH_SECRET_DEFAULT_SIZE;
     }
     XXH_ASSERT(customSeed != NULL);
+    if (customSeed == NULL) return XXH_ERROR;
 
     /* Fill secretBuffer with a copy of customSeed - repeat as needed */
     {   size_t pos = 0;

--- a/xxhash.h
+++ b/xxhash.h
@@ -1131,27 +1131,26 @@ XXH_PUBLIC_API XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t s
  * as it becomes much more difficult for an external actor to guess how to impact the calculation logic.
  *
  * The function accepts as input a custom seed of any length and any content,
- * and derives from it a high-entropy secret of length XXH3_SECRET_DEFAULT_SIZE
- * into an already allocated buffer secretBuffer.
- * The generated secret is _always_ XXH_SECRET_DEFAULT_SIZE bytes long.
+ * and derives from it a high-entropy secret of length @secretSize
+ * into an already allocated buffer @secretBuffer.
+ * @secretSize must be >= XXH3_SECRET_SIZE_MIN
  *
  * The generated secret can then be used with any `*_withSecret()` variant.
  * Functions `XXH3_128bits_withSecret()`, `XXH3_64bits_withSecret()`,
  * `XXH3_128bits_reset_withSecret()` and `XXH3_64bits_reset_withSecret()`
  * are part of this list. They all accept a `secret` parameter
- * which must be very long for implementation reasons (>= XXH3_SECRET_SIZE_MIN)
+ * which must be large enough for implementation reasons (>= XXH3_SECRET_SIZE_MIN)
  * _and_ feature very high entropy (consist of random-looking bytes).
  * These conditions can be a high bar to meet, so
- * this function can be used to generate a secret of proper quality.
+ * XXH3_generateSecret() can be employed to ensure proper quality.
  *
  * customSeed can be anything. It can have any size, even small ones,
- * and its content can be anything, even stupidly "low entropy" source such as a bunch of zeroes.
- * The resulting `secret` will nonetheless provide all expected qualities.
+ * and its content can be anything, even "poor entropy" sources such as a bunch of zeroes.
+ * The resulting `secret` will nonetheless provide all required qualities.
  *
- * Supplying NULL as the customSeed copies the default secret into `secretBuffer`.
  * When customSeedSize > 0, supplying NULL as customSeed is undefined behavior.
  */
-XXH_PUBLIC_API void XXH3_generateSecret(void* secretBuffer, const void* customSeed, size_t customSeedSize);
+XXH_PUBLIC_API XXH_errorcode XXH3_generateSecret(void* secretBuffer, size_t secretSize, const void* customSeed, size_t customSeedSize);
 
 
 /*
@@ -5504,47 +5503,44 @@ XXH128_hashFromCanonical(const XXH128_canonical_t* src)
  */
 #define XXH_MIN(x, y) (((x) > (y)) ? (y) : (x))
 
+static void XXH3_combine16(void* dst, XXH128_hash_t h128)
+{
+    XXH_writeLE64( dst, XXH_readLE64(dst) ^ h128.low64 );
+    XXH_writeLE64( (char*)dst+8, XXH_readLE64((char*)dst+8) ^ h128.high64 );
+}
+
 /*! @ingroup xxh3_family */
-XXH_PUBLIC_API void
-XXH3_generateSecret(void* secretBuffer, const void* customSeed, size_t customSeedSize)
+XXH_PUBLIC_API XXH_errorcode
+XXH3_generateSecret(void* secretBuffer, size_t secretSize, const void* customSeed, size_t customSeedSize)
 {
     XXH_ASSERT(secretBuffer != NULL);
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
     if (customSeedSize == 0) {
-        memcpy(secretBuffer, XXH3_kSecret, XXH_SECRET_DEFAULT_SIZE);
-        return;
+        customSeed = XXH3_kSecret;
+        customSeedSize = XXH_SECRET_DEFAULT_SIZE;
     }
     XXH_ASSERT(customSeed != NULL);
 
-    {   size_t const segmentSize = sizeof(XXH128_hash_t);
-        size_t const nbSegments = XXH_SECRET_DEFAULT_SIZE / segmentSize;
-        XXH128_canonical_t scrambler;
-        XXH64_hash_t seeds[12];
-        size_t segnb;
-        XXH_ASSERT(nbSegments == 12);
-        XXH_ASSERT(segmentSize * nbSegments == XXH_SECRET_DEFAULT_SIZE); /* exact multiple */
-        XXH128_canonicalFromHash(&scrambler, XXH128(customSeed, customSeedSize, 0));
-
-        /*
-        * Copy customSeed to seeds[], truncating or repeating as necessary.
-        */
-        {   size_t toFill = XXH_MIN(customSeedSize, sizeof(seeds));
-            size_t filled = toFill;
-            memcpy(seeds, customSeed, toFill);
-            while (filled < sizeof(seeds)) {
-                toFill = XXH_MIN(filled, sizeof(seeds) - filled);
-                memcpy((char*)seeds + filled, seeds, toFill);
-                filled += toFill;
-        }   }
-
-        /* generate secret */
-        memcpy(secretBuffer, &scrambler, sizeof(scrambler));
-        for (segnb=1; segnb < nbSegments; segnb++) {
-            size_t const segmentStart = segnb * segmentSize;
-            XXH128_canonical_t segment;
-            XXH128_canonicalFromHash(&segment,
-                XXH128(&scrambler, sizeof(scrambler), XXH_readLE64(seeds + segnb) + segnb) );
-            memcpy((char*)secretBuffer + segmentStart, &segment, sizeof(segment));
+    /* Fill secretBuffer with a copy of customSeed - repeat as needed */
+    {   size_t pos = 0;
+        while (pos < secretSize) {
+            size_t const toCopy = XXH_MIN((secretSize - pos), customSeedSize);
+            memcpy((char*)secretBuffer + pos, customSeed, toCopy);
+            pos += toCopy;
     }   }
+
+    {   size_t const nbSeg16 = secretSize / 16;
+        size_t n;
+        XXH128_canonical_t scrambler;
+        XXH128_canonicalFromHash(&scrambler, XXH128(customSeed, customSeedSize, 0));
+        for (n=0; n<nbSeg16; n++) {
+            XXH128_hash_t const h128 = XXH128(&scrambler, sizeof(scrambler), n);
+            XXH3_combine16((char*)secretBuffer + n*16, h128);
+        }
+        /* last segment */
+        XXH3_combine16((char*)secretBuffer + secretSize - 16, XXH128_hashFromCanonical(&scrambler));
+    }
+    return XXH_OK;
 }
 
 /*! @ingroup xxh3_family */


### PR DESCRIPTION
`XXH3_generateSecret()` can now generate `secret` of any size 
as long as it's `>= XX3_SECRET_SIZE_MIN` .

Note that results produced by this version
are not comparable to results produced by earlier version.
`XXH3_generateSecret()` is still labelled experimental,
aka, its result are not yet guaranteed to remain stable across versions.