### PR TITLE
Fix clang-cl dispatch

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -85,7 +85,8 @@ endif()
 # libxxhash
 if((DEFINED DISPATCH) AND (DEFINED PLATFORM))
   # Only support DISPATCH option on x86_64.
-  if("${PLATFORM}" STREQUAL "x86_64")
+  if(("${PLATFORM}" STREQUAL "x86_64") OR ("${PLATFORM}" STREQUAL "AMD64"))
+    set(XXHSUM_DISPATCH ON)
     message(STATUS "Enable xxHash dispatch mode")
     add_library(xxhash "${XXHASH_DIR}/xxh_x86dispatch.c"
                        "${XXHASH_DIR}/xxhash.c"
@@ -113,12 +114,17 @@ set_target_properties(xxhash PROPERTIES
 if(XXHASH_BUILD_XXHSUM)
   set(XXHSUM_DIR "${XXHASH_DIR}/cli")
   # xxhsum
-  add_executable(xxhsum "${XXHSUM_DIR}/xxhsum.c"
-                        "${XXHSUM_DIR}/xsum_os_specific.c"
-                        "${XXHSUM_DIR}/xsum_output.c"
-                        "${XXHSUM_DIR}/xsum_sanity_check.c"
-                        "${XXHSUM_DIR}/xsum_bench.c"
-                )
+  set(XXHSUM_SOURCES)
+  if (XXHSUM_DISPATCH)
+    list(APPEND XXHSUM_SOURCES "${XXHASH_DIR}/xxh_x86dispatch.c")
+  endif()
+  list(APPEND XXHSUM_SOURCES "${XXHSUM_DIR}/xxhsum.c"
+                             "${XXHSUM_DIR}/xsum_os_specific.c"
+                             "${XXHSUM_DIR}/xsum_output.c"
+                             "${XXHSUM_DIR}/xsum_sanity_check.c"
+                             "${XXHSUM_DIR}/xsum_bench.c"
+      )
+  add_executable(xxhsum ${XXHSUM_SOURCES})
   add_executable(${PROJECT_NAME}::xxhsum ALIAS xxhsum)
 
   target_link_libraries(xxhsum PRIVATE xxhash)

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -184,6 +184,18 @@ extern "C" {
 #  define XXH_TARGET_SSE2 __attribute__((__target__("sse2")))
 #  define XXH_TARGET_AVX2 __attribute__((__target__("avx2")))
 #  define XXH_TARGET_AVX512 __attribute__((__target__("avx512f")))
+#elif defined(__clang__) && defined(_MSC_VER) /* clang-cl.exe */
+#  include <emmintrin.h> /* SSE2 */
+#  if XXH_DISPATCH_AVX2 || XXH_DISPATCH_AVX512
+#    include <immintrin.h> /* AVX2, AVX512F */
+#    include <smmintrin.h>
+#    include <avxintrin.h>
+#    include <avx2intrin.h>
+#    include <avx512fintrin.h>
+#  endif
+#  define XXH_TARGET_SSE2 __attribute__((__target__("sse2")))
+#  define XXH_TARGET_AVX2 __attribute__((__target__("avx2")))
+#  define XXH_TARGET_AVX512 __attribute__((__target__("avx512f")))
 #elif defined(_MSC_VER)
 #  include <intrin.h>
 #  define XXH_TARGET_SSE2


### PR DESCRIPTION
This PR resolves #763 and #863 (partially).
Also enables to compile `xxhsum` with auto-vec (dispatch).

We can build it with the following commands

```powershell
cd cmake_unofficial
mkdir build-clang-cl
cd build-clang-cl

cmake .. -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64 -DCMAKE_GENERATOR_TOOLSET=ClangCL
cmake --build . --config Release
.\Release\xxhsum.exe -bi1
```

It also supports standard `XXH_DISPATCH_*` configurations.

```powershell
cmake .. -DXXHASH_C_FLAGS="-DXXH_DISPATCH_AVX2=0" -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64 -DCMAKE_GENERATOR_TOOLSET=ClangCL
```
