### PR TITLE
Fix: add gcc -Og check and fix its false positive warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,11 @@ clangtest: clean
 	@echo ---- test clang compilation ----
 	CC=clang MOREFLAGS="-Werror -Wconversion -Wno-sign-conversion" $(MAKE) all
 
+.PHONY: gcc-og-test
+gcc-og-test: clean
+	@echo ---- test gcc -Og compilation ----
+	CFLAGS="-Og -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror -fPIC" MOREFLAGS="-Werror" $(MAKE) all
+
 .PHONY: cxxtest
 cxxtest: clean
 	@echo ---- test C++ compilation ----
@@ -420,7 +425,7 @@ test-inline:
 
 .PHONY: test-all
 test-all: CFLAGS += -Werror
-test-all: test test32 test-unicode clangtest cxxtest usan test-inline listL120 trailingWhitespace test-xxh-nnn-sums
+test-all: test test32 test-unicode clangtest gcc-og-test cxxtest usan test-inline listL120 trailingWhitespace test-xxh-nnn-sums
 
 .PHONY: test-tools
 test-tools:

--- a/xxhash.h
+++ b/xxhash.h
@@ -1285,7 +1285,12 @@ struct XXH3_state_s {
  * Note that this doesn't prepare the state for a streaming operation,
  * it's still necessary to use XXH3_NNbits_reset*() afterwards.
  */
-#define XXH3_INITSTATE(XXH3_state_ptr)   { (XXH3_state_ptr)->seed = 0; }
+#define XXH3_INITSTATE(XXH3_state_ptr)                       \
+    do {                                                     \
+        XXH3_state_t* tmp_xxh3_state_ptr = (XXH3_state_ptr); \
+        tmp_xxh3_state_ptr->seed = 0;                        \
+        tmp_xxh3_state_ptr->extSecret = NULL;                \
+    } while(0)
 
 
 /*!


### PR DESCRIPTION
Before adding `gcc-12` and `-Og` test to our CI, I'd like to fix `gcc -Og` issue.
See also #810

Actually, this is a false positve of `gcc -Og`.  So there must be another ways to avoid this warning.
But since it seems there's easy / safe / explicit fix for it with negilible const, I'd like to it to `XXH3_INITSTATE()`.
( See advice https://github.com/Cyan4973/xxHash/issues/810#issuecomment-1455245974 from  @easyaspi314 )
