### PR TITLE
ci: fix tipi build error on github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: mkdir -p ~/.tipi
+        # FIX: we currently need a full clone
+        with:
+          fetch-depth: '0'
+      - run: |
+        mkdir -p /usr/local/share/.tipi
+        # FIX: Hack for github action
+        git config --global --add safe.directory /usr/local/share/.tipi
+        git config --global --add safe.directory /__w/xxHash/xxHash/
 
       # checking if the xxHash project builds and passes tests
       - name: Build as project target linux-cxx17 (run test multiInclude)


### PR DESCRIPTION
[err] Dynamic exception type: std::runtime_error
std::exception::what: can not create git repository [-3] - config value
  'safe.directory' was not found
[err] Something went wrong, for help on your issue, we could enjoy getting
  your report at https://tipi.build/#contact
Error: Process completed with exit code 1.

Apply the workaround from Yannic (https://github.com/Cyan4973/xxHash/pull/744) on github CI workflow

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>
Cc: Yannic Staudt <yannic@tipi.build>