### PR TITLE
CI: fix missing space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,10 +563,10 @@ jobs:
         with:
           fetch-depth: '0'
       - run: |
-        mkdir -p /usr/local/share/.tipi
-        # FIX: Hack for github action
-        git config --global --add safe.directory /usr/local/share/.tipi
-        git config --global --add safe.directory /__w/xxHash/xxHash/
+          mkdir -p /usr/local/share/.tipi
+          # FIX: Hack for github action
+          git config --global --add safe.directory /usr/local/share/.tipi
+          git config --global --add safe.directory /__w/xxHash/xxHash/
 
       # checking if the xxHash project builds and passes tests
       - name: Build as project target linux-cxx17 (run test multiInclude)


### PR DESCRIPTION
Missing space caused that github action doesn't work.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>