### PR TITLE
Add WebAssembly SIMD128 implementation and Node.JS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,9 +252,9 @@ jobs:
       run: |
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" RUN_ENV="node" NODE_JS=1 make clean check
 
-    - name: SIMD128 code path (XXH_VECTOR=XXH_WASM128)
+    - name: SIMD128 (via NEON SIMDe) code path (XXH_VECTOR=XXH_NEON)
       run: |
-        CPPFLAGS="-DXXH_VECTOR=XXH_WASM128 -msimd128" RUN_ENV="node" NODE_JS=1 make clean check
+        CPPFLAGS="-DXXH_VECTOR=XXH_NEON -msimd128" RUN_ENV="node" NODE_JS=1 make clean check
 
     - name: Scalar asm.js (-sWASM=0)
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,59 @@ jobs:
         make -C tests/bench
 
 
+  ubuntu-wasm:
+    name: Ubuntu Node ${{ matrix.node-version }} WebAssembly/asm.js tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 17.x, 18.x]
+
+    env:
+      EM_VERSION: 3.1.33 # TODO: more emsdk versions
+      EM_CACHE_FOLDER: emsdk-cache-${{ matrix.node-version }}
+      CC: emcc
+
+    steps:
+    - uses: actions/checkout@v3 # https://github.com/actions/checkout
+
+    - name: Setup cache
+      id: cache-system-libraries
+      uses: actions/cache@v3
+      with:
+        path: ${{env.EM_CACHE_FOLDER}}
+        key: em${{env.EM_VERSION}}-node${{ matrix.node-version }}-${{ runner.os }}
+
+    - name: Setup emsdk
+      uses: mymindstorm/setup-emsdk@v12
+      with:
+        version: ${{env.EM_VERSION}}
+        actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Environment info
+      run: |
+        echo && node -p '`node version: ${process.versions.node}, v8 version: ${process.versions.v8}`'
+        echo && emcc --version
+        echo && make -v
+        echo && cat /proc/cpuinfo || echo /proc/cpuinfo is not present
+
+    - name: Scalar code path
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" RUN_ENV="node" NODE_JS=1 make clean check
+
+    - name: SIMD128 code path (XXH_VECTOR=XXH_WASM128)
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_WASM128 -msimd128" RUN_ENV="node" NODE_JS=1 make clean check
+
+    - name: Scalar asm.js (-sWASM=0)
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" RUN_ENV="node" NODE_JS=1 LDFLAGS="-sWASM=0" make clean check
+
+
   ubuntu-misc:
     name: Linux x64 misc tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ else
 EXT =
 endif
 
+ifeq ($(NODE_JS),1)
+    LDFLAGS += -lnodefs.js -lnoderawfs.js
+    CPPFLAGS += -DXSUM_NODE_JS=1
+    RUN_ENV ?= node
+endif
+
 # OS X linker doesn't support -soname, and use different extension
 # see: https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryDesignGuidelines.html
 ifeq ($(UNAME), Darwin)
@@ -174,6 +180,7 @@ clean:  ## remove all build artifacts
 	$(Q)$(RM) -r *.dSYM   # Mac OS-X specific
 	$(Q)$(RM) core *.o *.obj *.$(SHARED_EXT) *.$(SHARED_EXT).* *.a libxxhash.pc
 	$(Q)$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) dispatch$(EXT)
+	$(Q)$(RM) xxhsum.wasm xxhsum.js xxhsum.html
 	$(Q)$(RM) xxh32sum$(EXT) xxh64sum$(EXT) xxh128sum$(EXT)
 	$(Q)$(RM) $(XXHSUM_SRC_DIR)/*.o $(XXHSUM_SRC_DIR)/*.obj
 	$(MAKE) -C tests clean

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,10 @@ EXT =
 endif
 
 ifeq ($(NODE_JS),1)
-    LDFLAGS += -lnodefs.js -lnoderawfs.js
+    # Link in unrestricted filesystem support
+    LDFLAGS += -sNODERAWFS
+    # Set flag to fix isatty() support
     CPPFLAGS += -DXSUM_NODE_JS=1
-    RUN_ENV ?= node
 endif
 
 # OS X linker doesn't support -soname, and use different extension
@@ -198,6 +199,7 @@ clean:  ## remove all build artifacts
 .PHONY: check
 check: xxhsum   ## basic tests for xxhsum CLI, set RUN_ENV for emulated environments
 	# stdin
+	# If you get "Wrong parameters" on Emscripten+Node.js, recompile with `NODE_JS=1`
 	$(RUN_ENV) ./xxhsum$(EXT) < xxhash.c
 	# multiple files
 	$(RUN_ENV) ./xxhsum$(EXT) xxhash.*

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The following macros can be set at compilation time to modify libxxhash's behavi
 When compiling the Command Line Interface `xxhsum` using `make`, the following environment variables can also be set :
 - `DISPATCH=1` : use `xxh_x86dispatch.c`, to automatically select between `scalar`, `sse2`, `avx2` or `avx512` instruction set at runtime, depending on local host. This option is only valid for `x86`/`x64` systems.
 - `XXH_1ST_SPEED_TARGET` : select an initial speed target, expressed in MB/s, for the first speed test in benchmark mode. Benchmark will adjust the target at subsequent iterations, but the first test is made "blindly" by targeting this speed. Currently conservatively set to 10 MB/s, to support very slow (emulated) platforms.
+- `NODE_JS=1` : When compiling `xxhsum` for Node.js with Emscripten, this links the `NODERAWFS` library for unrestricted filesystem access and patches `isatty` to make the command line utility correctly detect the terminal. This does make the binary specific to Node.js.
 
 ### Building xxHash - Using vcpkg
 

--- a/cli/xsum_arch.h
+++ b/cli/xsum_arch.h
@@ -151,6 +151,12 @@
 #  define XSUM_ARCH "s390x"
 #elif defined(__s390__)
 #  define XSUM_ARCH "s390"
+#elif defined(__wasm__) || defined(__asmjs__) || defined(__EMSCRIPTEN__)
+#  if defined(__wasm_simd128__)
+#    define XSUM_ARCH "wasm/asmjs + simd128"
+#  else
+#    define XSUM_ARCH "wasm/asmjs"
+#  endif
 #else
 #  define XSUM_ARCH "unknown"
 #endif

--- a/cli/xsum_os_specific.c
+++ b/cli/xsum_os_specific.c
@@ -39,7 +39,33 @@
     typedef struct stat XSUM_stat_t;
 #endif
 
-#if (defined(__linux__) && (XSUM_PLATFORM_POSIX_VERSION >= 1)) \
+#if defined(__EMSCRIPTEN__) && defined(XSUM_NODE_JS)
+#  include <unistd.h>   /* isatty */
+#  include <emscripten.h> /* EM_ASM_INT */
+
+/* The emscripten SDK always returns 1 on standard streams even when
+ * NodeJS is being piped. */
+static int XSUM_IS_CONSOLE(FILE* stdStream)
+{
+    /* https://github.com/iliakan/detect-node */
+    int is_node = EM_ASM_INT((
+        return (Object.prototype.toString.call(
+            typeof process !== 'undefined' ? process : 0
+        ) == '[object process]') | 0
+    ));
+
+    if (is_node) {
+        if (stdStream == stdin) {
+            return EM_ASM_INT(return process.stdin.isTTY);
+        } else if (stdStream == stdout) {
+            return EM_ASM_INT(return process.stdout.isTTY);
+        } else if (stdStream == stderr) {
+            return EM_ASM_INT(return process.stderr.isTTY);
+        }
+    }
+    return isatty(fileno(stdStream));
+}
+#elif defined(__EMSCRIPTEN__) || (defined(__linux__) && (XSUM_PLATFORM_POSIX_VERSION >= 1)) \
  || (XSUM_PLATFORM_POSIX_VERSION >= 200112L) \
  || defined(__DJGPP__) \
  || defined(__MSYS__) \

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -56,6 +56,14 @@ extern "C" {
 #  error "Dispatching is currently only supported on x86 and x86_64."
 #endif
 
+#ifndef XXH_HAS_INCLUDE
+#  ifdef __has_include
+#    define XXH_HAS_INCLUDE(x) __has_include(x)
+#  else
+#    define XXH_HAS_INCLUDE(x) 0
+#  endif
+#endif
+
 /*!
  * @def XXH_X86DISPATCH_ALLOW_AVX
  * @brief Disables the AVX sanity check.

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -85,12 +85,6 @@ extern "C" {
 #  error "Do not compile xxh_x86dispatch.c with AVX enabled! See the comment above."
 #endif
 
-#ifdef __has_include
-#  define XXH_HAS_INCLUDE(header) __has_include(header)
-#else
-#  define XXH_HAS_INCLUDE(header) 0
-#endif
-
 /*!
  * @def XXH_DISPATCH_SCALAR
  * @brief Enables/dispatching the scalar code path.
@@ -107,7 +101,7 @@ extern "C" {
 #ifndef XXH_DISPATCH_SCALAR
 #  if defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2) /* SSE2 on by default */ \
      || defined(__x86_64__) || defined(_M_X64) /* x86_64 */ \
-     || defined(__ANDROID__) || defined(__APPLEv__) /* Android or macOS */
+     || defined(__ANDROID__) || defined(__APPLE__) /* Android or macOS */
 #     define XXH_DISPATCH_SCALAR 0 /* disable */
 #  else
 #     define XXH_DISPATCH_SCALAR 1

--- a/xxhash.h
+++ b/xxhash.h
@@ -884,10 +884,18 @@ XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const
  * at competitive speeds, even without vector support. Further details are
  * explained in the implementation.
  *
- * Optimized implementations are provided for AVX512, AVX2, SSE2, NEON, POWER8,
- * ZVector and scalar targets. This can be controlled via the @ref XXH_VECTOR
- * macro. For the x86 family, an automatic dispatcher is included separately
- * in @ref xxh_x86dispatch.c.
+ * XXH3 has a fast scalar implementation, but it also includes accelerated SIMD
+ * implementations for many common platforms:
+ *   - AVX512
+ *   - AVX2
+ *   - SSE2
+ *   - ARM NEON
+ *   - WebAssembly SIMD128
+ *   - POWER8 VSX
+ *   - s390x ZVector
+ * This can be controlled via the @ref XXH_VECTOR macro, but it automatically
+ * selects the best version according to predefined macros. For the x86 family, an
+ * automatic runtime dispatcher is included separately in @ref xxh_x86dispatch.c.
  *
  * XXH3 implementation is portable:
  * it has a generic C90 formulation that can be compiled on any platform,
@@ -1895,10 +1903,12 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  define XXH_COMPILER_GUARD(var) ((void)0)
 #endif
 
-#if defined(__clang__) && !defined(__wasm__)
-#  define XXH_COMPILER_GUARD_W(var) __asm__("" : "+w" (var))
+/* Specifically for NEON vectors which use the "w" constraint, on
+ * Clang. */
+#if defined(__clang__) && defined(__ARM_ARCH) && !defined(__wasm__)
+#  define XXH_COMPILER_GUARD_CLANG_NEON(var) __asm__("" : "+w" (var))
 #else
-#  define XXH_COMPILER_GUARD_W(var) ((void)0)
+#  define XXH_COMPILER_GUARD_CLANG_NEON(var) ((void)0)
 #endif
 
 /* *************************************
@@ -3254,8 +3264,8 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
     XXH_AVX512 = 3,  /*!< AVX512 for Skylake and Icelake */
     XXH_NEON   = 4,  /*!<
                        * NEON for most ARMv7-A, all AArch64, and WASM SIMD128
-                       * which uses SIMDeverywhere and happens to overlay with
-                       * native instructions almost perfectly.
+                       * via the SIMDeverywhere polyfill provided with the
+                       * Emscripten SDK.
                        */
     XXH_VSX    = 5,  /*!< VSX and ZVector for POWER8/z13 (64-bit) */
     XXH_SVE    = 6,  /*!< SVE for some ARMv8-A and ARMv9-A */
@@ -4595,7 +4605,7 @@ XXH3_scalarScrambleRound(void* XXH_RESTRICT acc,
 
 /*!
  * @internal
- * @brief The bulk processing loop for NEON.
+ * @brief The bulk processing loop for NEON and WASM SIMD128.
  *
  * The NEON code path is actually partially scalar when running on AArch64. This
  * is to optimize the pipelining and can have up to 15% speedup depending on the
@@ -4613,7 +4623,7 @@ XXH3_scalarScrambleRound(void* XXH_RESTRICT acc,
  * there needs to be *three* versions of the accumulate operation used
  * for the remaining 2 lanes.
  *
- * WASM's SIMD128 uses SIMDe's polyfill because the intrinsics overlap
+ * WASM's SIMD128 uses SIMDe's arm_neon.h polyfill because the intrinsics overlap
  * nearly perfectly.
  */
 
@@ -4677,9 +4687,9 @@ XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
              * get one vector with the low 32 bits of each lane, and one vector
              * with the high 32 bits of each lane.
              *
-             * This compiles to two instructions on AArch64 and has a paired vector
-             * result, which is an artifact from ARMv7a's version which modified both
-             * vectors in place.
+             * The intrinsic returns a double vector because the original ARMv7-a
+             * instruction modified both arguments in place. AArch64 and SIMD128 emit
+             * two instructions from this intrinsic.
              *
              *  [ dk11L | dk11H | dk12L | dk12H ] -> [ dk11L | dk12L | dk21L | dk22L ]
              *  [ dk21L | dk21H | dk22L | dk22H ] -> [ dk11H | dk12H | dk21H | dk22H ]
@@ -4695,7 +4705,7 @@ XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
             /*
              * Then, we can split the vectors horizontally and multiply which, as for most
              * widening intrinsics, have a variant that works on both high half vectors
-             * for free on AArch64.
+             * for free on AArch64. A similar instruction is available on SIMD128.
              *
              * sum = data_swap + (u64x2) data_key_lo * (u64x2) data_key_hi
              */
@@ -4713,8 +4723,8 @@ XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
              * for reasons likely related to umlal being limited to certain NEON
              * pipelines, this is worse. A compiler guard fixes this.
              */
-            XXH_COMPILER_GUARD_W(sum_1);
-            XXH_COMPILER_GUARD_W(sum_2);
+            XXH_COMPILER_GUARD_CLANG_NEON(sum_1);
+            XXH_COMPILER_GUARD_CLANG_NEON(sum_2);
             /* xacc[i] = acc_vec + sum; */
             xacc[i]   = vaddq_u64(xacc[i], sum_1);
             xacc[i+1] = vaddq_u64(xacc[i+1], sum_2);
@@ -4737,7 +4747,7 @@ XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
             /* sum = data_swap + (u64x2) data_key_lo * (u64x2) data_key_hi; */
             uint64x2_t sum = vmlal_u32(data_swap, data_key_lo, data_key_hi);
             /* Same Clang workaround as before */
-            XXH_COMPILER_GUARD_W(sum);
+            XXH_COMPILER_GUARD_CLANG_NEON(sum);
             /* xacc[i] = acc_vec + sum; */
             xacc[i] = vaddq_u64 (xacc[i], sum);
         }

--- a/xxhash.h
+++ b/xxhash.h
@@ -1895,7 +1895,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  define XXH_COMPILER_GUARD(var) ((void)0)
 #endif
 
-#if defined(__clang__)
+#if defined(__clang__) && !defined(__wasm__)
 #  define XXH_COMPILER_GUARD_W(var) __asm__("" : "+w" (var))
 #else
 #  define XXH_COMPILER_GUARD_W(var) ((void)0)
@@ -3111,13 +3111,22 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
 #    define XXH_unlikely(x) (x)
 #endif
 
+#ifndef XXH_HAS_INCLUDE
+#  ifdef __has_include
+#    define XXH_HAS_INCLUDE(x) __has_include(x)
+#  else
+#    define XXH_HAS_INCLUDE(x) 0
+#  endif
+#endif
+
 #if defined(__GNUC__) || defined(__clang__)
 #  if defined(__ARM_FEATURE_SVE)
 #    include <arm_sve.h>
 #  endif
 #  if defined(__ARM_NEON__) || defined(__ARM_NEON) \
    || (defined(_M_ARM) && _M_ARM >= 7) \
-   || defined(_M_ARM64) || defined(_M_ARM64EC)
+   || defined(_M_ARM64) || defined(_M_ARM64EC) \
+   || (defined(__wasm_simd128__) && XXH_HAS_INCLUDE(<arm_neon.h>)) /* WASM SIMD128 via SIMDe */
 #    define inline __inline__  /* circumvent a clang bug */
 #    include <arm_neon.h>
 #    undef inline
@@ -3240,7 +3249,11 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
                       */
     XXH_AVX2   = 2,  /*!< AVX2 for Haswell and Bulldozer */
     XXH_AVX512 = 3,  /*!< AVX512 for Skylake and Icelake */
-    XXH_NEON   = 4,  /*!< NEON for most ARMv7-A and all AArch64 */
+    XXH_NEON   = 4,  /*!<
+                       * NEON for most ARMv7-A, all AArch64, and WASM SIMD128
+                       * which uses SIMDeverywhere and happens to overlay with
+                       * native instructions almost perfectly.
+                       */
     XXH_VSX    = 5,  /*!< VSX and ZVector for POWER8/z13 (64-bit) */
     XXH_SVE    = 6,  /*!< SVE for some ARMv8-A and ARMv9-A */
 };
@@ -3273,6 +3286,7 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  elif ( \
         defined(__ARM_NEON__) || defined(__ARM_NEON) /* gcc */ \
      || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC) /* msvc */ \
+     || (defined(__wasm_simd128__) && XXH_HAS_INCLUDE(<arm_neon.h>)) /* wasm simd128 via SIMDe */ \
    ) && ( \
         defined(_WIN32) || defined(__LITTLE_ENDIAN__) /* little endian only */ \
     || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
@@ -3478,6 +3492,9 @@ XXH_vmlal_high_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
  *
  * It also seems to fix some bad codegen on GCC, making it almost as fast as clang.
  *
+ * When using WASM SIMD128, if this is 2 or 6, SIMDe will scalarize 2 of the lanes meaning
+ * it effectively becomes worse 4.
+ *
  * @see XXH3_accumulate_512_neon()
  */
 # ifndef XXH3_NEON_LANES
@@ -3622,7 +3639,6 @@ do { \
     acc = svadd_u64_x(mask, acc, mul);                               \
 } while (0)
 #endif /* XXH_VECTOR == XXH_SVE */
-
 
 /* prefetch
  * can be disabled, by declaring XXH_NO_PREFETCH build macro */
@@ -4593,7 +4609,11 @@ XXH3_scalarScrambleRound(void* XXH_RESTRICT acc,
  * Since, as stated, the most optimal amount of lanes for Cortexes is 6,
  * there needs to be *three* versions of the accumulate operation used
  * for the remaining 2 lanes.
+ *
+ * WASM's SIMD128 uses SIMDe's polyfill because the intrinsics overlap
+ * nearly perfectly.
  */
+
 XXH_FORCE_INLINE void
 XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
                     const void* XXH_RESTRICT input,
@@ -4604,10 +4624,19 @@ XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
     {   /* GCC for darwin arm64 does not like aliasing here */
         xxh_aliasing_uint64x2_t* const xacc = (xxh_aliasing_uint64x2_t*) acc;
         /* We don't use a uint32x4_t pointer because it causes bus errors on ARMv7. */
-        uint8_t const* const xinput = (const uint8_t *) input;
-        uint8_t const* const xsecret  = (const uint8_t *) secret;
+        uint8_t const* xinput = (const uint8_t *) input;
+        uint8_t const* xsecret  = (const uint8_t *) secret;
 
         size_t i;
+#ifdef __wasm_simd128__
+        /*
+         * On WASM SIMD128, vector literals are a thing and Clang really wants to use them.
+         *
+         * This is all great if SIMD128 was native, but it is JITted to a bunch of immediate
+         * loads which isn't faster and wastes code space.
+         */
+        XXH_COMPILER_GUARD(xsecret);
+#endif
         /* Scalar lanes use the normal scalarRound routine */
         for (i = XXH3_NEON_LANES; i < XXH_ACC_NB; i++) {
             XXH3_scalarRound(acc, input, secret, i);
@@ -4709,9 +4738,16 @@ XXH3_scrambleAcc_neon(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 
     {   xxh_aliasing_uint64x2_t* xacc       = (xxh_aliasing_uint64x2_t*) acc;
         uint8_t const* xsecret = (uint8_t const*) secret;
-        uint32x2_t prime       = vdup_n_u32 (XXH_PRIME32_1);
 
         size_t i;
+        /* WASM uses operator overloads and  */
+#ifndef __wasm_simd128__
+        /* { prime32_1, prime32_1 } */
+        uint32x2_t const kPrimeLo = vdup_n_u32(XXH_PRIME32_1);
+        /* { 0, prime32_1, 0, prime32_1 } */
+        uint32x4_t const kPrimeHi = vreinterpretq_u32_u64(vdupq_n_u64((xxh_u64)XXH_PRIME32_1 << 32));
+#endif
+
         /* AArch64 uses both scalar and neon at the same time */
         for (i = XXH3_NEON_LANES; i < XXH_ACC_NB; i++) {
             XXH3_scalarScrambleRound(acc, secret, i);
@@ -4725,33 +4761,28 @@ XXH3_scrambleAcc_neon(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
             /* xacc[i] ^= xsecret[i]; */
             uint64x2_t key_vec  = XXH_vld1q_u64(xsecret + (i * 16));
             uint64x2_t data_key = veorq_u64(data_vec, key_vec);
-
             /* xacc[i] *= XXH_PRIME32_1 */
-            uint32x2_t data_key_lo = vmovn_u64(data_key);
-            uint32x2_t data_key_hi = vshrn_n_u64(data_key, 32);
+#ifdef __wasm_simd128__
+            /* SIMD128 has multiply by u64x2, use it instead of expanding and scalarizing */
+            xacc[i] = data_key * XXH_PRIME32_1;
+#else
             /*
-             * prod_hi = (data_key >> 32) * XXH_PRIME32_1;
+             * Expanded version with portable NEON intrinsics
              *
-             * Avoid vmul_u32 + vshll_n_u32 since Clang 6 and 7 will
-             * incorrectly "optimize" this:
-             *   tmp     = vmul_u32(vmovn_u64(a), vmovn_u64(b));
-             *   shifted = vshll_n_u32(tmp, 32);
-             * to this:
-             *   tmp     = "vmulq_u64"(a, b); // no such thing!
-             *   shifted = vshlq_n_u64(tmp, 32);
+             *    lo(x) * lo(y) + (hi(x) * lo(y) << 32)
              *
-             * However, unlike SSE, Clang lacks a 64-bit multiply routine
-             * for NEON, and it scalarizes two 64-bit multiplies instead.
+             * prod_hi = hi(data_key) * lo(prime) << 32
              *
-             * vmull_u32 has the same timing as vmul_u32, and it avoids
-             * this bug completely.
-             * See https://bugs.llvm.org/show_bug.cgi?id=39967
+             * Since we only need 32 bits of this multiply a trick can be used, reinterpreting the vector
+             * as a uint32x4_t and multiplying by { 0, prime, 0, prime } to cancel out the unwanted bits
+             * and avoid the shift.
              */
-            uint64x2_t prod_hi = vmull_u32 (data_key_hi, prime);
-            /* xacc[i] = prod_hi << 32; */
-            prod_hi = vshlq_n_u64(prod_hi, 32);
-            /* xacc[i] += (prod_hi & 0xFFFFFFFF) * XXH_PRIME32_1; */
-            xacc[i] = vmlal_u32(prod_hi, data_key_lo, prime);
+            uint32x4_t prod_hi = vmulq_u32 (vreinterpretq_u32_u64(data_key), kPrimeHi);
+            /* Extract low bits for vmlal_u32  */
+            uint32x2_t data_key_lo = vmovn_u64(data_key);
+            /* xacc[i] = prod_hi + lo(data_key) * XXH_PRIME32_1; */
+            xacc[i] = vmlal_u32(vreinterpretq_u64_u32(prod_hi), data_key_lo, kPrimeLo);
+#endif
         }
     }
 }

--- a/xxhash.h
+++ b/xxhash.h
@@ -2287,7 +2287,7 @@ static xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input)
     acc += input * XXH_PRIME32_2;
     acc  = XXH_rotl32(acc, 13);
     acc *= XXH_PRIME32_1;
-#if (defined(__SSE4_1__) || defined(__aarch64__)) && !defined(XXH_ENABLE_AUTOVECTORIZE)
+#if (defined(__SSE4_1__) || defined(__aarch64__) || defined(__wasm_simd128__)) && !defined(XXH_ENABLE_AUTOVECTORIZE)
     /*
      * UGLY HACK:
      * A compiler fence is the only thing that prevents GCC and Clang from
@@ -2320,6 +2320,9 @@ static xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input)
      * This is also enabled on AArch64, as Clang is *very aggressive* in vectorizing
      * the loop. NEON is only faster on the A53, and with the newer cores, it is less
      * than half the speed.
+     *
+     * Additionally, this is used on WASM SIMD128 because it JITs to the same
+     * SIMD instructions and has the same issue.
      */
     XXH_COMPILER_GUARD(acc);
 #endif


### PR DESCRIPTION
 - Support WebAssembly SIMD128 via the NEON path
   - The Emscripten SDK includes the SIMDeverywhere polyfill for `<arm_neon.h>`
   - Since SIMD128 seems to be designed after a subset of NEON, the double width NEON path maps 1:1 and gets full speed with few modifications
      - Note: `XXH3_NEON_LANES != 8` IS BAD since SIMDe scalarizes half vectors
   - On v8, about 2x faster than scalar on AArch64, 3-4x faster on x86_64
   - Firefox seems to be slightly faster on x86, slightly slower on aarch64
 - Adds a few fixes for compiling with Node.JS (`make NODE_JS=1`)
   - Requires linking `nodefs` and `noderawfs` to access local files
   - Hook into node.js directly using inline JavaScript to access `tty.isatty()` from Node instead of the broken `isatty()` in libc (which always returns `1` for stdin/stdout/stderr) 
 - Add `wasm/asmjs` to the welcome message
 - Remove `emcc` output files on `make clean`
 - Add basic CI tests for both WASM and asm.js (the latter of which is painfully slow lol)
 - Also since I needed to modify XXH3_scrambleAcc_neon, I found a stupidly obvious optimization to standard NEON. 

Due to the fact that WebAssembly is JIT-compiled and that JavaScript timer precision is limited due to Spectre, the results may vary.

NEON gets almost native speed on v8, but x86_64 does not mainly due to the instruction sets not exactly matching up. Firefox's aarch64 JIT seems to be considerably slower when it comes to WASM.

`xxhsum -b` on an AArch64 Google Tensor G1 (Cortex-X1 @ 2.80 GHz):
| Browser/engine | Scalar XXH3_64b | Scalar XXH128 | WASM128 XXH3_64B | WASM128 XXH128 |
|:--|:--|:--|:--|:--|
| Node 18.13 / v8 10.2.154 (termux) | 8421.7 MB/s | 8161.7 MB/s | 16485.4 MB/s | 16355.0 MB/s |
| Firefox Nightly for Android 112.0a1 | 7850.5 MB/s | 7870.8 MB/s | 6148.4 MB/s | 5861.7 MB/s | 

x86_64 (with AVX2) Core i7-8650U @ 2.11 GHz (turbo 4.20 GHz):

| Browser/engine | Scalar XXH3_64b | Scalar XXH128 | WASM128 XXH3_64B | WASM128 XXH128 |
|:--|:--|:--|:--|:--|
| Node 18.14 / v8 10.2.154 (mingw64) | 3605.8 MB/s | 3473.8 MB/s | 9658.2 MB/s | 11535.5 MB/s |
| Firefox for Windows 110.0.1 | 6406.9 MB/s | 6004.3 MB/s | 9249.1 MB/s | 9288.8 MB/s |

(Not sure why XXH128 is that much faster on x86 but not ARM. Maybe code alignment memes?).