### PR TITLE
fix issues reported by cppcheck

### DIFF
--- a/cli/xsum_os_specific.c
+++ b/cli/xsum_os_specific.c
@@ -217,7 +217,6 @@ static int XSUM_stat(const char* infilename, XSUM_stat_t* statbuf)
 XSUM_ATTRIBUTE((__format__(__printf__, 2, 0)))
 static int XSUM_vasprintf(char** strp, const char* format, va_list ap)
 {
-    int ret;
     int size;
     va_list copy;
     /*
@@ -235,6 +234,7 @@ static int XSUM_vasprintf(char** strp, const char* format, va_list ap)
         *strp = NULL;
         return size;
     } else {
+        int ret;
         *strp = (char*) malloc((size_t)size + 1);
         if (*strp == NULL) {
             return -1;

--- a/cli/xsum_sanity_check.c
+++ b/cli/xsum_sanity_check.c
@@ -568,7 +568,7 @@ static void XSUM_testXXH128_withSecret(const void* data, const void* secret, siz
     XXH128_hash_t Nresult = testData->Nresult;
     if (len == 0) {
         data = NULL;
-    } else if (len>0) {
+    } else {
         assert(data != NULL);
     }
     {   XXH128_hash_t const Dresult = XXH3_128bits_withSecret(data, len, secret, secretSize);

--- a/tests/bench/benchHash.c
+++ b/tests/bench/benchHash.c
@@ -28,6 +28,7 @@
 
 #include <stdlib.h>   // malloc
 #include <assert.h>
+#include <string.h>
 
 #include "benchHash.h"
 
@@ -104,6 +105,7 @@ bench_hash_internal(BMK_benchFn_t hashfn, void* payload,
     };
     BMK_runOutcome_t result;
 
+    memset(&result, 0, sizeof(result));
     while (!BMK_isCompleted_TimedFn(txf)) {
         result = BMK_benchTimedFn(txf, params);
         assert(BMK_isSuccessful_runOutcome(result));

--- a/tests/bench/benchfn.c
+++ b/tests/bench/benchfn.c
@@ -90,6 +90,7 @@ static BMK_runOutcome_t BMK_runOutcome_error(size_t errorResult)
 static BMK_runOutcome_t BMK_setValid_runTime(BMK_runTime_t runTime)
 {
     BMK_runOutcome_t outcome;
+    memset(&outcome, 0, sizeof(outcome));
     outcome.error_tag_never_ever_use_directly = 0;
     outcome.internal_never_ever_use_directly = runTime;
     return outcome;

--- a/tests/collisions/main.c
+++ b/tests/collisions/main.c
@@ -206,7 +206,7 @@ static double Cnm(int n, int m)
 {
     assert(n > 0);
     assert(m > 0);
-    assert(m <= m);
+    assert(m <= n);
     double acc = 1;
     for (int i=0; i<m; i++) {
         acc *= n - i;


### PR DESCRIPTION
Run command "make clean cppcheck".

---- static analyzer - cppcheck ----
cppcheck . --force --enable=warning,portability,performance,style --error-exitcode=1 > /dev/null cli/xsum_os_specific.c:220:9: style: The scope of the variable 'ret' can be reduced. [variableScope]
    int ret;
        ^
cli/xsum_sanity_check.c:571:19: style: Condition 'len>0' is always true [knownConditionTrueFalse]
    } else if (len>0) {
                  ^
cli/xsum_sanity_check.c:569:13: note: Assuming that condition 'len==0' is not redundant
    if (len == 0) {
            ^
cli/xsum_sanity_check.c:571:19: note: Condition 'len>0' is always true
    } else if (len>0) {
                  ^
tests/bench/benchHash.c:112:55: error: Uninitialized variables: result.internal_never_ever_use_directly, result.error_result_never_ever_use_directly, result.error_tag_never_ever_use_directly [uninitvar]
    BMK_runTime_t const runTime = BMK_extract_runTime(result);
                                                      ^
tests/bench/benchHash.c:107:12: note: Assuming condition is false
    while (!BMK_isCompleted_TimedFn(txf)) {
           ^
tests/bench/benchHash.c:107:12: note: Assuming condition is false
    while (!BMK_isCompleted_TimedFn(txf)) {
           ^
tests/bench/benchHash.c:107:12: note: Assuming condition is false
    while (!BMK_isCompleted_TimedFn(txf)) {
           ^
tests/bench/benchHash.c:112:55: note: Uninitialized variables: result.internal_never_ever_use_directly, result.error_result_never_ever_use_directly, result.error_tag_never_ever_use_directly
    BMK_runTime_t const runTime = BMK_extract_runTime(result);
                                                      ^
tests/bench/benchfn.c:95:12: error: Uninitialized variable: outcome.error_result_never_ever_use_directly [uninitvar]
    return outcome;
           ^
tests/collisions/main.c:209:14: style: Same expression on both sides of '<='. [duplicateExpression]
    assert(m <= m);
             ^
make: *** [Makefile:387: cppcheck] Error 1

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>