### PR TITLE
Add clang-cl for MSVC 2019 to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,9 +376,9 @@ jobs:
       fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
       matrix:
         system: [
-          { os: windows-2022, vc: "VC++ 2022" },
-          { os: windows-2019, vc: "VC++ 2019" },
-          { os: windows-2016, vc: "VC++ 2017" }, # windows-2016 will be removed on March 15, 2022.
+          { os: windows-2022, vc: "VC++ 2022", clangcl: 'false', }, # CMake failed to configure clang-cl with VC++2022.
+          { os: windows-2019, vc: "VC++ 2019", clangcl: 'true',  },
+          { os: windows-2016, vc: "VC++ 2017", clangcl: 'false', }, # windows-2016 will be removed on March 15, 2022.
         ]
         arch: [ x64, Win32, ARM, ARM64 ]
     steps:
@@ -397,6 +397,21 @@ jobs:
       if: ${{ matrix.arch == 'x64' || matrix.arch == 'Win32' }}
       run: |
         .\cmake_unofficial\build\Release\xxhsum.exe -bi1
+
+    - name: Build ${{ matrix.system.os }}, clang-cl, ${{ matrix.arch }}
+      if: ${{ matrix.system.clangcl == 'true' }}
+      run: |
+        cd cmake_unofficial
+        mkdir build-clang-cl
+        cd build-clang-cl
+        cmake .. -DCMAKE_BUILD_TYPE=Release -A x64 -DCMAKE_GENERATOR_TOOLSET=ClangCL
+        cmake --build . --config Release
+
+    - name: Test (clang-cl)
+      # Run benchmark for testing only if target arch is x64 or Win32.
+      if: ${{ matrix.system.clangcl == 'true' && ( matrix.arch == 'x64' || matrix.arch == 'Win32' ) }}
+      run: |
+        .\cmake_unofficial\build-clang-cl\Release\xxhsum.exe -bi1
 
 
   # Windows, { mingw64, mingw32 }


### PR DESCRIPTION
This change introduces clang-cl for MSVC 2019.

As for MSVC 2022, it seems CMake fails to configure MSVC 2022 project with ClangCL.

Here's [actual build log](https://github.com/t-mat/xxHash/runs/4377319873?check_suite_focus=true#step:6:5).
