### PR TITLE
Remove macOS-10.15 from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
         LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
 
-  # macOS, { 10.15, 11 }
+  # macOS, { 11 }
 
   macos-general:
     name: ${{ matrix.system.os }}
@@ -417,7 +417,6 @@ jobs:
       matrix:
         system: [
           { os: macos-11    },
-          { os: macos-10.15 },
         ]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR fixes the following error

<img width="637" alt="image" src="https://user-images.githubusercontent.com/898396/188182464-6910cb97-8082-49c9-8acb-c9b76cde7562.png">

See also:
- Actual error in CI : https://github.com/Cyan4973/xxHash/actions/runs/2979849990
- Announce from GitHub: https://github.com/actions/runner-images/issues/5583
