### PR TITLE
Fix: brace expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ listL120:  # extract lines >= 120 characters in *.{c,h}, by Takayuki Matsuoka (n
 
 .PHONY: trailingWhitespace
 trailingWhitespace:
-	! $(GREP) -E "`printf '[ \\t]$$'`" cli/*.{c,h,1} *.c *.h LICENSE Makefile cmake_unofficial/CMakeLists.txt
+	! $(GREP) -E "`printf '[ \\t]$$'`" cli/*.c cli/*.h cli/*.1 *.c *.h LICENSE Makefile cmake_unofficial/CMakeLists.txt
 
 .PHONY: lint-unicode
 lint-unicode:


### PR DESCRIPTION
Currently, `make trailingWhitespace` fails with the following error (but `!` passes it).

```
$ make trailingWhitespace
! grep -E "`printf '[ \\t]$'`" cli/*.{c,h,1} *.c *.h LICENSE Makefile cmake_unofficial/CMakeLists.txt
grep: cli/*.{c,h,1}: No such file or directory
```

This error is caused by `cli/*.{c,h,1}`, because GNU `make` invokes `shell` which doesn't support brace expansion.

This PR fixes it with plain wildcards.
