### PR TITLE
Add --ignore-missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,10 @@ test-filename-escape:
 test-cli-comment-line:
 	$(MAKE) -C tests test_cli_comment_line
 
+.PHONY: test-cli-ignore-missing
+test-cli-ignore-missing:
+	$(MAKE) -C tests test_cli_ignore_missing
+
 .PHONY: armtest
 armtest: clean
 	@echo ---- test ARM compilation ----

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -108,6 +108,10 @@ test_filename_escape: $(XXHSUM)
 test_cli_comment_line: $(XXHSUM)
 	$(SHELL) ./cli-comment-line.sh
 
+.PHONY: test_cli_ignore_missing
+test_cli_ignore_missing: $(XXHSUM)
+	$(SHELL) ./cli-ignore-missing.sh
+
 .PHONY: test_sanity
 test_sanity: sanity_test.c
 	$(CC) $(CFLAGS) $(LDFLAGS) sanity_test.c -o sanity_test$(EXT)

--- a/tests/cli-ignore-missing.sh
+++ b/tests/cli-ignore-missing.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Exit immediately if any command fails.
+# https://stackoverflow.com/a/2871034
+set -e -u -x
+
+
+# Normal
+./xxhsum ./Makefile > ./.test.xxh
+./xxhsum --check ./.test.xxh
+
+
+# Missing, expect error
+# (1) Create checksum file.
+# (2) Remove one of them.
+# (3) --check it
+# (4) Expect NG (missing file)
+cp Makefile .test.makefile
+./xxhsum ./.test.makefile > ./.test.xxh
+rm ./.test.makefile
+! ./xxhsum --check ./.test.xxh  # Put '!' for expecting error
+
+
+# Missing, --ignore-missing
+# (1) Create checksum file.
+# (2) Remove one of them.
+# (3) --check it with --ignore-missing.
+# (4) Expect OK
+
+cp Makefile .test.makefile
+./xxhsum Makefile ./.test.makefile > ./.test.xxh
+rm ./.test.makefile
+./xxhsum --check --ignore-missing ./.test.xxh
+
+
+# Missing, --ignore-missing, expect error
+# (1) Create checksum file.
+# (2) Remove all of them.
+# (3) --check it with --ignore-missing.
+# (4) Expect NG (no file was verified).
+
+cp Makefile .test.makefile
+./xxhsum ./.test.makefile > ./.test.xxh
+rm ./.test.makefile
+! ./xxhsum --check --ignore-missing ./.test.xxh  # Put '!' for expecting error
+
+
+# Cleanup
+( rm ./.test.* ) || true
+
+echo OK


### PR DESCRIPTION
Another trivial PR for `--ignore-missing`.  Resolves #811

- Add `--ignore-missing` option for `xxhsum`.
- Add test script `tests/cli-ignore-missing.sh` and related `Makefile` entries.
  - Note that we still don't have CLI test entry in our CI.

## `--ignore-missing` may fail

`xxhsum` returns failure exit code when

- `--ignore-missing` is presented.
- Checksum file is specified.
- But `XSUM_checkFile()` doesn't read actual file (maybe) due to `--ignore-missing`
  - See also : https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L1558-L1564

If so, `xxhsum` reports `no file was verified` with failure exit code.

## See also

<details><summary>`--ignore-missing` related code in `digest.c`</summary>

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L190-L191

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L362

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L380

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L506

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L978-L982

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L1236-L1240

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L1325-L1328

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L1429-L1431

- https://github.com/coreutils/coreutils/blob/2f1cffe07ab0f0b4135a52d95f1689d7fc7f26c9/src/digest.c#L1558-L1564

</details>
