### PR TITLE
cmake: bump minimum required to version 3.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,26 +341,26 @@ jobs:
         cat build/libxxhash.pc | grep "libdir=/usr/lib"
         cat build/libxxhash.pc | grep "includedir=/usr/include"
 
-    - name: cmake minimum version v2.8.12 test
+    - name: cmake minimum version v3.5 test
       run: |
         mkdir -p cmake_bins
         cd cmake_bins
-        wget https://cmake.org/files/v2.8/cmake-2.8.12.2-Linux-i386.tar.gz
-        tar xzf cmake-2.8.12.2-Linux-i386.tar.gz
+        wget https://cmake.org/files/v3.5/cmake-3.5.0-Linux-i386.tar.gz
+        tar xzf cmake-3.5.0-Linux-i386.tar.gz
         cd ../cmake_unofficial
         rm -rf build
         pwd
         ls
         mkdir -p build
         cd build
-        ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake --version
-        ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake ..
-        ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake --build .
+        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --version
+        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake ..
+        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --build .
         mkdir -p test_install_dir
-        DESTDIR=test_install_dir ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake --install .
+        DESTDIR=test_install_dir ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --install .
         rm -rf *
-        ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake -DCMAKE_BUILD_TYPE=Debug ..
-        ../../cmake_bins/cmake-2.8.12.2-Linux-i386/bin/cmake --build .
+        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake -DCMAKE_BUILD_TYPE=Debug ..
+        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --build .
 
 
 

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # For details, see <https://creativecommons.org/publicdomain/zero/1.0/>.
 
-cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 
 set(XXHASH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
@@ -25,14 +25,10 @@ if("${CMAKE_VERSION}" VERSION_LESS "3.13")
 else()
     cmake_policy (SET CMP0077 NEW)
 endif()
-if("${CMAKE_VERSION}" VERSION_LESS "3.0")
-    project(xxHash C)
-else()
-    cmake_policy (SET CMP0048 NEW)
-    project(xxHash
-        VERSION ${XXHASH_VERSION_STRING}
-        LANGUAGES C)
-endif()
+cmake_policy (SET CMP0048 NEW)
+project(xxHash
+    VERSION ${XXHASH_VERSION_STRING}
+    LANGUAGES C)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Project build type" FORCE)
@@ -168,19 +164,9 @@ if(NOT XXHASH_BUNDLED_MODE)
     ${PROJECT_SOURCE_DIR}/xxHashConfig.cmake.in
     ${xxHash_PROJECT_CONFIG}
     INSTALL_DESTINATION ${xxHash_CONFIG_INSTALL_DIR})
-  if("${CMAKE_VERSION}" VERSION_LESS "3.0")
-      set(XXHASH_EXPORT_SET xxhash)
-      if(XXHASH_BUILD_XXHSUM)
-        set(XXHASH_EXPORT_SET ${XXHASH_EXPORT_SET} xxhsum)
-      endif()
-      export(TARGETS ${XXHASH_EXPORT_SET}
-      FILE ${xxHash_TARGETS_CONFIG}
-      NAMESPACE ${PROJECT_NAME}::)
-  else()
     export(EXPORT xxHashTargets
       FILE ${xxHash_TARGETS_CONFIG}
       NAMESPACE ${PROJECT_NAME}::)
-  endif()
 
   install(FILES ${xxHash_PROJECT_CONFIG} ${xxHash_VERSION_CONFIG}
     DESTINATION ${xxHash_CONFIG_INSTALL_DIR})


### PR DESCRIPTION
This fixes the following warning when configuring with CMake 3.27+:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```