### PR TITLE
added a compilation warning message for XXH_OLD_NAMES

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,7 @@ v0.8.2
 - portability: can build on Haiku (@Begasus)
 - portability: validated on m68k and risc-v
 - doc  : XXH3 specification (@Adrien1018)
-- doc  : improved doxygen documentation (@easyaspi314)
+- doc  : improved doxygen documentation (@easyaspi314, @t-mat)
 - misc : dedicated sanity test binary (@t-mat)
 
 v0.8.1

--- a/xxhash.h
+++ b/xxhash.h
@@ -2197,6 +2197,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 typedef XXH32_hash_t xxh_u32;
 
 #ifdef XXH_OLD_NAMES
+#  warning "XXH_OLD_NAMES is planned to be removed starting v0.9. If the program depends on it, consider moving away from it by employing newer type names directly"
 #  define BYTE xxh_u8
 #  define U8   xxh_u8
 #  define U32  xxh_u32


### PR DESCRIPTION
as suggested by @t-mat,
warning about the upcoming deprecation of this feature.