### PR TITLE
Dedicated sanity test program

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
       matrix:
         include: [
           { name: 'ARM',             xcc_pkg: gcc-arm-linux-gnueabi,        xcc: arm-linux-gnueabi-gcc,        xemu_pkg: qemu-system-arm,   xemu: qemu-arm-static,     os: ubuntu-latest, },
-          { name: 'ARM64',           xcc_pkg: gcc-aarch64-linux-gnu,        xcc: aarch64-linux-gnu-gcc,        xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-latest, },
+          { name: 'AARCH64',         xcc_pkg: gcc-aarch64-linux-gnu,        xcc: aarch64-linux-gnu-gcc,        xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-latest, },
           { name: 'PPC64LE',         xcc_pkg: gcc-powerpc64le-linux-gnu,    xcc: powerpc64le-linux-gnu-gcc,    xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64le-static, os: ubuntu-latest, },
           { name: 'PPC64',           xcc_pkg: gcc-powerpc64-linux-gnu,      xcc: powerpc64-linux-gnu-gcc,      xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64-static,   os: ubuntu-latest, },
           { name: 'S390X',           xcc_pkg: gcc-s390x-linux-gnu,          xcc: s390x-linux-gnu-gcc,          xemu_pkg: qemu-system-s390x, xemu: qemu-s390x-static,   os: ubuntu-latest, },
@@ -313,21 +313,21 @@ jobs:
           { name: 'M68K',            xcc_pkg: gcc-m68k-linux-gnu,           xcc: m68k-linux-gnu-gcc,           xemu_pkg: qemu-system-m68k,  xemu: qemu-m68k-static,    os: ubuntu-latest, },
 
           { name: 'ARM, gcc-10',     xcc_pkg: gcc-10-arm-linux-gnueabi,     xcc: arm-linux-gnueabi-gcc-10,     xemu_pkg: qemu-system-arm,   xemu: qemu-arm-static,     os: ubuntu-20.04, },
-          { name: 'ARM64, gcc-10',   xcc_pkg: gcc-10-aarch64-linux-gnu,     xcc: aarch64-linux-gnu-gcc-10,     xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
+          { name: 'AARCH64, gcc-10', xcc_pkg: gcc-10-aarch64-linux-gnu,     xcc: aarch64-linux-gnu-gcc-10,     xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
           { name: 'PPC64LE, gcc-10', xcc_pkg: gcc-10-powerpc64le-linux-gnu, xcc: powerpc64le-linux-gnu-gcc-10, xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64le-static, os: ubuntu-20.04, },
           { name: 'PPC64, gcc-10',   xcc_pkg: gcc-10-powerpc64-linux-gnu,   xcc: powerpc64-linux-gnu-gcc-10,   xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64-static,   os: ubuntu-20.04, },
           { name: 'S390X, gcc-10',   xcc_pkg: gcc-10-s390x-linux-gnu,       xcc: s390x-linux-gnu-gcc-10,       xemu_pkg: qemu-system-s390x, xemu: qemu-s390x-static,   os: ubuntu-20.04, },
           { name: 'MIPS, gcc-10',    xcc_pkg: gcc-10-mips-linux-gnu,        xcc: mips-linux-gnu-gcc-10,        xemu_pkg: qemu-system-mips,  xemu: qemu-mips-static,    os: ubuntu-20.04, },
 
           { name: 'ARM, gcc-9',      xcc_pkg: gcc-9-arm-linux-gnueabi,      xcc: arm-linux-gnueabi-gcc-9,      xemu_pkg: qemu-system-arm,   xemu: qemu-arm-static,     os: ubuntu-20.04, },
-          { name: 'ARM64, gcc-9',    xcc_pkg: gcc-9-aarch64-linux-gnu,      xcc: aarch64-linux-gnu-gcc-9,      xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
+          { name: 'AARCH64, gcc-9',  xcc_pkg: gcc-9-aarch64-linux-gnu,      xcc: aarch64-linux-gnu-gcc-9,      xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
           { name: 'PPC64LE, gcc-9',  xcc_pkg: gcc-9-powerpc64le-linux-gnu,  xcc: powerpc64le-linux-gnu-gcc-9,  xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64le-static, os: ubuntu-20.04, },
           { name: 'PPC64, gcc-9',    xcc_pkg: gcc-9-powerpc64-linux-gnu,    xcc: powerpc64-linux-gnu-gcc-9,    xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64-static,   os: ubuntu-20.04, },
           { name: 'S390X, gcc-9',    xcc_pkg: gcc-9-s390x-linux-gnu,        xcc: s390x-linux-gnu-gcc-9,        xemu_pkg: qemu-system-s390x, xemu: qemu-s390x-static,   os: ubuntu-20.04, },
           { name: 'MIPS, gcc-9',     xcc_pkg: gcc-9-mips-linux-gnu,         xcc: mips-linux-gnu-gcc-9,         xemu_pkg: qemu-system-mips,  xemu: qemu-mips-static,    os: ubuntu-20.04, },
 
           { name: 'ARM, gcc-8',      xcc_pkg: gcc-8-arm-linux-gnueabi,      xcc: arm-linux-gnueabi-gcc-8,      xemu_pkg: qemu-system-arm,   xemu: qemu-arm-static,     os: ubuntu-20.04, },
-          { name: 'ARM64, gcc-8',    xcc_pkg: gcc-8-aarch64-linux-gnu,      xcc: aarch64-linux-gnu-gcc-8,      xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
+          { name: 'AARCH64, gcc-8',  xcc_pkg: gcc-8-aarch64-linux-gnu,      xcc: aarch64-linux-gnu-gcc-8,      xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
           { name: 'PPC64LE, gcc-8',  xcc_pkg: gcc-8-powerpc64le-linux-gnu,  xcc: powerpc64le-linux-gnu-gcc-8,  xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64le-static, os: ubuntu-20.04, },
           { name: 'PPC64, gcc-8',    xcc_pkg: gcc-8-powerpc64-linux-gnu,    xcc: powerpc64-linux-gnu-gcc-8,    xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64-static,   os: ubuntu-20.04, },
           { name: 'S390X, gcc-8',    xcc_pkg: gcc-8-s390x-linux-gnu,        xcc: s390x-linux-gnu-gcc-8,        xemu_pkg: qemu-system-s390x, xemu: qemu-s390x-static,   os: ubuntu-20.04, },
@@ -360,14 +360,14 @@ jobs:
         echo && which $XEMU
         echo && $XEMU --version
 
-    - name: ARM (XXH_VECTOR=[ scalar, NEON ])
-      if: ${{ matrix.name == 'ARM' }}
+    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, NEON ])
+      if: ${{ startsWith(matrix.name, 'ARM') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_NEON" CFLAGS="-O3 -march=armv7-a -fPIC -mfloat-abi=softfp -mfpu=neon-vfpv4" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: ARM64 (XXH_VECTOR=[ scalar, NEON, SVE ])
-      if: ${{ matrix.name == 'ARM64' }}
+    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, NEON, SVE ])
+      if: ${{ startsWith(matrix.name, 'ARM64') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_NEON" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
@@ -383,19 +383,19 @@ jobs:
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_VSX" CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: S390X (XXH_VECTOR=[ scalar, VSX ])
-      if: ${{ matrix.name == 'S390X' }}
+    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, VSX ])
+      if: ${{ startsWith(matrix.name, 'S390X') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS=-DXXH_VECTOR=XXH_VSX CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: MIPS (XXH_VECTOR=[ scalar ])
-      if: ${{ matrix.name == 'MIPS' }}
+    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar ])
+      if: ${{ startsWith(matrix.name, 'MIPS') }}
       run: |
         LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: M68K (XXH_VECTOR=[ scalar ])
-      if: ${{ matrix.name == 'M68K' }}
+    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar ])
+      if: ${{ startsWith(matrix.name, 'M68K') }}
       run: |
         LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,8 @@ jobs:
           { name: 'MIPS, gcc-9',     xcc_pkg: gcc-9-mips-linux-gnu,         xcc: mips-linux-gnu-gcc-9,         xemu_pkg: qemu-system-mips,  xemu: qemu-mips-static,    os: ubuntu-20.04, },
 
           { name: 'ARM, gcc-8',      xcc_pkg: gcc-8-arm-linux-gnueabi,      xcc: arm-linux-gnueabi-gcc-8,      xemu_pkg: qemu-system-arm,   xemu: qemu-arm-static,     os: ubuntu-20.04, },
-          { name: 'AARCH64, gcc-8',  xcc_pkg: gcc-8-aarch64-linux-gnu,      xcc: aarch64-linux-gnu-gcc-8,      xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
+          # aarch64-linux-gnu-gcc-8 linker has an issue for LDFLAGS="-static"
+          # { name: 'AARCH64, gcc-8',  xcc_pkg: gcc-8-aarch64-linux-gnu,      xcc: aarch64-linux-gnu-gcc-8,      xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
           { name: 'PPC64LE, gcc-8',  xcc_pkg: gcc-8-powerpc64le-linux-gnu,  xcc: powerpc64le-linux-gnu-gcc-8,  xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64le-static, os: ubuntu-20.04, },
           { name: 'PPC64, gcc-8',    xcc_pkg: gcc-8-powerpc64-linux-gnu,    xcc: powerpc64-linux-gnu-gcc-8,    xemu_pkg: qemu-system-ppc,   xemu: qemu-ppc64-static,   os: ubuntu-20.04, },
           { name: 'S390X, gcc-8',    xcc_pkg: gcc-8-s390x-linux-gnu,        xcc: s390x-linux-gnu-gcc-8,        xemu_pkg: qemu-system-s390x, xemu: qemu-s390x-static,   os: ubuntu-20.04, },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,14 +360,14 @@ jobs:
         echo && which $XEMU
         echo && $XEMU --version
 
-    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, NEON ])
+    - name: ARM (XXH_VECTOR=[ scalar, NEON ])
       if: ${{ startsWith(matrix.name, 'ARM') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_NEON" CFLAGS="-O3 -march=armv7-a -fPIC -mfloat-abi=softfp -mfpu=neon-vfpv4" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
     - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, NEON, SVE ])
-      if: ${{ startsWith(matrix.name, 'ARM64') }}
+      if: ${{ startsWith(matrix.name, 'AARCH64') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_NEON" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
@@ -383,18 +383,18 @@ jobs:
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_VSX" CFLAGS="-O3 -maltivec -mvsx -mpower8-vector -mcpu=power8" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, VSX ])
+    - name: S390X (XXH_VECTOR=[ scalar, VSX ])
       if: ${{ startsWith(matrix.name, 'S390X') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS=-DXXH_VECTOR=XXH_VSX CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar ])
+    - name: MIPS (XXH_VECTOR=[ scalar ])
       if: ${{ startsWith(matrix.name, 'MIPS') }}
       run: |
         LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar ])
+    - name: M68K (XXH_VECTOR=[ scalar ])
       if: ${{ startsWith(matrix.name, 'M68K') }}
       run: |
         LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_NEON" CFLAGS="-O3 -march=armv7-a -fPIC -mfloat-abi=softfp -mfpu=neon-vfpv4" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, NEON, SVE ])
+    - name: AARCH64 (XXH_VECTOR=[ scalar, NEON, SVE ])
       if: ${{ startsWith(matrix.name, 'AARCH64') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
@@ -378,7 +378,7 @@ jobs:
         CPPFLAGS="-DXXH_VECTOR=XXH_SVE" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu max,sve128=on,sve256=on,sve512=on,sve1024=on,sve2048=off" make clean check
         CPPFLAGS="-DXXH_VECTOR=XXH_SVE" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu max,sve128=on,sve256=on,sve512=on,sve1024=on,sve2048=on" make clean check
 
-    - name: ${{ matrix.name }} (XXH_VECTOR=[ scalar, VSX ])
+    - name: PPC64(LE) (XXH_VECTOR=[ scalar, VSX ])
       if: ${{ startsWith(matrix.name, 'PPC64') }}
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ xxhsum_privateXXH
 xxhsum_inlinedXXH
 dispatch
 tests/generate_unicode_test
+tests/sanity_test
+tests/sanity_test_vectors_generator
 
 # local conf
 .clang_complete

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ clean:  ## remove all build artifacts
 # make check can be run with cross-compiled binaries on emulated environments (qemu user mode)
 # by setting $(RUN_ENV) to the target emulation environment
 .PHONY: check
-check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environments
+check: xxhsum test_sanity   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environments
 	# stdin
 	$(RUN_ENV) ./xxhsum$(EXT) < xxhash.c
 	# multiple files
@@ -215,6 +215,10 @@ check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environm
 .PHONY: test-unicode
 test-unicode:
 	$(MAKE) -C tests test_unicode
+
+.PHONY: test_sanity
+test_sanity:
+	$(MAKE) -C tests test_sanity
 
 .PHONY: test-mem
 VALGRIND = valgrind --leak-check=yes --error-exitcode=1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -51,7 +51,7 @@ default: all
 all: test
 
 .PHONY: test
-test: test_multiInclude test_unicode
+test: test_multiInclude test_unicode test_sanity
 
 .PHONY: test_multiInclude
 test_multiInclude:
@@ -104,6 +104,16 @@ endif
 test_filename_escape: $(XXHSUM)
 	./filename-escape.sh
 
+.PHONY: test_sanity
+test_sanity: sanity_test.c
+	$(CC) $(CFLAGS) $(LDFLAGS) sanity_test.c -o sanity_test$(EXT)
+	$(RUN_ENV) ./sanity_test$(EXT)
+
+.PHONY: sanity_test_vectors.h
+sanity_test_vectors.h: sanity_test_vectors_generator.c
+	$(CC) $(CFLAGS) $(LDFLAGS) sanity_test_vectors_generator.c -o sanity_test_vectors_generator$(EXT)
+	./sanity_test_vectors_generator$(EXT)
+
 xxhash.o: ../xxhash.c ../xxhash.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -c -o $@ $<
 
@@ -114,3 +124,4 @@ clean:
 	@$(RM) *.o
 	@$(RM) multiInclude multiInclude_withxxhash
 	@$(RM) *.unicode generate_unicode_test$(EXT) unicode_test.* xxhsum*
+	@$(RM) sanity_test$(EXT) sanity_test_vectors_generator$(EXT)

--- a/tests/sanity_test.c
+++ b/tests/sanity_test.c
@@ -1,0 +1,764 @@
+// xxHash/tests/sanity_test.c
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Building
+// ========
+//
+// cc sanity_test.c && ./a.out
+//
+/*
+notes or changes:
+
+main()
+------
+
+- All test methods (XXH32, XXH64, ...) are context free.
+  - It means that there's no restriction by order of tests and # of test.  (Ready for multi-threaded / distributed test)
+  - To achieve it, some test has dedicated 'randSeed' to decouple dependency between tests.
+  - Note that for() loop is not ready for distributed test.
+    - randSeed still needs to be computed step by step in the for() loop so far.
+
+*/
+#define XXH_STATIC_LINKING_ONLY
+#define XXH_IMPLEMENTATION   /* access definitions */
+#include "../cli/xsum_arch.h"
+#include "../cli/xsum_os_specific.h"
+#include "../cli/xsum_output.h"
+#include "../cli/xsum_output.c"
+#define XSUM_NO_MAIN 1
+#include "../cli/xsum_os_specific.h"
+#include "../cli/xsum_os_specific.c"
+#include "../xxhash.h"
+#include "sanity_test_vectors.h"
+
+#include <assert.h> /* assert */
+
+/* use #define to make them constant, required for initialization */
+#define PRIME32 2654435761U
+#define PRIME64 11400714785074694797ULL
+
+#define SANITY_BUFFER_SIZE (4096 + 64 + 1)
+
+
+/**/
+static int abortByError = 1;
+
+
+/**/
+static void abortSanityTest() {
+    /* ??? : Should we show this message? */
+    XSUM_log("\rNote: If you modified the hash functions, make sure to either update tests/sanity_test_vectors.h with the following command\n"
+             "\r  make -C tests sanity_test_vectors.h\n");
+    XSUM_log("\rAbort.\n");
+    exit(1);
+}
+
+/* TODO : Share this function with sanity_check.c and xsum_sanity_check.c */
+/*
+ * Fills a test buffer with pseudorandom data.
+ *
+ * This is used in the sanity check - its values must not be changed.
+ */
+static void fillTestBuffer(XSUM_U8* buffer, size_t bufferLenInBytes)
+{
+    XSUM_U64 byteGen = PRIME32;
+    size_t i;
+
+    assert(buffer != NULL);
+
+    for (i = 0; i < bufferLenInBytes; ++i) {
+        buffer[i] = (XSUM_U8)(byteGen>>56);
+        byteGen *= PRIME64;
+    }
+}
+
+
+/* TODO : Share this function with sanity_check.c and xsum_sanity_check.c */
+/*
+ * Create (malloc) and fill buffer with pseudorandom data for sanity check.
+ *
+ * Use releaseSanityBuffer() to delete the buffer.
+ */
+static XSUM_U8* createSanityBuffer(size_t bufferLenInBytes)
+{
+    XSUM_U8* buffer = (XSUM_U8*) malloc(bufferLenInBytes);
+    assert(buffer != NULL);
+    fillTestBuffer(buffer, bufferLenInBytes);
+    return buffer;
+}
+
+
+/* TODO : Share this function with sanity_check.c and xsum_sanity_check.c */
+/*
+ * Delete (free) the buffer which has been genereated by createSanityBuffer()
+ */
+static void releaseSanityBuffer(XSUM_U8* buffer)
+{
+    assert(buffer != NULL);
+    free(buffer);
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void checkResult32(XXH32_hash_t r1, XXH32_hash_t r2, const char* testName, size_t testNb, size_t lineNb)
+{
+    if(r1 == r2) {
+        return;
+    }
+
+    XSUM_log("\rError: %s #%zd, line #%zd: Sanity check failed!\n", testName, testNb, lineNb);
+    XSUM_log("\rGot 0x%08X, expected 0x%08X.\n", (unsigned)r1, (unsigned)r2);
+
+    if(abortByError) {
+        abortSanityTest();
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void checkResult64(XXH64_hash_t r1, XXH64_hash_t r2, const char* testName, size_t testNb, size_t lineNb)
+{
+    if(r1 == r2) {
+        return;
+    }
+
+    XSUM_log("\rError: %s #%zd, line #%zd: Sanity check failed!\n", testName, testNb, lineNb);
+    XSUM_log("\rGot 0x%08X%08XULL, expected 0x%08X%08XULL.\n",
+            (unsigned)(r1>>32), (unsigned)r1, (unsigned)(r2>>32), (unsigned)r2);
+
+    if(abortByError) {
+        abortSanityTest();
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void checkResult128(XXH128_hash_t r1, XXH128_hash_t r2, const char* testName, size_t testNb, size_t lineNb)
+{
+    if ((r1.low64 == r2.low64) && (r1.high64 == r2.high64)) {
+        return;
+    }
+
+    XSUM_log("\rError: %s #%zd, line #%zd: Sanity check failed!\n", testName, testNb, lineNb);
+    XSUM_log("\rGot { 0x%08X%08XULL, 0x%08X%08XULL }, expected { 0x%08X%08XULL, 0x%08X%08XULL } \n",
+            (unsigned)(r1.low64>>32), (unsigned)r1.low64, (unsigned)(r1.high64>>32), (unsigned)r1.high64,
+            (unsigned)(r2.low64>>32), (unsigned)r2.low64, (unsigned)(r2.high64>>32), (unsigned)r2.high64 );
+
+    if(abortByError) {
+        abortSanityTest();
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void checkResultTestDataSample(const XSUM_U8* r1, const XSUM_U8* r2, const char* testName, size_t testNb, size_t lineNb)
+{
+    if(memcmp(r1, r2, SECRET_SAMPLE_NBBYTES) == 0) {
+        return;
+    }
+
+    XSUM_log("\rError: %s #%zd, line #%zd: Sanity check failed!\n", testName, testNb, lineNb);
+    XSUM_log("\rGot { 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X }, expected { 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X } \n",
+            r1[0], r1[1], r1[2], r1[3], r1[4],
+            r2[0], r2[1], r2[2], r2[3], r2[4] );
+
+    if(abortByError) {
+        abortSanityTest();
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void testXXH32(
+    const void* data,
+    const XSUM_testdata32_t* testData,
+    const char* testName,
+    size_t testNb
+) {
+    size_t   const len     = testData->len;
+    XSUM_U32 const seed    = testData->seed;
+    XSUM_U32 const Nresult = testData->Nresult;
+
+    XXH32_state_t * const state = XXH32_createState();
+
+    if (len == 0) {
+        data = NULL;
+    } else {
+        assert(data != NULL);
+    }
+
+    assert(state != NULL);
+
+    checkResult32(XXH32(data, len, seed), Nresult, testName, testNb, __LINE__);
+
+    (void)XXH32_reset(state, seed);
+    (void)XXH32_update(state, data, len);
+    checkResult32(XXH32_digest(state), Nresult, testName, testNb, __LINE__);
+
+    (void)XXH32_reset(state, seed);
+    {
+        size_t pos;
+        for (pos = 0; pos < len; ++pos) {
+            (void)XXH32_update(state, ((const char*)data)+pos, 1);
+        }
+    }
+    checkResult32(XXH32_digest(state), Nresult, testName, testNb, __LINE__);
+
+    XXH32_freeState(state);
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void testXXH64(
+    const void* data,
+    const XSUM_testdata64_t* testData,
+    const char* testName,
+    size_t testNb
+)
+{
+    size_t   const len     = (size_t)testData->len;
+    XSUM_U64 const seed    = testData->seed;
+    XSUM_U64 const Nresult = testData->Nresult;
+
+    XXH64_state_t * const state = XXH64_createState();
+
+    if (len == 0) {
+        data = NULL;
+    } else {
+        assert(data != NULL);
+    }
+
+    assert(state != NULL);
+
+    checkResult64(XXH64(data, len, seed), Nresult, testName, testNb, __LINE__);
+
+    (void)XXH64_reset(state, seed);
+    (void)XXH64_update(state, data, len);
+    checkResult64(XXH64_digest(state), Nresult, testName, testNb, __LINE__);
+
+    (void)XXH64_reset(state, seed);
+    {
+        size_t pos;
+        for (pos = 0; pos < len; ++pos) {
+            (void)XXH64_update(state, ((const char*)data)+pos, 1);
+        }
+    }
+    checkResult64(XXH64_digest(state), Nresult, testName, testNb, __LINE__);
+    XXH64_freeState(state);
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/*
+ * Used to get "random" (but actually 100% reproducible) lengths for
+ * XSUM_XXH3_randomUpdate.
+ */
+static XSUM_U32 SANITY_TEST_rand(XSUM_U64* pRandSeed)
+{
+    XSUM_U64 seed = *pRandSeed;
+    seed *= PRIME64;
+    *pRandSeed = seed;
+    return (XSUM_U32)(seed >> 40);
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static XSUM_U64 SANITY_TEST_computeRandSeed(size_t step)
+{
+    XSUM_U64 randSeed = PRIME32;
+    size_t i = 0;
+    for(i = 0; i < step; ++i) {
+        SANITY_TEST_rand(&randSeed);
+    }
+    return randSeed;
+}
+
+
+/* TODO : Share this definition with xsum_sanity_check.c */
+/*
+ * Technically, XXH3_64bits_update is identical to XXH3_128bits_update as of
+ * v0.8.0, but we treat them as separate.
+ */
+typedef XXH_errorcode (*SANITY_TEST_XXH3_update_t)(XXH3_state_t* state, const void* input, size_t length);
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/*
+ * Runs the passed XXH3_update variant on random lengths. This is to test the
+ * more complex logic of the update function, catching bugs like this one:
+ *    https://github.com/Cyan4973/xxHash/issues/378
+ */
+static void SANITY_TEST_XXH3_randomUpdate(
+    XXH3_state_t* state,
+    const void* data,
+    size_t len,
+    XSUM_U64* pRandSeed,
+    SANITY_TEST_XXH3_update_t update_fn
+)
+{
+    size_t p = 0;
+    while (p < len) {
+        size_t const modulo = len > 2 ? len : 2;
+        size_t l = (size_t)(SANITY_TEST_rand(pRandSeed)) % modulo;
+        if (p + l > len) l = len - p;
+        (void)update_fn(state, (const char*)data+p, l);
+        p += l;
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void testXXH3(
+    const void* data,
+    const XSUM_testdata64_t* testData,
+    XSUM_U64* pRandSeed,
+    const char* testName,
+    size_t testNb
+)
+{
+    size_t   const len     = testData->len;
+    XSUM_U64 const seed    = testData->seed;
+    XSUM_U64 const Nresult = testData->Nresult;
+    if (len == 0) {
+        data = NULL;
+    } else {
+        assert(data != NULL);
+    }
+    {   XSUM_U64 const Dresult = XXH3_64bits_withSeed(data, len, seed);
+        checkResult64(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* check that the no-seed variant produces same result as seed==0 */
+    if (seed == 0) {
+        XSUM_U64 const Dresult = XXH3_64bits(data, len);
+        checkResult64(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* check that the combination of
+     * XXH3_generateSecret_fromSeed() and XXH3_64bits_withSecretandSeed()
+     * results in exactly the same hash generation as XXH3_64bits_withSeed() */
+    {   char secretBuffer[XXH3_SECRET_DEFAULT_SIZE+1];
+        char* const secret = secretBuffer + 1;  /* intentional unalignment */
+        XXH3_generateSecret_fromSeed(secret, seed);
+        {   XSUM_U64 const Dresult = XXH3_64bits_withSecretandSeed(data, len, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+            checkResult64(Dresult, Nresult, testName, testNb, __LINE__);
+    }   }
+
+    /* streaming API test */
+    {   XXH3_state_t* const state = XXH3_createState();
+        assert(state != NULL);
+        /* single ingestion */
+        (void)XXH3_64bits_reset_withSeed(state, seed);
+        (void)XXH3_64bits_update(state, data, len);
+        checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* random ingestion */
+        (void)XXH3_64bits_reset_withSeed(state, seed);
+        SANITY_TEST_XXH3_randomUpdate(state, data, len, pRandSeed, &XXH3_64bits_update);
+        checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* byte by byte ingestion */
+        {   size_t pos;
+            (void)XXH3_64bits_reset_withSeed(state, seed);
+            for (pos=0; pos<len; pos++)
+                (void)XXH3_64bits_update(state, ((const char*)data)+pos, 1);
+            checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        /* check that streaming with a combination of
+         * XXH3_generateSecret_fromSeed() and XXH3_64bits_reset_withSecretandSeed()
+         * results in exactly the same hash generation as XXH3_64bits_reset_withSeed() */
+        {   char secretBuffer[XXH3_SECRET_DEFAULT_SIZE+1];
+            char* const secret = secretBuffer + 1;  /* intentional unalignment */
+            XXH3_generateSecret_fromSeed(secret, seed);
+            /* single ingestion */
+            (void)XXH3_64bits_reset_withSecretandSeed(state, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+            (void)XXH3_64bits_update(state, data, len);
+            checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        XXH3_freeState(state);
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void testXXH3_withSecret(
+    const void* data,
+    const void* secret,
+    size_t secretSize,
+    const XSUM_testdata64_t* testData,
+    XSUM_U64* pRandSeed,
+    const char* testName,
+    size_t testNb
+)
+{
+    size_t   const len     = (size_t)testData->len;
+    XSUM_U64 const Nresult = testData->Nresult;
+
+    if (len == 0) {
+        data = NULL;
+    } else {
+        assert(data != NULL);
+    }
+    {   XSUM_U64 const Dresult = XXH3_64bits_withSecret(data, len, secret, secretSize);
+        checkResult64(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* check that XXH3_64bits_withSecretandSeed()
+     * results in exactly the same return value as XXH3_64bits_withSecret() */
+    if (len > XXH3_MIDSIZE_MAX)
+    {   XSUM_U64 const Dresult = XXH3_64bits_withSecretandSeed(data, len, secret, secretSize, 0);
+        checkResult64(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* streaming API test */
+    {   XXH3_state_t * const state = XXH3_createState();
+        assert(state != NULL);
+        (void)XXH3_64bits_reset_withSecret(state, secret, secretSize);
+        (void)XXH3_64bits_update(state, data, len);
+        checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* random ingestion */
+        (void)XXH3_64bits_reset_withSecret(state, secret, secretSize);
+        SANITY_TEST_XXH3_randomUpdate(state, data, len, pRandSeed, &XXH3_64bits_update);
+        checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* byte by byte ingestion */
+        {   size_t pos;
+            (void)XXH3_64bits_reset_withSecret(state, secret, secretSize);
+            for (pos=0; pos<len; pos++)
+                (void)XXH3_64bits_update(state, ((const char*)data)+pos, 1);
+            checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        /* check that XXH3_64bits_reset_withSecretandSeed()
+         * results in exactly the same return value as XXH3_64bits_reset_withSecret() */
+         if (len > XXH3_MIDSIZE_MAX) {
+            /* single ingestion */
+            (void)XXH3_64bits_reset_withSecretandSeed(state, secret, secretSize, 0);
+            (void)XXH3_64bits_update(state, data, len);
+            checkResult64(XXH3_64bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        XXH3_freeState(state);
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void testXXH128(
+    const void* data,
+    const XSUM_testdata128_t* testData,
+    XSUM_U64* pRandSeed,
+    const char* testName,
+    size_t testNb
+)
+{
+    size_t        const len     = (size_t)testData->len;
+    XSUM_U64      const seed    = testData->seed;
+    XXH128_hash_t const Nresult = testData->Nresult;
+    if (len == 0) {
+        data = NULL;
+    } else {
+        assert(data != NULL);
+    }
+
+    {   XXH128_hash_t const Dresult = XXH3_128bits_withSeed(data, len, seed);
+        checkResult128(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* check that XXH128() is identical to XXH3_128bits_withSeed() */
+    {   XXH128_hash_t const Dresult2 = XXH128(data, len, seed);
+        checkResult128(Dresult2, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* check that the no-seed variant produces same result as seed==0 */
+    if (seed == 0) {
+        XXH128_hash_t const Dresult = XXH3_128bits(data, len);
+        checkResult128(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* check that the combination of
+     * XXH3_generateSecret_fromSeed() and XXH3_128bits_withSecretandSeed()
+     * results in exactly the same hash generation as XXH3_64bits_withSeed() */
+    {   char secretBuffer[XXH3_SECRET_DEFAULT_SIZE+1];
+        char* const secret = secretBuffer + 1;  /* intentional unalignment */
+        XXH3_generateSecret_fromSeed(secret, seed);
+        {   XXH128_hash_t const Dresult = XXH3_128bits_withSecretandSeed(data, len, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+            checkResult128(Dresult, Nresult, testName, testNb, __LINE__);
+    }   }
+
+    /* streaming API test */
+    {   XXH3_state_t * const state = XXH3_createState();
+        assert(state != NULL);
+
+        /* single ingestion */
+        (void)XXH3_128bits_reset_withSeed(state, seed);
+        (void)XXH3_128bits_update(state, data, len);
+        checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* random ingestion */
+        (void)XXH3_128bits_reset_withSeed(state, seed);
+        SANITY_TEST_XXH3_randomUpdate(state, data, len, pRandSeed, &XXH3_128bits_update);
+        checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* byte by byte ingestion */
+        {   size_t pos;
+            (void)XXH3_128bits_reset_withSeed(state, seed);
+            for (pos=0; pos<len; pos++)
+                (void)XXH3_128bits_update(state, ((const char*)data)+pos, 1);
+            checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        /* check that streaming with a combination of
+         * XXH3_generateSecret_fromSeed() and XXH3_128bits_reset_withSecretandSeed()
+         * results in exactly the same hash generation as XXH3_128bits_reset_withSeed() */
+        {   char secretBuffer[XXH3_SECRET_DEFAULT_SIZE+1];
+            char* const secret = secretBuffer + 1;  /* intentional unalignment */
+            XXH3_generateSecret_fromSeed(secret, seed);
+            /* single ingestion */
+            (void)XXH3_128bits_reset_withSecretandSeed(state, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+            (void)XXH3_128bits_update(state, data, len);
+            checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        XXH3_freeState(state);
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void testXXH128_withSecret(
+    const void* data,
+    const void* secret,
+    size_t secretSize,
+    const XSUM_testdata128_t* testData,
+    XSUM_U64* pRandSeed,
+    const char* testName,
+    size_t testNb
+)
+{
+    size_t        const len     = testData->len;
+    XXH128_hash_t const Nresult = testData->Nresult;
+    if (len == 0) {
+        data = NULL;
+    } else {
+        assert(data != NULL);
+    }
+
+    {   XXH128_hash_t const Dresult = XXH3_128bits_withSecret(data, len, secret, secretSize);
+        checkResult128(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* check that XXH3_128bits_withSecretandSeed()
+     * results in exactly the same return value as XXH3_128bits_withSecret() */
+    if (len > XXH3_MIDSIZE_MAX)
+    {   XXH128_hash_t const Dresult = XXH3_128bits_withSecretandSeed(data, len, secret, secretSize, 0);
+        checkResult128(Dresult, Nresult, testName, testNb, __LINE__);
+    }
+
+    /* streaming API test */
+    {   XXH3_state_t* const state = XXH3_createState();
+        assert(state != NULL);
+        (void)XXH3_128bits_reset_withSecret(state, secret, secretSize);
+        (void)XXH3_128bits_update(state, data, len);
+        checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* random ingestion */
+        (void)XXH3_128bits_reset_withSecret(state, secret, secretSize);
+        SANITY_TEST_XXH3_randomUpdate(state, data, len, pRandSeed, &XXH3_128bits_update);
+        checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+
+        /* byte by byte ingestion */
+        {   size_t pos;
+            (void)XXH3_128bits_reset_withSecret(state, secret, secretSize);
+            for (pos=0; pos<len; pos++)
+                (void)XXH3_128bits_update(state, ((const char*)data)+pos, 1);
+            checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        /* check that XXH3_128bits_reset_withSecretandSeed()
+         * results in exactly the same return value as XXH3_128bits_reset_withSecret() */
+         if (len > XXH3_MIDSIZE_MAX) {
+            /* single ingestion */
+            (void)XXH3_128bits_reset_withSecretandSeed(state, secret, secretSize, 0);
+            (void)XXH3_128bits_update(state, data, len);
+            checkResult128(XXH3_128bits_digest(state), Nresult, testName, testNb, __LINE__);
+        }
+
+        XXH3_freeState(state);
+    }
+}
+
+
+/* TODO : Share this function with xsum_sanity_check.c */
+/**/
+static void testSecretGenerator(
+    const void* customSeed,
+    const XSUM_testdata_sample_t* testData,
+    const char* testName,
+    size_t testNb
+)
+{
+    /* TODO : Share this array with sanity_check.c and xsum_sanity_check.c */
+    static const int sampleIndex[SECRET_SAMPLE_NBBYTES] = { 0, 62, 131, 191, 241 };  /* position of sampled bytes */
+    XSUM_U8 secretBuffer[SECRET_SIZE_MAX] = {0};
+    XSUM_U8 samples[SECRET_SAMPLE_NBBYTES];
+    int i;
+
+    assert(testData->secretLen <= SECRET_SIZE_MAX);
+    XXH3_generateSecret(secretBuffer, testData->secretLen, customSeed, testData->seedLen);
+    for (i=0; i<SECRET_SAMPLE_NBBYTES; i++) {
+        samples[i] = secretBuffer[sampleIndex[i]];
+    }
+    checkResultTestDataSample(samples, testData->byte, testName, testNb, __LINE__);
+}
+
+
+/**/
+int main(int argc, const char* argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    size_t testCount = 0;
+    size_t      const sanityBufferSizeInBytes = SANITY_BUFFER_SIZE;
+    XSUM_U8*    const sanityBuffer            = createSanityBuffer(sanityBufferSizeInBytes);
+    const void* const secret                  = sanityBuffer + 7;
+    size_t      const secretSize              = XXH3_SECRET_SIZE_MIN + 11;
+    assert(sanityBufferSizeInBytes >= 7 + secretSize);
+
+    {
+        /* XXH32 */
+        size_t const n = sizeof(XSUM_XXH32_testdata) / sizeof(XSUM_XXH32_testdata[0]);
+        size_t i;
+        for (i = 0; i < n; ++i, ++testCount) {
+            testXXH32(
+                sanityBuffer,
+                &XSUM_XXH32_testdata[i],
+                "XSUM_XXH32_testdata",
+                i
+            );
+        }
+    }
+
+    {
+        /* XXH64 */
+        size_t const n = sizeof(XSUM_XXH64_testdata) / sizeof(XSUM_XXH64_testdata[0]);
+        size_t i;
+        for (i = 0; i < n; ++i, ++testCount) {
+            testXXH64(
+                sanityBuffer,
+                &XSUM_XXH64_testdata[i],
+                "XSUM_XXH64_testdata",
+                i
+            );
+        }
+    }
+
+    {
+        /* XXH3_64bits, seeded */
+        size_t const randCount = 0;
+        XSUM_U64 randSeed = SANITY_TEST_computeRandSeed(randCount);
+        size_t const n = sizeof(XSUM_XXH3_testdata) / sizeof(XSUM_XXH3_testdata[0]);
+        size_t i;
+        for (i = 0; i < n; ++i, ++testCount) {
+            testXXH3(
+                sanityBuffer,
+                &XSUM_XXH3_testdata[i],
+                &randSeed,
+                "XSUM_XXH3_testdata",
+                i
+            );
+        }
+    }
+
+    {
+        /* XXH3_64bits, custom secret */
+        size_t const randCount = 22730;
+        XSUM_U64 randSeed = SANITY_TEST_computeRandSeed(randCount);
+        size_t const n = sizeof(XSUM_XXH3_withSecret_testdata) / sizeof(XSUM_XXH3_withSecret_testdata[0]);
+        size_t i;
+        for (i = 0; i < n; ++i, ++testCount) {
+            testXXH3_withSecret(
+                sanityBuffer,
+                secret,
+                secretSize,
+                &XSUM_XXH3_withSecret_testdata[i],
+                &randSeed,
+                "XSUM_XXH3_withSecret_testdata",
+                i
+            );
+            testCount++;
+        }
+    }
+
+    {
+        /* XXH128 */
+        size_t const randCount = 34068;
+        XSUM_U64 randSeed = SANITY_TEST_computeRandSeed(randCount);
+        size_t const n = (sizeof(XSUM_XXH128_testdata)/sizeof(XSUM_XXH128_testdata[0]));
+        size_t i;
+        for (i = 0; i < n; ++i, ++testCount) {
+            testXXH128(
+                sanityBuffer,
+                &XSUM_XXH128_testdata[i],
+                &randSeed,
+                "XSUM_XXH128_testdata",
+                i
+            );
+        }
+    }
+
+    {
+        /* XXH128 with custom Secret */
+        size_t const randCount = 68019;
+        XSUM_U64 randSeed = SANITY_TEST_computeRandSeed(randCount);
+        size_t const n = (sizeof(XSUM_XXH128_withSecret_testdata)/sizeof(XSUM_XXH128_withSecret_testdata[0]));
+        size_t i;
+        for (i = 0; i < n; ++i, ++testCount) {
+            testXXH128_withSecret(
+                sanityBuffer,
+                secret,
+                secretSize,
+                &XSUM_XXH128_withSecret_testdata[i],
+                &randSeed,
+                "XSUM_XXH128_withSecret_testdata",
+                i
+            );
+        }
+    }
+
+    {
+        /* secret generator */
+        size_t const n = sizeof(XSUM_XXH3_generateSecret_testdata) / sizeof(XSUM_XXH3_generateSecret_testdata[0]);
+        size_t i;
+        for (i = 0; i < n; ++i, ++testCount) {
+            assert(XSUM_XXH3_generateSecret_testdata[i].seedLen <= SANITY_BUFFER_SIZE);
+            testSecretGenerator(
+                sanityBuffer,
+                &XSUM_XXH3_generateSecret_testdata[i],
+                "XSUM_XXH3_generateSecret_testdata",
+                i
+            );
+        }
+    }
+
+    releaseSanityBuffer(sanityBuffer);
+
+    XSUM_log("\rOK. (passes %zd tests)\n", testCount);
+
+    return EXIT_SUCCESS;
+}

--- a/tests/sanity_test_vectors_generator.c
+++ b/tests/sanity_test_vectors_generator.c
@@ -1,0 +1,464 @@
+// xxHash/tests/sanity_test_vectors_generator.c
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// So far, this program just generates sanity_test_vectors.h
+//
+// Building
+// ========
+//
+// cc sanity_test_vectors_generator.c && ./a.out
+// less sanity_test_vectors.h
+//
+#define XXH_STATIC_LINKING_ONLY
+#define XXH_IMPLEMENTATION   /* access definitions */
+#include "../cli/xsum_arch.h"
+#include "../cli/xsum_os_specific.h"
+#include "../xxhash.h"
+
+#include <assert.h> /* assert */
+
+/* use #define to make them constant, required for initialization */
+#define PRIME32 2654435761U
+#define PRIME64 11400714785074694797ULL
+
+#define SANITY_BUFFER_SIZE (4096 + 64 + 1)
+
+
+/* TODO : Share these test vector definitions with sanity_check.c and xsum_sanity_check.c */
+/*
+ * Test data vectors
+ */
+typedef struct {
+    XSUM_U32 len;
+    XSUM_U32 seed;
+    XSUM_U32 Nresult;
+} XSUM_testdata32_t;
+
+typedef struct {
+    XSUM_U32 len;
+    XSUM_U64 seed;
+    XSUM_U64 Nresult;
+} XSUM_testdata64_t;
+
+typedef struct {
+    XSUM_U32 len;
+    XSUM_U64 seed;
+    XXH128_hash_t Nresult;
+} XSUM_testdata128_t;
+
+#define SECRET_SAMPLE_NBBYTES 5
+typedef struct {
+    XSUM_U32 seedLen;
+    XSUM_U32 secretLen;
+    XSUM_U8 byte[SECRET_SAMPLE_NBBYTES];
+} XSUM_testdata_sample_t;
+
+#ifndef   SECRET_SIZE_MAX
+#  define SECRET_SIZE_MAX 9867
+#endif
+
+
+/* TODO : Share these generators with sanity_check.c and xsum_sanity_check.c */
+/* Test vector generators */
+static XSUM_testdata32_t tvgen_XXH32(const XSUM_U8* buf, size_t len, XSUM_U32 seed) {
+    XSUM_testdata32_t v;
+    v.len     = len;
+    v.seed    = seed;
+    v.Nresult = XXH32(buf, len, seed);
+    return v;
+}
+
+static XSUM_testdata64_t tvgen_XXH64(const XSUM_U8* buf, size_t len, XSUM_U64 seed) {
+    XSUM_testdata64_t v;
+    v.len     = len;
+    v.seed    = seed;
+    v.Nresult = XXH64(buf, len, seed);
+    return v;
+}
+
+static XSUM_testdata64_t tvgen_XXH3_64bits_withSeed(const XSUM_U8* buf, size_t len, XSUM_U64 seed) {
+    XSUM_testdata64_t v;
+    v.len     = len;
+    v.seed    = seed;
+    v.Nresult = XXH3_64bits_withSeed(buf, len, seed);
+    return v;
+}
+
+static XSUM_testdata64_t tvgen_XXH3_64bits_withSecret(const XSUM_U8* buf, size_t len, const void* secret, size_t secretSize) {
+    XSUM_testdata64_t v;
+    v.len     = len;
+    v.seed    = 0;
+    v.Nresult = XXH3_64bits_withSecret(buf, len, secret, secretSize);
+    return v;
+}
+
+static XSUM_testdata128_t tvgen_XXH3_128bits_withSeed(const XSUM_U8* buf, size_t len, XSUM_U64 seed) {
+    XSUM_testdata128_t v;
+    v.len     = len;
+    v.seed    = seed;
+    v.Nresult = XXH3_128bits_withSeed(buf, len, seed);
+    return v;
+}
+
+static XSUM_testdata128_t tvgen_XXH3_128bits_withSecret(const XSUM_U8* buf, size_t len, const void* secret, size_t secretSize) {
+    XSUM_testdata128_t v;
+    v.len     = len;
+    v.seed    = 0;
+    v.Nresult = XXH3_128bits_withSecret(buf, len, secret, secretSize);
+    return v;
+}
+
+static XSUM_testdata_sample_t tvgen_XXH3_generateSecret(
+    void* secretBuffer,
+    size_t secretSize,
+    const void* customSeed,
+    size_t customSeedSize
+) {
+    XXH3_generateSecret(secretBuffer, secretSize, customSeed, customSeedSize);
+
+    XSUM_testdata_sample_t v;
+    v.seedLen   = customSeedSize;
+    v.secretLen = secretSize;
+
+    /* TODO : Share this array with sanity_check.c and xsum_sanity_check.c */
+    /* position of sampled bytes */
+    static const int sampleIndex[SECRET_SAMPLE_NBBYTES] = { 0, 62, 131, 191, 241 };
+
+    for(int i = 0; i < SECRET_SAMPLE_NBBYTES; ++i) {
+        const XSUM_U8* const secretBufferAsU8 = (const XSUM_U8*) secretBuffer;
+        v.byte[i] = secretBufferAsU8[sampleIndex[i]];
+    }
+    return v;
+}
+
+
+/* Test vector serializers */
+static void fprintf_XSUM_testdata32_t(FILE* fp, XSUM_testdata32_t const v) {
+    fprintf(fp, "{ %4d, 0x%08XU, 0x%08XU },", v.len, v.seed, v.Nresult);
+}
+
+static void fprintf_XSUM_testdata64_t(FILE* fp, XSUM_testdata64_t const v) {
+    fprintf(fp, "{ %4d, 0x%016zXULL, 0x%016zXULL },", v.len, v.seed, v.Nresult);
+}
+
+static void fprintf_XSUM_testdata128_t(FILE* fp, XSUM_testdata128_t const v) {
+    fprintf(fp, "{ %4d, 0x%016zXULL, { 0x%016zXULL, 0x%016zXULL } },",
+            v.len, v.seed, v.Nresult.low64, v.Nresult.high64);
+}
+
+static void fprintf_XSUM_testdata_sample_t(FILE* fp, XSUM_testdata_sample_t const v) {
+    fprintf(fp,"{ %4d, %4d, { 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X } },",
+            v.seedLen, v.secretLen, v.byte[0], v.byte[1], v.byte[2], v.byte[3], v.byte[4]);
+}
+
+
+/* TODO : Share this function with sanity_check.c and xsum_sanity_check.c */
+/*
+ * Fills a test buffer with pseudorandom data.
+ *
+ * This is used in the sanity check - its values must not be changed.
+ */
+static void fillTestBuffer(XSUM_U8* buffer, size_t bufferLenInBytes)
+{
+    XSUM_U64 byteGen = PRIME32;
+    size_t i;
+
+    assert(buffer != NULL);
+
+    for (i = 0; i < bufferLenInBytes; ++i) {
+        buffer[i] = (XSUM_U8)(byteGen>>56);
+        byteGen *= PRIME64;
+    }
+}
+
+
+/* TODO : Share this function with sanity_check.c and xsum_sanity_check.c */
+/*
+ * Create (malloc) and fill buffer with pseudorandom data for sanity check.
+ *
+ * Use releaseSanityBuffer() to delete the buffer.
+ */
+static XSUM_U8* createSanityBuffer(size_t bufferLenInBytes)
+{
+    XSUM_U8* const buffer = (XSUM_U8*) malloc(bufferLenInBytes);
+    assert(buffer != NULL);
+    fillTestBuffer(buffer, bufferLenInBytes);
+    return buffer;
+}
+
+
+/* TODO : Share this function with sanity_check.c and xsum_sanity_check.c */
+/*
+ * Delete (free) the buffer which has been genereated by createSanityBuffer()
+ */
+static void releaseSanityBuffer(XSUM_U8* buffer)
+{
+    assert(buffer != NULL);
+    free(buffer);
+}
+
+
+/* Generate test vectors for XXH32() */
+static void generate_sanity_test_vectors_xxh32(FILE* fp, size_t maxLen) {
+    const char* const arrayTypeName = "XSUM_testdata32_t";
+    const char* const arrayName     = "XSUM_XXH32_testdata";
+    fprintf(fp, "static const %s %s[] = {\n", arrayTypeName, arrayName);
+
+    XSUM_U8* const sanityBuffer = createSanityBuffer(maxLen);
+
+    size_t index = 0;
+    for(size_t len = 0; len < maxLen; ++len) {
+        static const size_t seeds[] = { 0, PRIME32 };
+        for(size_t iSeed = 0; iSeed < sizeof(seeds)/sizeof(seeds[0]); ++iSeed) {
+            size_t const seed = seeds[iSeed];
+            XSUM_testdata32_t const v = tvgen_XXH32(sanityBuffer, len, seed);
+
+            fprintf(fp, "    ");
+            fprintf_XSUM_testdata32_t(fp, v);
+            fprintf(fp, " /* %s[%zd] */\n", arrayName, index++);
+        }
+    }
+
+    releaseSanityBuffer(sanityBuffer);
+    fprintf(fp, "};\n");
+}
+
+
+/* Generate test vectors for XXH64() */
+static void generate_sanity_test_vectors_xxh64(FILE* fp, size_t maxLen) {
+    const char* const arrayTypeName = "XSUM_testdata64_t";
+    const char* const arrayName     = "XSUM_XXH64_testdata";
+    fprintf(fp, "static const %s %s[] = {\n", arrayTypeName, arrayName);
+
+    XSUM_U8* const sanityBuffer = createSanityBuffer(maxLen);
+
+    size_t index = 0;
+    for(size_t len = 0; len < maxLen; ++len) {
+        static const size_t seeds[] = { 0, PRIME32 };
+        for(size_t iSeed = 0; iSeed < sizeof(seeds)/sizeof(seeds[0]); ++iSeed) {
+            size_t const seed = seeds[iSeed];
+            XSUM_testdata64_t const v = tvgen_XXH64(sanityBuffer, len, seed);
+
+            fprintf(fp, "    ");
+            fprintf_XSUM_testdata64_t(fp, v);
+            fprintf(fp, " /* %s[%zd] */\n", arrayName, index++);
+        }
+    }
+
+    releaseSanityBuffer(sanityBuffer);
+    fprintf(fp, "};\n");
+}
+
+
+/* Generate test vectors for XXH3_64bits_withSeed() */
+static void generate_sanity_test_vectors_xxh3(FILE* fp, size_t maxLen) {
+    const char* const arrayTypeName = "XSUM_testdata64_t";
+    const char* const arrayName     = "XSUM_XXH3_testdata";
+    fprintf(fp, "static const %s %s[] = {\n", arrayTypeName, arrayName);
+
+    XSUM_U8* const sanityBuffer = createSanityBuffer(maxLen);
+
+    size_t index = 0;
+    for(size_t len = 0; len < maxLen; ++len) {
+        static const size_t seeds[] = { 0, PRIME64 };
+        for(size_t iSeed = 0; iSeed < sizeof(seeds)/sizeof(seeds[0]); ++iSeed) {
+            size_t const seed = seeds[iSeed];
+            XSUM_testdata64_t const v = tvgen_XXH3_64bits_withSeed(sanityBuffer, len, seed);
+
+            fprintf(fp, "    ");
+            fprintf_XSUM_testdata64_t(fp, v);
+            fprintf(fp, " /* %s[%zd] */\n", arrayName, index++);
+        }
+    }
+
+    releaseSanityBuffer(sanityBuffer);
+    fprintf(fp, "};\n");
+}
+
+
+/* Generate test vectors for XXH3_64bits_withSecret() */
+static void generate_sanity_test_vectors_xxh3_withSecret(FILE* fp, size_t maxLen) {
+    const char* const arrayTypeName = "XSUM_testdata64_t";
+    const char* const arrayName     = "XSUM_XXH3_withSecret_testdata";
+    fprintf(fp, "static const %s %s[] = {\n", arrayTypeName, arrayName);
+
+    XSUM_U8* const sanityBuffer = createSanityBuffer(maxLen);
+
+    const void* const secret = sanityBuffer + 7;
+    size_t const secretSize = XXH3_SECRET_SIZE_MIN + 11;
+    assert(maxLen >= 7 + secretSize);
+
+    size_t index = 0;
+    for(size_t len = 0; len < maxLen; ++len) {
+        XSUM_testdata64_t const v = tvgen_XXH3_64bits_withSecret(sanityBuffer, len, secret, secretSize);
+
+        fprintf(fp, "    ");
+        fprintf_XSUM_testdata64_t(fp, v);
+        fprintf(fp, " /* %s[%zd] */\n", arrayName, index++);
+    }
+
+    releaseSanityBuffer(sanityBuffer);
+    fprintf(fp, "};\n");
+}
+
+
+/* Generate test vectors for XXH3_128bits_withSeed() */
+static void generate_sanity_test_vectors_xxh128(FILE* fp, size_t maxLen) {
+    const char* const arrayTypeName = "XSUM_testdata128_t";
+    const char* const arrayName     = "XSUM_XXH128_testdata";
+    fprintf(fp, "static const %s %s[] = {\n", arrayTypeName, arrayName);
+
+    XSUM_U8* const sanityBuffer = createSanityBuffer(maxLen);
+
+    size_t index = 0;
+    for(size_t len = 0; len < maxLen; ++len) {
+        static const size_t seeds[] = { 0, PRIME32, PRIME64 };
+        for(size_t iSeed = 0; iSeed < sizeof(seeds)/sizeof(seeds[0]); ++iSeed) {
+            XSUM_U64 const seed = seeds[iSeed];
+            XSUM_testdata128_t const v = tvgen_XXH3_128bits_withSeed(sanityBuffer, len, seed);
+
+            fprintf(fp, "    ");
+            fprintf_XSUM_testdata128_t(fp, v);
+            fprintf(fp, " /* %s[%zd] */\n", arrayName, index++);
+        }
+    }
+    fprintf(fp, "};\n");
+    releaseSanityBuffer(sanityBuffer);
+}
+
+
+/* Generate test vectors for XXH3_128bits_withSecret() */
+static void generate_sanity_test_vectors_xxh128_withSecret(FILE* fp, size_t maxLen) {
+    const char* const arrayTypeName = "XSUM_testdata128_t";
+    const char* const arrayName     = "XSUM_XXH128_withSecret_testdata";
+    fprintf(fp, "static const %s %s[] = {\n", arrayTypeName, arrayName);
+
+    XSUM_U8* const sanityBuffer = createSanityBuffer(maxLen);
+
+    const void* const secret = sanityBuffer + 7;
+    size_t const secretSize = XXH3_SECRET_SIZE_MIN + 11;
+    assert(maxLen >= 7 + secretSize);
+
+    size_t index = 0;
+    for(size_t len = 0; len < maxLen; ++len) {
+        XSUM_testdata128_t const v = tvgen_XXH3_128bits_withSecret(sanityBuffer, len, secret, secretSize);
+
+        fprintf(fp, "    ");
+        fprintf_XSUM_testdata128_t(fp, v);
+        fprintf(fp, " /* %s[%zd] */\n", arrayName, index++);
+    }
+
+    fprintf(fp, "};\n");
+    releaseSanityBuffer(sanityBuffer);
+}
+
+
+/* Generate test vectors for XXH3_generateSecret() */
+static void generate_sanity_test_vectors_xxh3_generateSecret(FILE* fp, size_t maxLen) {
+    const char* const arrayTypeName = "XSUM_testdata_sample_t";
+    const char* const arrayName     = "XSUM_XXH3_generateSecret_testdata";
+    fprintf(fp, "static const %s %s[] = {\n", arrayTypeName, arrayName);
+
+    XSUM_U8* const sanityBuffer = createSanityBuffer(maxLen);
+    const void* const customSeed = sanityBuffer;
+    static const size_t seedLens[] = {
+        0,
+        1,
+        XXH3_SECRET_SIZE_MIN - 1,
+        XXH3_SECRET_DEFAULT_SIZE + 500
+    };
+    static const size_t secretLens[] = {
+        192,
+        240,
+        277,
+        SECRET_SIZE_MAX
+    };
+
+    size_t index = 0;
+    for(size_t iSeedLen = 0; iSeedLen < sizeof(seedLens)/sizeof(seedLens[0]); ++iSeedLen) {
+        for(size_t iSecretLen = 0; iSecretLen < sizeof(secretLens)/sizeof(secretLens[0]); ++iSecretLen) {
+            size_t const seedLen = seedLens[iSeedLen];
+            size_t const secretLen = secretLens[iSecretLen];
+            XSUM_U8 secretBuffer[SECRET_SIZE_MAX] = {0};
+
+            assert(seedLen <= maxLen);
+            assert(secretLen <= SECRET_SIZE_MAX);
+
+            XSUM_testdata_sample_t const v = tvgen_XXH3_generateSecret(
+                secretBuffer,
+                secretLen,
+                customSeed,
+                seedLen
+            );
+
+            fprintf(fp, "    ");
+            fprintf_XSUM_testdata_sample_t(fp, v);
+            fprintf(fp, " /* %s[%zd] */\n", arrayName, index++);
+        }
+    }
+    fprintf(fp, "};\n");
+
+    releaseSanityBuffer(sanityBuffer);
+}
+
+
+/* Generate test vectors */
+void generate_sanity_test_vectors(size_t maxLen) {
+    const char* filename = "sanity_test_vectors.h";
+    fprintf(stderr, "Generating %s\n", filename);
+    FILE* fp = fopen(filename, "w");
+    fprintf(fp,
+        "typedef struct {\n"
+        "    XSUM_U32 len;\n"
+        "    XSUM_U32 seed;\n"
+        "    XSUM_U32 Nresult;\n"
+        "} XSUM_testdata32_t;\n"
+        "\n"
+        "typedef struct {\n"
+        "    XSUM_U32 len;\n"
+        "    XSUM_U64 seed;\n"
+        "    XSUM_U64 Nresult;\n"
+        "} XSUM_testdata64_t;\n"
+        "\n"
+        "typedef struct {\n"
+        "    XSUM_U32 len;\n"
+        "    XSUM_U64 seed;\n"
+        "    XXH128_hash_t Nresult;\n"
+        "} XSUM_testdata128_t;\n"
+        "\n"
+        "#ifndef SECRET_SAMPLE_NBBYTES\n"
+        "#define SECRET_SAMPLE_NBBYTES 5\n"
+        "#endif\n"
+        "\n"
+        "typedef struct {\n"
+        "    XSUM_U32 seedLen;\n"
+        "    XSUM_U32 secretLen;\n"
+        "    XSUM_U8 byte[SECRET_SAMPLE_NBBYTES];\n"
+        "} XSUM_testdata_sample_t;\n"
+        "\n"
+        "#ifndef SECRET_SIZE_MAX\n"
+        "#define SECRET_SIZE_MAX 9867\n"
+        "#endif\n"
+        "\n"
+    );
+
+    generate_sanity_test_vectors_xxh32(fp, maxLen);
+    generate_sanity_test_vectors_xxh64(fp, maxLen);
+    generate_sanity_test_vectors_xxh3(fp, maxLen);
+    generate_sanity_test_vectors_xxh3_withSecret(fp, maxLen);
+    generate_sanity_test_vectors_xxh128(fp, maxLen);
+    generate_sanity_test_vectors_xxh128_withSecret(fp, maxLen);
+    generate_sanity_test_vectors_xxh3_generateSecret(fp, maxLen);
+    fclose(fp);
+}
+
+
+/**/
+int main(int argc, const char* argv[])
+{
+    (void) argc;
+    (void) argv;
+    const size_t sanityBufferSizeInBytes = SANITY_BUFFER_SIZE;
+    generate_sanity_test_vectors(sanityBufferSizeInBytes);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR adds dedicated sanity test program.  See #821 for details.

## `make check`
- `make check` invokes `make test_sanity`
- `make test_sanity` invokes `make -C tests test_sanity`
- `make -C tests test_sanity` creates and executes `test/sanity_test`
  - Note that `test/sanity_test` depends `test/sanity_test_vectors.h`

## `make -C tests sanity_test_vectors.h`
When we need to update `tests/sanity_test_vectors.h`, we should invoke the following command

```
make -C tests sanity_test_vectors.h
```

This command creates and executes `tests/sanity_test_vectors_generator`.
And it updates `tests/sanity_test_vectors.h`

## TODO

Since large part of `sanity_test.c` is copied from `xsum_sanity_check.c`, we should tweak then to avoid to copy same code to multiple places.
But as a "version 0" of dedicated sanity test program, I leave them as is to detect possible issue in `sanity_test.c`.
