### PR TITLE
Fix off-by-one in XXH3_consumeStripes() (Fixes #816)

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -5471,7 +5471,7 @@ XXH3_consumeStripes(xxh_u64* XXH_RESTRICT acc,
             /* Then continue the loop with the full block size */
             nbStripesThisIter = nbStripesPerBlock;
             initialSecret = secret;
-        } while (nbStripes > nbStripesPerBlock);
+        } while (nbStripes >= nbStripesPerBlock);
         *nbStripesSoFarPtr = 0;
     }
     /* Process a partial block */


### PR DESCRIPTION
Silly error by me that caused a scramble to be skipped.