### PR TITLE
fix #627

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -5572,7 +5572,7 @@ XXH128_hashFromCanonical(const XXH128_canonical_t* src)
  */
 #define XXH_MIN(x, y) (((x) > (y)) ? (y) : (x))
 
-static void XXH3_combine16(void* dst, XXH128_hash_t h128)
+XXH_FORCE_INLINE void XXH3_combine16(void* dst, XXH128_hash_t h128)
 {
     XXH_writeLE64( dst, XXH_readLE64(dst) ^ h128.low64 );
     XXH_writeLE64( (char*)dst+8, XXH_readLE64((char*)dst+8) ^ h128.high64 );


### PR DESCRIPTION
attempt to fix a minor PVS Studio warning
which claims that passing a value by copy is worse for performance than a value by reference.
Given that the value is 16 bytes long, the claim is quite debatable, if not already silly from the start,
but it is even more so in this case because the function is very short and designed to be inlined by the compiler anyway.

Made the inlining objective more explicit, in an attempt to silence the static analyzer objection.

This is a blind fix, as I don't have PVS Studio to check.

fix #627 (hopefully)