### PR TITLE
benchmark : adjust initial speed target to 10 MB/s

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The following macros can be set at compilation time to modify libxxhash's behavi
 
 When compiling the Command Line Interface `xxhsum` using `make`, the following environment variables can also be set :
 - `DISPATCH=1` : use `xxh_x86dispatch.c`, to automatically select between `scalar`, `sse2`, `avx2` or `avx512` instruction set at runtime, depending on local host. This option is only valid for `x86`/`x64` systems.
+- `XXH_1ST_SPEED_TARGET` : select an initial speed target, expressed in MB/s, for the first speed test in benchmark mode. Benchmark will adjust the target at subsequent iterations, but the first test is made "blindly" by targeting this speed. Currently conservatively set to 10 MB/s, to support very slow (emulated) platforms.
 
 ### Building xxHash - Using vcpkg
 

--- a/cli/xsum_bench.c
+++ b/cli/xsum_bench.c
@@ -45,6 +45,18 @@
 #define TIMELOOP  (TIMELOOP_S * CLOCKS_PER_SEC)   /* target timing per iteration */
 #define TIMELOOP_MIN (TIMELOOP / 2)               /* minimum timing to validate a result */
 
+/* Each benchmark iteration attempts to match TIMELOOP (1 second).
+ * The nb of loops is adjusted at each iteration to reach that target.
+ * However, initially, there is no information, so 1st iteration blindly targets an arbitrary speed.
+ * If it's too small, it will be adjusted, and a new attempt will be made.
+ * But if it's too large, the first iteration can be very long,
+ * before being fixed at second attempt.
+ * So prefer starting with small speed targets.
+ * XXH_1ST_SPEED_TARGET is defined in MB/s */
+#ifndef XXH_1ST_SPEED_TARGET
+# define XXH_1ST_SPEED_TARGET 10
+#endif
+
 #define MAX_MEM    (2 GB - 64 MB)
 
 static clock_t XSUM_clockSpan( clock_t start )
@@ -216,7 +228,7 @@ int g_nbIterations = NBLOOPS_DEFAULT;
 static void XSUM_benchHash(hashFunction h, const char* hName, int testID,
                            const void* buffer, size_t bufferSize)
 {
-    XSUM_U32 nbh_perIteration = (XSUM_U32)((300 MB) / (bufferSize+1)) + 1;  /* first iteration conservatively aims for 300 MB/s */
+    XSUM_U32 nbh_perIteration = (XSUM_U32)((XXH_1ST_SPEED_TARGET MB) / (bufferSize+1)) + 1;
     int iterationNb, nbIterations = g_nbIterations + !g_nbIterations /* min 1 */;
     double fastestH = 100000000.;
     assert(HASHNAME_MAX > 2);


### PR DESCRIPTION
Additionally, the initial speed target can be selected at compilation time, by setting new optional build macro `XXH_1ST_SPEED_TARGET`.

Solves @easyaspi314 comment in https://github.com/Cyan4973/xxHash/issues/821#issuecomment-1462961579, in order to support "1.5 GHz Cortex-A53 tablet with `s390x` in QEMU with `-O0 -mzvector`" which is very slow.