### PR TITLE
Fix build with clang

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -3365,6 +3365,7 @@ XXH_FORCE_INLINE uint64x2_t XXH_vld1q_u64(void const* ptr)
 #    if defined(__GNUC__) && !defined(__APPLE_ALTIVEC__)
 #      define __APPLE_ALTIVEC__
 #    endif
+#    define vector __vector
 #    include <altivec.h>
 #  endif
 


### PR DESCRIPTION
Currently build fails with error on FreeBSD/powerpc64le:
```
In file included from /wrkdirs/usr/ports/mail/rspamd-devel/work/rspamd-93430bb/contrib/xxhash/xxhash.h:3065:
/usr/lib/clang/11.0.1/include/altivec.h:55:19: error: unknown type name 'vector'
static __inline__ vector bool char __ATTRS_o_ai
                  ^
/usr/lib/clang/11.0.1/include/altivec.h:56:10: error: unknown type name 'vector'
vec_perm(vector bool char __a, vector bool char __b, vector unsigned char __c);
         ^
/usr/lib/clang/11.0.1/include/altivec.h:56:32: error: unknown type name 'vector'
vec_perm(vector bool char __a, vector bool char __b, vector unsigned char __c);
                               ^
/usr/lib/clang/11.0.1/include/altivec.h:66:19: error: unknown type name 'vector'
static __inline__ vector bool short __ATTRS_o_ai vec_perm(
                  ^
/usr/lib/clang/11.0.1/include/altivec.h:67:5: error: unknown type name 'vector'
    vector bool short __a, vector bool short __b, vector unsigned char __c);
    ^
/usr/lib/clang/11.0.1/include/altivec.h:67:28: error: unknown type name 'vector'
    vector bool short __a, vector bool short __b, vector unsigned char __c);
                           ^
/usr/lib/clang/11.0.1/include/altivec.h:80:19: error: unknown type name 'vector'
static __inline__ vector bool int __ATTRS_o_ai
                  ^
/usr/lib/clang/11.0.1/include/altivec.h:81:10: error: unknown type name 'vector'
vec_perm(vector bool int __a, vector bool int __b, vector unsigned char __c);
         ^
/usr/lib/clang/11.0.1/include/altivec.h:81:31: error: unknown type name 'vector'
vec_perm(vector bool int __a, vector bool int __b, vector unsigned char __c);
                              ^
/usr/lib/clang/11.0.1/include/altivec.h:96:19: error: unknown type name 'vector'
static __inline__ vector bool long long __ATTRS_o_ai
                  ^
/usr/lib/clang/11.0.1/include/altivec.h:97:10: error: unknown type name 'vector'
vec_perm(vector bool long long __a, vector bool long long __b,
         ^
/usr/lib/clang/11.0.1/include/altivec.h:97:37: error: unknown type name 'vector'
vec_perm(vector bool long long __a, vector bool long long __b,
                                    ^
/usr/lib/clang/11.0.1/include/altivec.h:203:9: error: unknown type name 'vector'
vec_add(vector bool char __a, vector signed char __b) {
        ^
/usr/lib/clang/11.0.1/include/altivec.h:208:33: error: unknown type name 'vector'
vec_add(vector signed char __a, vector bool char __b) {
                                ^
/usr/lib/clang/11.0.1/include/altivec.h:218:9: error: unknown type name 'vector'
vec_add(vector bool char __a, vector unsigned char __b) {
        ^
/usr/lib/clang/11.0.1/include/altivec.h:223:35: error: unknown type name 'vector'
vec_add(vector unsigned char __a, vector bool char __b) {
                                  ^
/usr/lib/clang/11.0.1/include/altivec.h:232:53: error: unknown type name 'vector'
static __inline__ vector short __ATTRS_o_ai vec_add(vector bool short __a,
                                                    ^
/usr/lib/clang/11.0.1/include/altivec.h:238:53: error: unknown type name 'vector'
                                                    vector bool short __b) {
                                                    ^
/usr/lib/clang/11.0.1/include/altivec.h:248:9: error: unknown type name 'vector'
vec_add(vector bool short __a, vector unsigned short __b) {
        ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```