### PR TITLE
Add macOS matrix to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,11 +322,19 @@ jobs:
       run: |
         LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-  # macOS
 
-  macos-latest-general:
-    name: macOS general test
-    runs-on: macos-latest
+  # macOS, { 10.15, 11 }
+
+  macos-general:
+    name: ${{ matrix.system.os }}
+    runs-on: ${{ matrix.system.os }}
+    strategy:
+      fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
+      matrix:
+        system: [
+          { os: macos-11    },
+          { os: macos-10.15 },
+        ]
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR introduces matrix for multiple macOS systems.

For difference between `macos-10.15` and `macos-11`, see
https://github.com/actions/virtual-environments/issues/4060

Here's [actual build log on `macos-11`](https://github.com/t-mat/xxHash/runs/4376263530?check_suite_focus=true#step:3:6)
