### PR TITLE
fix: __cpuidex pointer type warning

### DIFF
--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -255,7 +255,7 @@ extern "C" {
 static void XXH_cpuid(xxh_u32 eax, xxh_u32 ecx, xxh_u32* abcd)
 {
 #if defined(_MSC_VER)
-    __cpuidex(abcd, eax, ecx);
+    __cpuidex((int*)abcd, eax, ecx);
 #else
     xxh_u32 ebx, edx;
 # if defined(__i386__) && defined(__PIC__)


### PR DESCRIPTION
`clang-cl` warns the first argument of `__cpuidex()` because it's int[].

```
void __cpuidex(
   int cpuInfo[4],
   int function_id,
   int subfunction_id
);
```

https://learn.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex

Without this patch, it reports the following warning

```
xxHash\xxh_x86dispatch.c(258,15): warning : passing 'xxh_u32 *'
(aka 'unsigned int *') to parameter of type 'int *' converts between pointers
to integer types with different sign [-Wpointer-sign]
```
