### PR TITLE
new build macro XXH_NO_STDLIB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,16 @@ noxxh3test: xxhash.c
 	$(NM) $(OFILE) | $(GREP) XXH3_ ; test $$? -eq 1
 	$(RM) $(OFILE)
 
+.PHONY: nostdlibtest
+nostdlibtest: CPPFLAGS += -DXXH_NO_STDLIB
+nostdlibtest: CFLAGS += -Werror -pedantic -Wno-long-long  # XXH64 requires long long support
+nostdlibtest: OFILE = xxh_nostdlib.o
+nostdlibtest: xxhash.c
+	@echo ---- test compilation without \<stdlib.h\> ----
+	$(CC) $(FLAGS) -c $^ -o $(OFILE)
+	$(NM) $(OFILE) | $(GREP) "U _free" ; test $$? -eq 1
+	$(RM) $(OFILE)
+
 .PHONY: usan
 usan: CC=clang
 usan: CXX=clang++
@@ -388,7 +398,7 @@ preview-man: man
 
 .PHONY: test
 test: DEBUGFLAGS += -DXXH_DEBUGLEVEL=1
-test: all namespaceTest check test-xxhsum-c c90test test-tools noxxh3test
+test: all namespaceTest check test-xxhsum-c c90test test-tools noxxh3test nostdlibtest
 
 .PHONY: test-inline
 test-inline:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ The following macros can be set at compilation time to modify libxxhash's behavi
 - `XXH32_ENDJMP`: Switch multi-branch finalization stage of XXH32 by a single jump.
                   This is generally undesirable for performance, especially when hashing inputs of random sizes.
                   But depending on exact architecture and compiler, a jump might provide slightly better performance on small inputs. Disabled by default.
+- `XXH_NO_STDLIB`: Disable invocation of `<stdlib.h>` functions, notably `malloc()` and `free()`.
+                   `libxxhash`'s `XXH*_createState()` will always fail and return `NULL`.
+                   But one-shot hashing (like `XXH32()`) or streaming using statically allocated states
+                   still work as expected.
+                   This build flag is useful for embedded environments without dynamic allocation.
 - `XXH_STATIC_LINKING_ONLY`: gives access to internal state declaration, required for static allocation.
                              Incompatible with dynamic linking, due to risks of ABI changes.
 - `XXH_NO_XXH3` : removes symbols related to `XXH3` (both 64 & 128 bits) from generated binary.

--- a/xxhash.h
+++ b/xxhash.h
@@ -1449,6 +1449,22 @@ XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
 /* *************************************
 *  Includes & Memory related functions
 ***************************************/
+#if defined(XXH_NO_STDLIB)
+
+/* When requesting to disable any mention of stdlib,
+ * the library loses the ability to invoked malloc / free.
+ * In practice, it means that functions like `XXH*_createState()`
+ * will always fail, and return NULL.
+ * This flag is useful in situations where
+ * xxhash.h is integrated into some kernel, embedded or limited environment
+ * without access to dynamic allocation.
+ */
+
+static void* XXH_malloc(size_t s) { (void)s; return NULL; }
+static void XXH_free(void* p) { (void)p; }
+
+#else
+
 /*
  * Modify the local functions below should you wish to use
  * different memory routines for malloc() and free()
@@ -1466,6 +1482,8 @@ static void* XXH_malloc(size_t s) { return malloc(s); }
  * @brief Modify this function to use a different routine than free().
  */
 static void XXH_free(void* p) { free(p); }
+
+#endif  /* XXH_NO_STDLIB */
 
 #include <string.h>
 


### PR DESCRIPTION
Useful for embedded / limited environments : 
ensures there is no usage / invocation of `<stdlib.h>` within `libxxhash`, notably no `malloc()` nor `free()`,
at the expense of `XXH*_createState()` functions, which now always return `NULL`.
This is only useful in situations where state is always allocated statically,
or only one-shot functions (like `XXH64()`) are used.