### PR TITLE
Use inline assembler for Power/IBM XL Compiler

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -3489,13 +3489,13 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_loadu(const void *ptr)
  * These intrinsics weren't added until GCC 8, despite existing for a while,
  * and they are endian dependent. Also, their meaning swap depending on version.
  * */
-# if defined(__s390x__) || defined(__ibmxl__)
+# if defined(__s390x__) 
  /* s390x is always big endian, no issue on this platform */
- /* The IBM XL Compiler only implements the standardized vec_* operations */
 #  define XXH_vec_mulo vec_mulo
 #  define XXH_vec_mule vec_mule
-# elif defined(__clang__) && XXH_HAS_BUILTIN(__builtin_altivec_vmuleuw)
+# elif defined(__clang__) && XXH_HAS_BUILTIN(__builtin_altivec_vmuleuw) && !defined(__ibmxl__)
 /* Clang has a better way to control this, we can just use the builtin which doesn't swap. */
+ /* The IBM XL Compiler (which defined __clang__) only implements the vec_* operations */
 #  define XXH_vec_mulo __builtin_altivec_vmulouw
 #  define XXH_vec_mule __builtin_altivec_vmuleuw
 # else

--- a/xxhash.h
+++ b/xxhash.h
@@ -3489,8 +3489,9 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_loadu(const void *ptr)
  * These intrinsics weren't added until GCC 8, despite existing for a while,
  * and they are endian dependent. Also, their meaning swap depending on version.
  * */
-# if defined(__s390x__)
+# if defined(__s390x__) || defined(__ibmxl__)
  /* s390x is always big endian, no issue on this platform */
+ /* The IBM XL Compiler only implements the standardized vec_* operations */
 #  define XXH_vec_mulo vec_mulo
 #  define XXH_vec_mule vec_mule
 # elif defined(__clang__) && XXH_HAS_BUILTIN(__builtin_altivec_vmuleuw)


### PR DESCRIPTION
Fixes #707. With that fix, the IBM XL Compiler can successfully compile xxHash.