### PR TITLE
s390x: add memory barrier to avoid fault issue

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -4698,6 +4698,7 @@ XXH3_accumulate_512_vsx(  void* XXH_RESTRICT acc,
         /* xacc[i] = acc_vec; */
         vec_xst((xxh_u32x4)acc_vec, 0, xacc + 4 * i);
     }
+    __sync_synchronize();
 }
 XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(vsx)
 


### PR DESCRIPTION
The issue link is in below.
https://github.com/Cyan4973/xxHash/issues/766

This issue occurs randomly. If we downgrade gcc optimization from "O3" to "O2", this issue is gone.

Now use memory barrier to implement the same effect.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>