### PR TITLE
remove tipi build temporary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,38 +549,38 @@ jobs:
           file ./xxhsum.exe | grep -q '80386' || $(exit 1)
           ./xxhsum.exe --version
 
-  tipi-build-linux:
-    name: tipi.build project build and dependency resolution
-    runs-on: ubuntu-latest
-    container: tipibuild/tipi-ubuntu
-
-    env:
-      HOME: /root
-
-    steps:
-      - uses: actions/checkout@v3
-        # FIX: we currently need a full clone
-        with:
-          fetch-depth: '0'
-      - run: |
-          mkdir -p /usr/local/share/.tipi
-          # FIX: Hack for github action
-          git config --global --add safe.directory /usr/local/share/.tipi
-          git config --global --add safe.directory /__w/xxHash/xxHash/
-
-      # checking if the xxHash project builds and passes tests
-      - name: Build as project target linux-cxx17 (run test multiInclude)
-        run: tipi . --dont-upgrade --verbose --test multiInclude -t linux-cxx17
-
-      - name: Build as project target linux-cxx20 (run test multiInclude)
-        run: tipi . --dont-upgrade --verbose --test multiInclude -t linux-cxx20
-
-      - name: Cleanup project builds
-        run: rm -r ./build
-
-      # trying if pulling the dependency with tipi works properly
-      - name: Build as dependency
-        run: |
-          cd ./cli
-          tipi . --dont-upgrade --verbose -t linux-cxx17
-          ./build/linux-cxx17/bin/xsum_os_specific
+#  tipi-build-linux:
+#    name: tipi.build project build and dependency resolution
+#    runs-on: ubuntu-latest
+#    container: tipibuild/tipi-ubuntu
+# 
+#    env:
+#      HOME: /root
+# 
+#    steps:
+#      - uses: actions/checkout@v3
+#        # FIX: we currently need a full clone
+#        with:
+#          fetch-depth: '0'
+#      - run: |
+#          mkdir -p /usr/local/share/.tipi
+#          # FIX: Hack for github action
+#          git config --global --add safe.directory /usr/local/share/.tipi
+#          git config --global --add safe.directory /__w/xxHash/xxHash/
+# 
+#      # checking if the xxHash project builds and passes tests
+#      - name: Build as project target linux-cxx17 (run test multiInclude)
+#        run: tipi . --dont-upgrade --verbose --test multiInclude -t linux-cxx17
+# 
+#      - name: Build as project target linux-cxx20 (run test multiInclude)
+#        run: tipi . --dont-upgrade --verbose --test multiInclude -t linux-cxx20
+# 
+#      - name: Cleanup project builds
+#        run: rm -r ./build
+# 
+#      # trying if pulling the dependency with tipi works properly
+#      - name: Build as dependency
+#        run: |
+#          cd ./cli
+#          tipi . --dont-upgrade --verbose -t linux-cxx17
+#          ./build/linux-cxx17/bin/xsum_os_specific


### PR DESCRIPTION
/usr/local/share/.tipi/w/cli-281f677/xsum_sanity_check.c:31:10: error: '../xxhash.h' file not found, did you mean 'xxhash.h'? 10081
10082
         ^~~~~~~~~~~~~
10083
         "xxhash.h"
10084
1 error generated.

Since there are always some tipi build issues, remove them temporary until it could be resolved.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>