### PR TITLE
Fixing tipi-build / Build as dependency CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,8 +579,21 @@ jobs:
         run: rm -r ./build
 
       # trying if pulling the dependency with tipi works properly
+      #
+      # note: the xxhashsum sources include xxhash using a #include "../xxhash.h" 
+      # this defeats the purpose of this test AND becase a bug post tipi v0.0.35 
+      # because of source mirroring (not) supporting relative include to locations
+      # outside of the project tree. 
+      #
+      # because of this we create a copy of the ./cli and apply some sed magic 
+      # to make the includes proper 'library' includes to simulate what someone
+      # consuming xxHash would do
+      #
+      # e.g. turning #include "../xxhash.h" => #include <xxhash.h>
       - name: Build as dependency
         run: |
-          cd ./cli
+          cp -a ./cli ./cli-tipi
+          cd ./cli-tipi
+          find ./ -type f -iname "*.c" | xargs sed -i 's;"../xxhash.h";<xxhash.h>;g'
           tipi . --dont-upgrade --verbose -t linux-cxx17
           ./build/linux-cxx17/bin/xsum_os_specific

--- a/cli/.tipi/deps
+++ b/cli/.tipi/deps
@@ -1,3 +1,3 @@
 {
-    "Cyan4973/xxHash": { "@": "v0.8.1" }
+    "Cyan4973/xxHash": { }
 }


### PR DESCRIPTION
As noted in https://github.com/Cyan4973/xxHash/pull/759 the way tipi synchronizes sources locally during build creates an issue the the case of relative includes that lead to paths outside of the build working directory structure.

Previously the in-place build tipi was running could resolve the path which could have masked issues with the dependency build.

As I think that knowing that xxHash can be depended upon in tipi projects is valuable here's a fix that patches the relative `#include`-s up during the build step.