### PR TITLE
VS2019 fix on xxhash.h

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1161,7 +1161,7 @@ struct XXH64_state_s {
 
 #ifndef XXH_NO_XXH3
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* >= C11 */
+#if !defined(_MSC_VER) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* >= C11 */
 #  include <stdalign.h>
 #  define XXH_ALIGN(n)      alignas(n)
 #elif defined(__cplusplus) && (__cplusplus >= 201103L) /* >= C++11 */


### PR DESCRIPTION
Issue on axmol (https://github.com/axmolengine/axmol): VS2019: thirdparty\xxhash: Cannot open include file: 'stdalign.h': No such file or directory  See also the solution:
https://github.com/axmolengine/axmol/issues/991