### PR TITLE
Fix xxhash.com address

### DIFF
--- a/doc/xxhash_spec.md
+++ b/doc/xxhash_spec.md
@@ -339,7 +339,7 @@ On 32-bit systems though, positions are reversed: `XXH64` performance is reduced
 Reference Implementation
 ----------------------------------------
 
-A reference library written in C is available at https://www.xxhash.com.
+A reference library written in C is available at [https://www.xxhash.com](https://cyan4973.github.io/xxHash/).
 The web page also links to multiple other implementations written in many different languages.
 It links to the [github project page](https://github.com/Cyan4973/xxHash) where an [issue board](https://github.com/Cyan4973/xxHash/issues) can be used for further public discussions on the topic.
 


### PR DESCRIPTION
Should be https://cyan4973.github.io/xxHash/ I reckon.