### PR TITLE
Feature: Support # comment lines in --check files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,10 @@ jobs:
       run: |
         make clean test-filename-escape
 
+    - name: test-cli-comment-line
+      run: |
+        make clean test-cli-comment-line
+
   ubuntu-cmake-unofficial:
     name: Linux x64 cmake unofficial build test
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,10 @@ test-xxhsum-c: xxhsum
 test-filename-escape:
 	$(MAKE) -C tests test_filename_escape
 
+.PHONY: test-cli-comment-line
+test-cli-comment-line:
+	$(MAKE) -C tests test_cli_comment_line
+
 .PHONY: armtest
 armtest: clean
 	@echo ---- test ARM compilation ----

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -814,6 +814,7 @@ static void XSUM_parseFile1(ParseFileArg* XSUM_parseFileArg, int rev)
                 switch (XSUM_getLineResult)
                 {
                 case GetLine_ok:
+                case GetLine_comment:
                 case GetLine_eof:
                     /* These cases never happen.  See above XSUM_getLineResult related "if"s.
                        They exist just for make gcc's -Wswitch-enum happy. */

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -488,6 +488,7 @@ static int XSUM_hashFiles(const char* fnList[], int fnTotal,
 
 typedef enum {
     GetLine_ok,
+    GetLine_comment,
     GetLine_eof,
     GetLine_exceedMaxLineLength,
     GetLine_outOfMemory
@@ -549,6 +550,7 @@ typedef struct {
 /*
  * Reads a line from stream `inFile`.
  * Returns GetLine_ok, if it reads line successfully.
+ * Returns GetLine_comment, if the line is beginning with '#'.
  * Returns GetLine_eof, if stream reaches EOF.
  * Returns GetLine_exceedMaxLineLength, if line length is longer than MAX_LINE_LENGTH.
  * Returns GetLine_outOfMemory, if line buffer memory allocation failed.
@@ -598,6 +600,12 @@ static GetLineResult XSUM_getLine(char** lineBuf, int* lineMax, FILE* inFile)
     }
 
     (*lineBuf)[len] = '\0';
+
+    /* Ignore comment lines, which begin with a '#' character. */
+    if (result == GetLine_ok && len > 0 && ((*lineBuf)[0] == '#')) {
+        result = GetLine_comment;
+    }
+
     return result;
 }
 
@@ -794,6 +802,12 @@ static void XSUM_parseFile1(ParseFileArg* XSUM_parseFileArg, int rev)
         {   GetLineResult const XSUM_getLineResult = XSUM_getLine(&XSUM_parseFileArg->lineBuf,
                                                         &XSUM_parseFileArg->lineMax,
                                                          XSUM_parseFileArg->inFile);
+
+            /* Ignore comment lines */
+            if (XSUM_getLineResult == GetLine_comment) {
+                continue;
+            }
+
             if (XSUM_getLineResult != GetLine_ok) {
                 if (XSUM_getLineResult == GetLine_eof) break;
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -104,6 +104,10 @@ endif
 test_filename_escape: $(XXHSUM)
 	./filename-escape.sh
 
+.PHONY: test_cli_comment_line
+test_cli_comment_line: $(XXHSUM)
+	$(SHELL) ./cli-comment-line.sh
+
 .PHONY: test_sanity
 test_sanity: sanity_test.c
 	$(CC) $(CFLAGS) $(LDFLAGS) sanity_test.c -o sanity_test$(EXT)

--- a/tests/cli-comment-line.sh
+++ b/tests/cli-comment-line.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Exit immediately if any command fails.
+# https://stackoverflow.com/a/2871034
+set -euxo
+
+
+# Default
+./xxhsum ./Makefile > ./.test.xxh
+echo '# Test comment line' | cat - ./.test.xxh > temp && mv temp ./.test.xxh
+./xxhsum --check ./.test.xxh
+
+# XXH32
+./xxhsum -H32 ./Makefile > ./.test.xxh32
+echo '# Test comment line' | cat - ./.test.xxh32 > temp && mv temp ./.test.xxh32
+./xxhsum --check ./.test.xxh32
+
+# XXH64
+./xxhsum -H64 ./Makefile > ./.test.xxh64
+echo '# Test comment line' | cat - ./.test.xxh64 > temp && mv temp ./.test.xxh64
+./xxhsum --check ./.test.xxh64
+
+# XXH128
+./xxhsum -H128 ./Makefile > ./.test.xxh128
+echo '# Test comment line' | cat - ./.test.xxh128 > temp && mv temp ./.test.xxh128
+./xxhsum --check ./.test.xxh128
+
+
+rm ./.test.xxh
+rm ./.test.xxh32
+rm ./.test.xxh64
+rm ./.test.xxh128


### PR DESCRIPTION
This PR resolves #836.

Basically, we just follow the following logic in the `digest.c` of GNU coreutils.
https://github.com/coreutils/coreutils/blob/d53190ed46a55f599800ebb2d8ddfe38205dbd24/src/digest.c#L1180-L1182

This PR also contains a trivial test shell script, `Makefile` entries and `ci.yml` entry for it.
