### PR TITLE
fix cmake --install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,8 @@ jobs:
         cd build
         cmake ..
         CFLAGS=-Werror make
+        mkdir test_install_dir
+        DESTDIR=test_install_dir cmake --install .
 
 
   # Linux, { ARM, ARM64, PPC64LE, PPC64, S390X }

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -122,7 +122,7 @@ if(NOT XXHASH_BUNDLED_MODE)
     install(TARGETS xxhsum
       EXPORT xxHashTargets
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-    install(FILES "${XXHASH_DIR}/xxhsum.1"
+    install(FILES "${XXHSUM_DIR}/xxhsum.1"
       DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
   endif(XXHASH_BUILD_XXHSUM)
 


### PR DESCRIPTION
fix #646, reported by @kloczek .

Used this opportunity to add a `cmake --install` test in CI.