### PR TITLE
fix: Intel compiler's warning for XXH_ASSERT()

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -2138,7 +2138,11 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  include <assert.h>   /* note: can still be disabled with NDEBUG */
 #  define XXH_ASSERT(c)   assert(c)
 #else
-#  define XXH_ASSERT(c)   XXH_ASSUME(c)
+#  if defined(__INTEL_COMPILER)
+#    define XXH_ASSERT(c)   XXH_ASSUME((unsigned char) (c))
+#  else
+#    define XXH_ASSERT(c)   XXH_ASSUME(c)
+#  endif
 #endif
 
 /* note: use after variable declarations */


### PR DESCRIPTION
Intel compiler expects `unsigned char` as an argument of `__builtin_assume()`.
Without this patch, it reports the following warnings to all `XXH_ASSERT()`s.

```
In file included from xxhash.c(43):
xxhash.h(6737): warning #2259: non-pointer conversion from "int" to "unsigned char" may lose significant bits
      XXH_ASSERT(secretBuffer != NULL);
      ^
```
