### PR TITLE
Change dispatch breakpoint to XXH3_accumulate()

### DIFF
--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -459,7 +459,7 @@ XXHL64_default_##suffix(const void* XXH_RESTRICT input, size_t len)           \
 {                                                                             \
     return XXH3_hashLong_64b_internal(                                        \
                input, len, XXH3_kSecret, sizeof(XXH3_kSecret),                \
-               XXH3_accumulate_512_##suffix, XXH3_scrambleAcc_##suffix        \
+               XXH3_accumulate_##suffix, XXH3_scrambleAcc_##suffix            \
     );                                                                        \
 }                                                                             \
                                                                               \
@@ -470,7 +470,7 @@ XXHL64_seed_##suffix(const void* XXH_RESTRICT input, size_t len,              \
                      XXH64_hash_t seed)                                       \
 {                                                                             \
     return XXH3_hashLong_64b_withSeed_internal(                               \
-                    input, len, seed, XXH3_accumulate_512_##suffix,           \
+                    input, len, seed, XXH3_accumulate_##suffix,               \
                     XXH3_scrambleAcc_##suffix, XXH3_initCustomSecret_##suffix \
     );                                                                        \
 }                                                                             \
@@ -483,7 +483,7 @@ XXHL64_secret_##suffix(const void* XXH_RESTRICT input, size_t len,            \
 {                                                                             \
     return XXH3_hashLong_64b_internal(                                        \
                     input, len, secret, secretLen,                            \
-                    XXH3_accumulate_512_##suffix, XXH3_scrambleAcc_##suffix   \
+                    XXH3_accumulate_##suffix, XXH3_scrambleAcc_##suffix       \
     );                                                                        \
 }                                                                             \
                                                                               \
@@ -493,7 +493,7 @@ XXH_NO_INLINE target XXH_errorcode                                            \
 XXH3_update_##suffix(XXH3_state_t* state, const void* input, size_t len)      \
 {                                                                             \
     return XXH3_update(state, (const xxh_u8*)input, len,                      \
-                    XXH3_accumulate_512_##suffix, XXH3_scrambleAcc_##suffix); \
+                    XXH3_accumulate_##suffix, XXH3_scrambleAcc_##suffix);     \
 }                                                                             \
                                                                               \
 /* ===   XXH128 default variants   === */                                     \
@@ -503,7 +503,7 @@ XXHL128_default_##suffix(const void* XXH_RESTRICT input, size_t len)          \
 {                                                                             \
     return XXH3_hashLong_128b_internal(                                       \
                     input, len, XXH3_kSecret, sizeof(XXH3_kSecret),           \
-                    XXH3_accumulate_512_##suffix, XXH3_scrambleAcc_##suffix   \
+                    XXH3_accumulate_##suffix, XXH3_scrambleAcc_##suffix       \
     );                                                                        \
 }                                                                             \
                                                                               \
@@ -515,7 +515,7 @@ XXHL128_secret_##suffix(const void* XXH_RESTRICT input, size_t len,           \
 {                                                                             \
     return XXH3_hashLong_128b_internal(                                       \
                     input, len, (const xxh_u8*)secret, secretLen,             \
-                    XXH3_accumulate_512_##suffix, XXH3_scrambleAcc_##suffix); \
+                    XXH3_accumulate_##suffix, XXH3_scrambleAcc_##suffix);     \
 }                                                                             \
                                                                               \
 /* ===   XXH128 Seeded variants   === */                                      \
@@ -525,7 +525,7 @@ XXHL128_seed_##suffix(const void* XXH_RESTRICT input, size_t len,             \
                       XXH64_hash_t seed)                                      \
 {                                                                             \
     return XXH3_hashLong_128b_withSeed_internal(input, len, seed,             \
-                    XXH3_accumulate_512_##suffix, XXH3_scrambleAcc_##suffix,  \
+                    XXH3_accumulate_##suffix, XXH3_scrambleAcc_##suffix,      \
                     XXH3_initCustomSecret_##suffix);                          \
 }
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -4059,6 +4059,7 @@ XXH3_len_129to240_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
 #  define ACC_NB XXH_ACC_NB
 #endif
 
+#define XXH_TARGET_DEFAULT /* nothing */
 /*
  * These macros are to generate an XXH3_accumulate() function.
  * The two arguments select the name suffix, target attribute, and prefetch distance,
@@ -4090,7 +4091,7 @@ XXH3_accumulate_##name(     xxh_u64* XXH_RESTRICT acc,      \
 XXH3_ACCUMULATE_TEMPLATE_3(name, target, XXH_PREFETCH_DIST)
 
 #define XXH3_ACCUMULATE_TEMPLATE(name)                      \
-XXH3_ACCUMULATE_TEMPLATE_3(name, /* empty */, XXH_PREFETCH_DIST)
+XXH3_ACCUMULATE_TEMPLATE_3(name, XXH_TARGET_DEFAULT, XXH_PREFETCH_DIST)
 
 
 XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
@@ -4141,7 +4142,7 @@ XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
      || (defined(XXH_DISPATCH_AVX512) && XXH_DISPATCH_AVX512 != 0)
 
 #ifndef XXH_TARGET_AVX512
-# define XXH_TARGET_AVX512  /* disable attribute target */
+# define XXH_TARGET_AVX512  XXH_TARGET_DEFAULT
 #endif
 
 XXH_FORCE_INLINE XXH_TARGET_AVX512 void
@@ -4251,7 +4252,7 @@ XXH3_initCustomSecret_avx512(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
     || (defined(XXH_DISPATCH_AVX2) && XXH_DISPATCH_AVX2 != 0)
 
 #ifndef XXH_TARGET_AVX2
-# define XXH_TARGET_AVX2  /* disable attribute target */
+# define XXH_TARGET_AVX2  XXH_TARGET_DEFAULT
 #endif
 
 XXH_FORCE_INLINE XXH_TARGET_AVX2 void
@@ -4357,7 +4358,7 @@ XXH_FORCE_INLINE XXH_TARGET_AVX2 void XXH3_initCustomSecret_avx2(void* XXH_RESTR
 #if (XXH_VECTOR == XXH_SSE2) || defined(XXH_X86DISPATCH)
 
 #ifndef XXH_TARGET_SSE2
-# define XXH_TARGET_SSE2  /* disable attribute target */
+# define XXH_TARGET_SSE2  XXH_TARGET_DEFAULT
 #endif
 
 XXH_FORCE_INLINE XXH_TARGET_SSE2 void
@@ -4822,36 +4823,40 @@ typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
 
 #if (XXH_VECTOR == XXH_AVX512)
 
+#define XXH3_accumulate_512 XXH3_accumulate_512_avx512
 #define XXH3_accumulate     XXH3_accumulate_avx512
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_avx512
 #define XXH3_initCustomSecret XXH3_initCustomSecret_avx512
 
 #elif (XXH_VECTOR == XXH_AVX2)
 
+#define XXH3_accumulate_512 XXH3_accumulate_512_avx2
 #define XXH3_accumulate     XXH3_accumulate_avx2
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_avx2
 #define XXH3_initCustomSecret XXH3_initCustomSecret_avx2
 
 #elif (XXH_VECTOR == XXH_SSE2)
 
+#define XXH3_accumulate_512 XXH3_accumulate_512_sse2
 #define XXH3_accumulate     XXH3_accumulate_sse2
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_sse2
 #define XXH3_initCustomSecret XXH3_initCustomSecret_sse2
 
 #elif (XXH_VECTOR == XXH_NEON)
 
+#define XXH3_accumulate_512 XXH3_accumulate_512_neon
 #define XXH3_accumulate     XXH3_accumulate_neon
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_neon
 #define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
 
 #elif (XXH_VECTOR == XXH_VSX)
-
+#define XXH3_accumulate_512 XXH3_accumulate_512_vsx
 #define XXH3_accumulate     XXH3_accumulate_vsx
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_vsx
 #define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
 
 #else /* scalar */
-
+#define XXH3_accumulate_512 XXH3_accumulate_512_scalar
 #define XXH3_accumulate     XXH3_accumulate_scalar
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_scalar
 #define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
@@ -4893,7 +4898,7 @@ XXH3_hashLong_internal_loop(xxh_u64* XXH_RESTRICT acc,
         /* last stripe */
         {   const xxh_u8* const p = input + len - XXH_STRIPE_LEN;
 #define XXH_SECRET_LASTACC_START 7  /* not aligned on 8, last secret is different from acc & scrambler */
-            f_acc(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START, 1);
+            XXH3_accumulate_512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START);
     }   }
 }
 
@@ -5420,20 +5425,18 @@ XXH3_digest_long (XXH64_hash_t* acc,
                             secret, state->secretLimit,
                             XXH3_accumulate, XXH3_scrambleAcc);
         /* last stripe */
-        XXH3_accumulate(acc,
-                        state->buffer + state->bufferedSize - XXH_STRIPE_LEN,
-                        secret + state->secretLimit - XXH_SECRET_LASTACC_START,
-                        1);
+        XXH3_accumulate_512(acc,
+                            state->buffer + state->bufferedSize - XXH_STRIPE_LEN,
+                            secret + state->secretLimit - XXH_SECRET_LASTACC_START);
     } else {  /* bufferedSize < XXH_STRIPE_LEN */
         xxh_u8 lastStripe[XXH_STRIPE_LEN];
         size_t const catchupSize = XXH_STRIPE_LEN - state->bufferedSize;
         XXH_ASSERT(state->bufferedSize > 0);  /* there is always some input buffered */
         XXH_memcpy(lastStripe, state->buffer + sizeof(state->buffer) - catchupSize, catchupSize);
         XXH_memcpy(lastStripe + catchupSize, state->buffer, state->bufferedSize);
-        XXH3_accumulate(acc,
-                        lastStripe,
-                        secret + state->secretLimit - XXH_SECRET_LASTACC_START,
-                        1);
+        XXH3_accumulate_512(acc,
+                            lastStripe,
+                            secret + state->secretLimit - XXH_SECRET_LASTACC_START);
     }
 }
 


### PR DESCRIPTION
This is in preparation for an SVE implementation. It may also improve performance for the normal x86 dispatcher.