### PR TITLE
Refactor to improve code size, fix GCC 12

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1724,12 +1724,14 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
 #  pragma warning(disable : 4127) /* disable: C4127: conditional expression is constant */
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#  define XXH_UNUSED __attribute__((unused))
+#else
+#  define XXH_UNUSED /* nothing */
+#endif
+
 #if XXH_NO_INLINE_HINTS  /* disable inlining hints */
-#  if defined(__GNUC__) || defined(__clang__)
-#    define XXH_FORCE_INLINE static __attribute__((unused))
-#  else
-#    define XXH_FORCE_INLINE static
-#  endif
+#  define XXH_FORCE_INLINE static XXH_UNUSED
 #  define XXH_NO_INLINE static
 /* enable inlining hints */
 #elif defined(__GNUC__) || defined(__clang__)
@@ -1751,11 +1753,11 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
 #if XXH_SIZE_OPT <= 0
 #  define XXH_INLINE XXH_FORCE_INLINE
 #else
-#  define XXH_INLINE static
+#  define XXH_INLINE static XXH_UNUSED
 #endif
 
 #if XXH_32BIT_OPT
-#  define XXH_INLINE_64BIT static
+#  define XXH_INLINE_64BIT static XXH_UNUSED
 #else
 #  define XXH_INLINE_64BIT XXH_INLINE
 #endif

--- a/xxhash.h
+++ b/xxhash.h
@@ -2564,7 +2564,7 @@ XXH32_update(XXH32_state_t* state, const void* input, size_t len)
             state->bufferedSize = 0;
         }
 
-        if (xinput + sizeof(state->buffer) <= bEnd) {
+        if ((size_t)(bEnd - xinput) >= sizeof(state->buffer)) {
             /* Process the remaining data */
             xinput = XXH32_consumeLong(state->acc, xinput, (size_t)(bEnd - xinput), XXH_unaligned);
         }
@@ -3028,7 +3028,7 @@ XXH64_update (XXH_NOESCAPE XXH64_state_t* state, XXH_NOESCAPE const void* input,
             state->bufferedSize = 0;
         }
 
-        if (xinput + sizeof(state->buffer) <= bEnd) {
+        if ((size_t)(bEnd - xinput) >= sizeof(state->buffer)) {
             /* Process the remaining data */
             xinput = XXH64_consumeLong(state->acc, xinput, (size_t)(bEnd - xinput), XXH_unaligned);
         }

--- a/xxhash.h
+++ b/xxhash.h
@@ -1698,7 +1698,7 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
 #endif
 
 #ifndef XXH_NO_INLINE_HINTS
-#  if XXH_SIZE_OPT >= 1 || defined(__NO_INLINE__)  /* -O0, -fno-inline */
+#  if defined(__NO_INLINE__)  /* -O0, -fno-inline */
 #    define XXH_NO_INLINE_HINTS 1
 #  else
 #    define XXH_NO_INLINE_HINTS 0
@@ -1747,10 +1747,17 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
 #  define XXH_NO_INLINE static
 #endif
 
+/* XXH_INLINE forces inline when not optimizing for size. */
+#if XXH_SIZE_OPT <= 0
+#  define XXH_INLINE XXH_FORCE_INLINE
+#else
+#  define XXH_INLINE static
+#endif
+
 #if XXH_32BIT_OPT
 #  define XXH_INLINE_64BIT static
 #else
-#  define XXH_INLINE_64BIT XXH_FORCE_INLINE
+#  define XXH_INLINE_64BIT XXH_INLINE
 #endif
 
 /* *************************************
@@ -2162,7 +2169,7 @@ XXH_FORCE_INLINE xxh_u32 XXH_readLE32(const void* memPtr)
          | ((xxh_u32)bytePtr[3] << 24);
 }
 
-XXH_FORCE_INLINE xxh_u32 XXH_readBE32(const void* memPtr)
+XXH_INLINE xxh_u32 XXH_readBE32(const void* memPtr)
 {
     const xxh_u8* bytePtr = (const xxh_u8 *)memPtr;
     return bytePtr[3]
@@ -2300,7 +2307,7 @@ static xxh_u32 XXH32_avalanche(xxh_u32 hash)
  * @internal
  * @brief Sets up the initial accumulator state for XXH32().
  */
-XXH_FORCE_INLINE void
+XXH_INLINE void
 XXH32_initAccs(xxh_u32 *acc, xxh_u32 seed)
 {
     XXH_ASSERT(acc != NULL);
@@ -2316,7 +2323,7 @@ XXH32_initAccs(xxh_u32 *acc, xxh_u32 seed)
  *
  * @return the end input pointer.
  */
-XXH_FORCE_INLINE const xxh_u8 *
+XXH_INLINE const xxh_u8 *
 XXH32_consumeLong(
     xxh_u32 *XXH_RESTRICT acc,
     xxh_u8 const *XXH_RESTRICT input,
@@ -2793,7 +2800,7 @@ static xxh_u64 XXH64_avalanche(xxh_u64 hash)
  * @internal
  * @brief Sets up the initial accumulator state for XXH64().
  */
-XXH_FORCE_INLINE void
+XXH_INLINE void
 XXH64_initAccs(xxh_u64 *acc, xxh_u64 seed)
 {
     XXH_ASSERT(acc != NULL);
@@ -2917,7 +2924,7 @@ XXH64_finalize(xxh_u64 hash, const xxh_u8* ptr, size_t len, XXH_alignment align)
  * @param align Whether @p input is aligned.
  * @return The calculated hash.
  */
-XXH_FORCE_INLINE XXH_PUREF xxh_u64
+XXH_INLINE XXH_PUREF xxh_u64
 XXH64_endian_align(const xxh_u8* input, size_t len, xxh_u64 seed, XXH_alignment align)
 {
     xxh_u64 h64;
@@ -3841,7 +3848,7 @@ static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len)
  *
  * This adds an extra layer of strength for custom secrets.
  */
-XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH_INLINE XXH_PUREF XXH64_hash_t
 XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
 {
     XXH_ASSERT(input != NULL);
@@ -3863,7 +3870,7 @@ XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_h
     }
 }
 
-XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH_INLINE XXH_PUREF XXH64_hash_t
 XXH3_len_4to8_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
 {
     XXH_ASSERT(input != NULL);
@@ -3879,7 +3886,7 @@ XXH3_len_4to8_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_h
     }
 }
 
-XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH_INLINE XXH_PUREF XXH64_hash_t
 XXH3_len_9to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
 {
     XXH_ASSERT(input != NULL);
@@ -3896,7 +3903,7 @@ XXH3_len_9to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
     }
 }
 
-XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH_INLINE XXH_PUREF XXH64_hash_t
 XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
 {
     XXH_ASSERT(len <= 16);
@@ -4738,7 +4745,7 @@ XXH3_scrambleAcc_vsx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 
 #if (XXH_VECTOR == XXH_SVE)
 
-XXH_FORCE_INLINE void
+XXH_INLINE void
 XXH3_accumulate_512_sve( void* XXH_RESTRICT acc,
                    const void* XXH_RESTRICT input,
                    const void* XXH_RESTRICT secret)
@@ -4778,7 +4785,7 @@ XXH3_accumulate_512_sve( void* XXH_RESTRICT acc,
     }
 }
 
-XXH_FORCE_INLINE void
+XXH_INLINE void
 XXH3_accumulate_sve(xxh_u64* XXH_RESTRICT acc,
                const xxh_u8* XXH_RESTRICT input,
                const xxh_u8* XXH_RESTRICT secret,
@@ -4894,7 +4901,7 @@ XXH3_accumulate_512_scalar(void* XXH_RESTRICT acc,
         XXH3_scalarRound(acc, input, secret, i);
     }
 }
-XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(scalar)
+XXH_INLINE XXH3_ACCUMULATE_TEMPLATE(scalar)
 
 /*!
  * @internal
@@ -4926,7 +4933,7 @@ XXH3_scalarScrambleRound(void* XXH_RESTRICT acc,
  * @internal
  * @brief Scrambles the accumulators after a large chunk has been read
  */
-XXH_FORCE_INLINE void
+XXH_INLINE void
 XXH3_scrambleAcc_scalar(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 {
     size_t i;
@@ -5064,7 +5071,7 @@ typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
 #  define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
 #endif
 
-XXH_FORCE_INLINE void
+XXH_INLINE void
 XXH3_hashLong_internal_loop(xxh_u64* XXH_RESTRICT acc,
                       const xxh_u8* XXH_RESTRICT input, size_t len,
                       const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
@@ -5144,7 +5151,7 @@ XXH3_finalizeLong_64b(const xxh_u64* XXH_RESTRICT acc, const xxh_u8* XXH_RESTRIC
 #define XXH3_INIT_ACC { XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3, \
                         XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1 }
 
-XXH_FORCE_INLINE XXH64_hash_t
+XXH_INLINE XXH64_hash_t
 XXH3_hashLong_64b_internal(const void* XXH_RESTRICT input, size_t len,
                            const void* XXH_RESTRICT secret, size_t secretSize,
                            XXH3_f_accumulate f_acc,
@@ -5165,7 +5172,7 @@ XXH3_hashLong_64b_internal(const void* XXH_RESTRICT input, size_t len,
  * so that the compiler can properly optimize the vectorized loop.
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
-XXH_FORCE_INLINE XXH64_hash_t
+XXH_INLINE XXH64_hash_t
 XXH3_hashLong_64b_withSecret(const void* XXH_RESTRICT input, size_t len,
                              XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
 {
@@ -5198,7 +5205,7 @@ XXH3_hashLong_64b_default(const void* XXH_RESTRICT input, size_t len,
  * It's important for performance that XXH3_hashLong is not inlined. Not sure
  * why (uop cache maybe?), but the difference is large and easily measurable.
  */
-XXH_FORCE_INLINE XXH64_hash_t
+XXH_INLINE XXH64_hash_t
 XXH3_hashLong_64b_withSeed_internal(const void* input, size_t len,
                                     XXH64_hash_t seed,
                                     XXH3_f_accumulate f_acc,
@@ -5234,7 +5241,7 @@ XXH3_hashLong_64b_withSeed(const void* XXH_RESTRICT input, size_t len,
 typedef XXH64_hash_t (*XXH3_hashLong64_f)(const void* XXH_RESTRICT, size_t,
                                           XXH64_hash_t, const xxh_u8* XXH_RESTRICT, size_t);
 
-XXH_FORCE_INLINE XXH64_hash_t
+XXH_INLINE XXH64_hash_t
 XXH3_64bits_internal(const void* XXH_RESTRICT input, size_t len,
                      XXH64_hash_t seed64, const void* XXH_RESTRICT secret, size_t secretLen,
                      XXH3_hashLong64_f f_hashLong)
@@ -5494,7 +5501,7 @@ XXH3_consumeStripes(xxh_u64* XXH_RESTRICT acc,
 /*
  * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
  */
-XXH_FORCE_INLINE XXH_errorcode
+XXH_INLINE XXH_errorcode
 XXH3_update(XXH3_state_t* XXH_RESTRICT const state,
             const xxh_u8* XXH_RESTRICT input, size_t len,
             XXH3_f_accumulate f_acc,
@@ -5781,7 +5788,7 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
 /*
  * Assumption: `secret` size is >= XXH3_SECRET_SIZE_MIN
  */
-XXH_FORCE_INLINE XXH_PUREF XXH128_hash_t
+XXH_INLINE XXH_PUREF XXH128_hash_t
 XXH3_len_0to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
 {
     XXH_ASSERT(len <= 16);
@@ -5920,7 +5927,7 @@ XXH3_finalizeLong_128b(const xxh_u64* XXH_RESTRICT acc, const xxh_u8* XXH_RESTRI
     return h128;
 }
 
-XXH_FORCE_INLINE XXH128_hash_t
+XXH_INLINE XXH128_hash_t
 XXH3_hashLong_128b_internal(const void* XXH_RESTRICT input, size_t len,
                             const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
                             XXH3_f_accumulate f_acc,
@@ -5963,7 +5970,7 @@ XXH3_hashLong_128b_withSecret(const void* XXH_RESTRICT input, size_t len,
                                        XXH3_accumulate, XXH3_scrambleAcc);
 }
 
-XXH_FORCE_INLINE XXH128_hash_t
+XXH_INLINE XXH128_hash_t
 XXH3_hashLong_128b_withSeed_internal(const void* XXH_RESTRICT input, size_t len,
                                 XXH64_hash_t seed64,
                                 XXH3_f_accumulate f_acc,

--- a/xxhash.h
+++ b/xxhash.h
@@ -1660,11 +1660,13 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
 
 #ifndef XXH_32BIT_OPT
    /* detect x32 and arm64_32 */
-#  if defined(__x86_64__) || defined(__arm64__) || defined(__aarch64__)
+#  if defined(__x86_64__) || defined(__arm64__) || defined(__aarch64__) || defined(__mips64__) \
+    || defined(__LP64__) || defined(__LLP64__) || defined(_WIN64) \
+    || defined(_M_X64) || defined(_M_ARM64) \
+    || (defined(SIZE_MAX) && (SIZE_MAX >> 1) > 0x80000000UL) /* Avoid comparison warnings */
 #     define XXH_32BIT_OPT 0
 #  else
-      /* avoid potential comparison warnings */
-#     define XXH_32BIT_OPT ((SIZE_MAX >> 1) < (0x80000000UL))
+#     define XXH_32BIT_OPT 1
 #  endif
 #endif
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -1633,16 +1633,6 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
 #  define XXH32_ENDJMP 0
 
 /*!
- * @internal
- * @brief Redefines old internal names.
- *
- * For compatibility with code that uses xxHash's internals before the names
- * were changed to improve namespacing. There is no other reason to use this.
- */
-#  define XXH_OLD_NAMES
-#  undef XXH_OLD_NAMES /* don't actually use, it is ugly. */
-
-/*!
  * @def XXH_NO_STREAM
  * @brief Disables the streaming API.
  *
@@ -1887,12 +1877,6 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #endif
 typedef XXH32_hash_t xxh_u32;
 
-#ifdef XXH_OLD_NAMES
-#  define BYTE xxh_u8
-#  define U8   xxh_u8
-#  define U32  xxh_u32
-#endif
-
 /* ***   Memory access   *** */
 
 /*!
@@ -1967,9 +1951,6 @@ static xxh_u32 XXH_read32(const void* memPtr) { return *(const xxh_u32*) memPtr;
  * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69502,
  * https://gcc.godbolt.org/z/xYez1j67Y.
  */
-#ifdef XXH_OLD_NAMES
-typedef union { xxh_u32 u32; } __attribute__((packed)) unalign;
-#endif
 static xxh_u32 XXH_read32(const void* ptr)
 {
     typedef __attribute__((aligned(1))) xxh_u32 xxh_unalign32;
@@ -2214,14 +2195,6 @@ XXH_PUBLIC_API unsigned XXH_versionNumber (void) { return XXH_VERSION_NUMBER; }
 #define XXH_PRIME32_4  0x27D4EB2FU  /*!< 0b00100111110101001110101100101111 */
 #define XXH_PRIME32_5  0x165667B1U  /*!< 0b00010110010101100110011110110001 */
 
-#ifdef XXH_OLD_NAMES
-#  define PRIME32_1 XXH_PRIME32_1
-#  define PRIME32_2 XXH_PRIME32_2
-#  define PRIME32_3 XXH_PRIME32_3
-#  define PRIME32_4 XXH_PRIME32_4
-#  define PRIME32_5 XXH_PRIME32_5
-#endif
-
 /*!
  * @internal
  * @brief Normal stripe processing routine.
@@ -2442,13 +2415,8 @@ XXH32_finalize(xxh_u32 hash, const xxh_u8* ptr, size_t len, XXH_alignment align)
     }
 }
 
-#ifdef XXH_OLD_NAMES
-#  define PROCESS1 XXH_PROCESS1
-#  define PROCESS4 XXH_PROCESS4
-#else
-#  undef XXH_PROCESS1
-#  undef XXH_PROCESS4
-#endif
+#undef XXH_PROCESS1
+#undef XXH_PROCESS4
 
 /*!
  * @internal
@@ -2637,10 +2605,6 @@ XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src
 
 typedef XXH64_hash_t xxh_u64;
 
-#ifdef XXH_OLD_NAMES
-#  define U64 xxh_u64
-#endif
-
 #if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==3))
 /*
  * Manual byteshift. Best for old compilers which don't inline memcpy.
@@ -2663,9 +2627,6 @@ static xxh_u64 XXH_read64(const void* memPtr)
  * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69502,
  * https://gcc.godbolt.org/z/xYez1j67Y.
  */
-#ifdef XXH_OLD_NAMES
-typedef union { xxh_u32 u32; xxh_u64 u64; } __attribute__((packed)) unalign64;
-#endif
 static xxh_u64 XXH_read64(const void* ptr)
 {
     typedef __attribute__((aligned(1))) xxh_u64 xxh_unalign64;
@@ -2772,14 +2733,6 @@ XXH_readLE64_align(const void* ptr, XXH_alignment align)
 #define XXH_PRIME64_3  0x165667B19E3779F9ULL  /*!< 0b0001011001010110011001111011000110011110001101110111100111111001 */
 #define XXH_PRIME64_4  0x85EBCA77C2B2AE63ULL  /*!< 0b1000010111101011110010100111011111000010101100101010111001100011 */
 #define XXH_PRIME64_5  0x27D4EB2F165667C5ULL  /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
-
-#ifdef XXH_OLD_NAMES
-#  define PRIME64_1 XXH_PRIME64_1
-#  define PRIME64_2 XXH_PRIME64_2
-#  define PRIME64_3 XXH_PRIME64_3
-#  define PRIME64_4 XXH_PRIME64_4
-#  define PRIME64_5 XXH_PRIME64_5
-#endif
 
 /*! @copydoc XXH32_round */
 static xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input)
@@ -2932,15 +2885,9 @@ XXH64_finalize(xxh_u64 hash, const xxh_u8* ptr, size_t len, XXH_alignment align)
     return  XXH64_avalanche(hash);
 }
 
-#ifdef XXH_OLD_NAMES
-#  define PROCESS1_64 XXH_PROCESS1_64
-#  define PROCESS4_64 XXH_PROCESS4_64
-#  define PROCESS8_64 XXH_PROCESS8_64
-#else
-#  undef XXH_PROCESS1_64
-#  undef XXH_PROCESS4_64
-#  undef XXH_PROCESS8_64
-#endif
+#undef XXH_PROCESS1_64
+#undef XXH_PROCESS4_64
+#undef XXH_PROCESS8_64
 
 /*!
  * @internal
@@ -3621,11 +3568,6 @@ XXH_ALIGN(64) static const xxh_u8 XXH3_kSecret[XXH_SECRET_DEFAULT_SIZE] = {
     0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
 };
 
-
-#ifdef XXH_OLD_NAMES
-#  define kSecret XXH3_kSecret
-#endif
-
 #ifdef XXH_DOXYGEN
 /*!
  * @brief Calculates a 32-bit to 64-bit long multiply.
@@ -4109,11 +4051,6 @@ XXH3_len_129to240_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
 #define XXH_STRIPE_LEN 64
 #define XXH_SECRET_CONSUME_RATE 8   /* nb of secret bytes consumed at each accumulation */
 #define XXH_ACC_NB (XXH_STRIPE_LEN / sizeof(xxh_u64))
-
-#ifdef XXH_OLD_NAMES
-#  define STRIPE_LEN XXH_STRIPE_LEN
-#  define ACC_NB XXH_ACC_NB
-#endif
 
 #ifndef XXH_PREFETCH_DIST
 #  ifdef __clang__


### PR DESCRIPTION
### Overview

Kinda a dump of (mostly) related changes I've been sitting on and never bothered to commit.

This is a set of changes to:
 - Reduce code size on `-O3`
    -  Especially on 32-bit, where `-O3` could get well over 100 kB `.text`
    - I feel this could still be improved if `hashLong` constant propagation can be reduced
 - Improve `-Os`/`XXH_SIZE_OPT` performance
 - Make things more clean and modular

**These haven't been micro-benchmarked yet.** The "what is worth inlining" is a rough estimate, and I want to go through the various recent compilers to find what works best. 


### Major changes:
 - GCC 12 will now be forced to `-O3` to work around the `-Og` bug. Fixes #800, #720 
    - Only applies when `__OPTIMIZE__`, `!__NO_INLINE__` and `XXH_SIZE_OPT <= 0` (`!__OPTIMIZE_SIZE__`), so `-O2` and `-Og` both apply
    - I tried with adjusting the inline hints but that tanked performance.
 - `XXH_INLINE`: Acts like existing `XXH_FORCE_INLINE` where it is disabled when `XXH_SIZE_OPT` is used.
    - `XXH_FORCE_INLINE` now actually force inlines unconditionally (when inline hints are on) and is used on XXH3 and XXH32's core loops and utilities. 
    - Greatly improves GCC `-Os` performance with only a small code size overhead
 - `XXH_32BIT_OPT`, `XXH_INLINE_64BIT`: These are used to reduce code bloat on 32-bit
    - This with the other related optimizations reduce `clang armv4t -O3` code size by **about half**, now being <100 kB
 - `XXH32` and `XXH64` have been rewritten to reuse the algorithm steps
 - `XXH3_update` has been rewritten to be much easier to understand and much smaller.
 - `XXH3_128bits_update` now tail calls `XXH3_64bits_update`, *greatly* reducing code size at the cost of one branch

### Minor changes:
 - GCC 11 and higher no longer force `-O2` on AVX2, that bug has been fixed.
 - `XXH32_state_t` and `XXH64_state_t` have some fields renamed and now use `unsigned char [N]` for their buffer
 - `XXH_OLD_NAMES` has been removed, it's been long enough
 - Fixed a few inline hints
 - Some reused snippets in XXH3 have been extracted into functions.
 - Fixed a theoretical integer overflow in the update code