### PR TITLE
Pb when building with gcc-12 -Og

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1764,7 +1764,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  define XXH_NO_INLINE static
 /* enable inlining hints */
 #elif defined(__GNUC__) || defined(__clang__)
-#  define XXH_FORCE_INLINE static __inline__ __attribute__((always_inline, unused))
+#  define XXH_FORCE_INLINE static
 #  define XXH_NO_INLINE static __attribute__((noinline))
 #elif defined(_MSC_VER)  /* Visual Studio */
 #  define XXH_FORCE_INLINE static __forceinline


### PR DESCRIPTION
Fixes:
 | xxhash.h:3932:1: error: inlining failed in call to 'always_inline' 'XXH3_accumulate_512_sse2': function not considered for inlining
 |  3932 | XXH3_accumulate_512_sse2( void* XXH_RESTRICT acc,
 |       | ^~~~~~~~~~~~~~~~~~~~~~~~
 | xxhash.h:4369:9: note: called from here
 |  4369 |         f_acc512(acc,
 |       |         ^~~~~~~~~~~~~
 |  4370 |                  in,
 |       |                  ~~~
 |  4371 |                  secret + n*XXH_SECRET_CONSUME_RATE);
 |       |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>