### PR TITLE
avoid add_compile_definitions for cmake < v3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,20 @@ jobs:
         mkdir test_install_dir
         DESTDIR=test_install_dir cmake --install .
 
+    - name: cmake minimum version v2.8.12 test
+      run: |
+        mkdir -p cmake_bins
+        cd cmake_bins
+        wget https://cmake.org/files/v2.8/cmake-2.8.12.2-Linux-i386.tar.gz
+        tar xzf cmake-2.8.12.2-Linux-i386.tar.gz
+        cd ../cmake_unofficial
+        mkdir -p build
+        cd build
+        ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake ..
+        rm -rf *
+        ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+
 
   # Linux, { ARM, ARM64, PPC64LE, PPC64, S390X }
   # All tests are using QEMU and gcc cross compiler.

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -42,9 +42,14 @@ endif()
 if(NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "xxHash build type: ${CMAKE_BUILD_TYPE}")
 endif()
+
 # Enable assert() statements in debug builds
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  add_compile_definitions(XXH_DEBUGLEVEL=1)
+    if("${CMAKE_VERSION}" VERSION_LESS "3.12")
+        # add_compile_definitions is not available for older cmake => do nothing
+    else()
+        add_compile_definitions(XXH_DEBUGLEVEL=1)
+    endif()
 endif()
 
 option(BUILD_SHARED_LIBS "Build shared library" ON)


### PR DESCRIPTION
Fix #682

Also: added a Github CI test to check that future updates to the `cmake` recipe remain compatible with selected `v2.8.12` minimum version, in both release and debug modes.
