### PR TITLE
Add GitHub Actions badge for release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Code is highly portable, and hashes are identical across all platforms (little /
 
 |Branch      |Status   |
 |------------|---------|
+|release     | [![Build Status](https://github.com/Cyan4973/xxHash/actions/workflows/ci.yml/badge.svg?branch=release)](https://github.com/Cyan4973/xxHash/actions?query=branch%3Arelease+) |
 |dev         | [![Build Status](https://github.com/Cyan4973/xxHash/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/Cyan4973/xxHash/actions?query=branch%3Adev+) |
 
 


### PR DESCRIPTION
This trivial changeset adds a GH Actions badge for `release` branch.

- First URL indicates SVG image of the badge for `release` branch.
- Second URL indicates GH Actions log for `release` branch.

You can preview this change in my branch:
https://github.com/t-mat/xxHash/tree/release-ci-badge