### PR TITLE
Added a GNU-like format for XXH3 checksum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ libxxhash.*
 xxh32sum
 xxh64sum
 xxh128sum
+xxh3sum
 xxhsum
 xxhsum32
 xxhsum_privateXXH

--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ xxhsum.o: $(XXHSUM_SRC_DIR)/xxhsum.c $(XXHSUM_HEADERS) \
 xxh_x86dispatch.o: xxh_x86dispatch.c xxh_x86dispatch.h xxhash.h
 
 .PHONY: xxhsum_and_links
-xxhsum_and_links: xxhsum xxh32sum xxh64sum xxh128sum
+xxhsum_and_links: xxhsum xxh32sum xxh64sum xxh128sum xxh3sum
 
-xxh32sum xxh64sum xxh128sum: xxhsum
+xxh32sum xxh64sum xxh128sum xxh3sum: xxhsum
 	ln -sf $<$(EXT) $@$(EXT)
 
 xxhsum_inlinedXXH: CPPFLAGS += -DXXH_INLINE_ALL
@@ -182,7 +182,7 @@ clean:  ## remove all build artifacts
 	$(Q)$(RM) core *.o *.obj *.$(SHARED_EXT) *.$(SHARED_EXT).* *.a libxxhash.pc
 	$(Q)$(RM) xxhsum$(EXT) xxhsum32$(EXT) xxhsum_inlinedXXH$(EXT) dispatch$(EXT)
 	$(Q)$(RM) xxhsum.wasm xxhsum.js xxhsum.html
-	$(Q)$(RM) xxh32sum$(EXT) xxh64sum$(EXT) xxh128sum$(EXT)
+	$(Q)$(RM) xxh32sum$(EXT) xxh64sum$(EXT) xxh128sum$(EXT) xxh3sum$(EXT)
 	$(Q)$(RM) $(XXHSUM_SRC_DIR)/*.o $(XXHSUM_SRC_DIR)/*.obj
 	$(MAKE) -C tests clean
 	$(MAKE) -C tests/bench clean
@@ -604,6 +604,7 @@ install_xxhsum: xxhsum
 	$(Q)ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh32sum
 	$(Q)ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh64sum
 	$(Q)ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh128sum
+	$(Q)ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh3sum
 
 install_man:
 	@echo Installing man pages
@@ -630,6 +631,7 @@ uninstall:  ## uninstall libraries, CLI, links and man page
 	$(Q)$(RM) $(DESTDIR)$(BINDIR)/xxh32sum
 	$(Q)$(RM) $(DESTDIR)$(BINDIR)/xxh64sum
 	$(Q)$(RM) $(DESTDIR)$(BINDIR)/xxh128sum
+	$(Q)$(RM) $(DESTDIR)$(BINDIR)/xxh3sum
 	$(Q)$(RM) $(DESTDIR)$(BINDIR)/xxhsum
 	$(Q)$(RM) $(DESTDIR)$(MANDIR)/xxh32sum.1
 	$(Q)$(RM) $(DESTDIR)$(MANDIR)/xxh64sum.1

--- a/Makefile
+++ b/Makefile
@@ -459,26 +459,37 @@ test-xxh-nnn-sums: xxhsum_and_links
 	./xxh32sum  README.md > tmp.xxh32sum.out
 	./xxh64sum  README.md > tmp.xxh64sum.out
 	./xxh128sum README.md > tmp.xxh128sum.out
+	./xxh3sum   README.md > tmp.xxh3sum.out
 	cat tmp.xxhsum.out
 	cat tmp.xxh32sum.out
 	cat tmp.xxh64sum.out
 	cat tmp.xxh128sum.out
+	cat tmp.xxh3sum.out
 	./xxhsum -c tmp.xxhsum.out
 	./xxhsum -c tmp.xxh32sum.out
 	./xxhsum -c tmp.xxh64sum.out
 	./xxhsum -c tmp.xxh128sum.out
+	./xxhsum -c tmp.xxh3sum.out
 	./xxh32sum -c tmp.xxhsum.out            ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh32sum -c tmp.xxh32sum.out
 	./xxh32sum -c tmp.xxh64sum.out          ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh32sum -c tmp.xxh128sum.out         ; test $$? -eq 1  # expects "no properly formatted"
+	./xxh32sum -c tmp.xxh3sum.out           ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh64sum -c tmp.xxhsum.out
 	./xxh64sum -c tmp.xxh32sum.out          ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh64sum -c tmp.xxh64sum.out
 	./xxh64sum -c tmp.xxh128sum.out         ; test $$? -eq 1  # expects "no properly formatted"
+	./xxh64sum -c tmp.xxh3sum.out           ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh128sum -c tmp.xxhsum.out           ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh128sum -c tmp.xxh32sum.out         ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh128sum -c tmp.xxh64sum.out         ; test $$? -eq 1  # expects "no properly formatted"
 	./xxh128sum -c tmp.xxh128sum.out
+	./xxh128sum -c tmp.xxh3sum.out          ; test $$? -eq 1  # expects "no properly formatted"
+	./xxh3sum -c tmp.xxhsum.out             ; test $$? -eq 1  # expects "no properly formatted"
+	./xxh3sum -c tmp.xxh32sum.out           ; test $$? -eq 1  # expects "no properly formatted"
+	./xxh3sum -c tmp.xxh64sum.out           ; test $$? -eq 1  # expects "no properly formatted"
+	./xxh3sum -c tmp.xxh128sum.out          ; test $$? -eq 1  # expects "no properly formatted"
+	./xxh3sum -c tmp.xxh3sum.out
 
 .PHONY: listL120
 listL120:  # extract lines >= 120 characters in *.{c,h}, by Takayuki Matsuoka (note: $$, for Makefile compatibility)
@@ -613,6 +624,7 @@ install_man:
 	$(Q)ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh32sum.1
 	$(Q)ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh64sum.1
 	$(Q)ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh128sum.1
+	$(Q)ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh3sum.1
 
 .PHONY: install
 install: install_libxxhash.a install_libxxhash install_libxxhash.includes install_libxxhash.pc install_xxhsum install_man ## install libraries, CLI, links and man page
@@ -636,6 +648,7 @@ uninstall:  ## uninstall libraries, CLI, links and man page
 	$(Q)$(RM) $(DESTDIR)$(MANDIR)/xxh32sum.1
 	$(Q)$(RM) $(DESTDIR)$(MANDIR)/xxh64sum.1
 	$(Q)$(RM) $(DESTDIR)$(MANDIR)/xxh128sum.1
+	$(Q)$(RM) $(DESTDIR)$(MANDIR)/xxh3sum.1
 	$(Q)$(RM) $(DESTDIR)$(MANDIR)/xxhsum.1
 	@echo xxhsum successfully uninstalled
 

--- a/Makefile
+++ b/Makefile
@@ -288,14 +288,14 @@ test-xxhsum-c: xxhsum
 	./xxhsum --tag -H1 xxhsum* | $(GREP) XXH64
 	./xxhsum --tag -H2 xxhsum* | $(GREP) XXH128
 	./xxhsum --tag -H3 xxhsum* | $(GREP) XXH3
-	./xxhsum       -H3 xxhsum* | $(GREP) XXH3  # --tag is implicit for H3
+	./xxhsum       -H3 xxhsum* | $(GREP) XXH3_ # prefix for GNU format
 	./xxhsum --tag -H32 xxhsum* | $(GREP) XXH32
 	./xxhsum --tag -H64 xxhsum* | $(GREP) XXH64
 	./xxhsum --tag -H128 xxhsum* | $(GREP) XXH128
 	./xxhsum --tag -H0 --little-endian xxhsum* | $(GREP) XXH32_LE
 	./xxhsum --tag -H1 --little-endian xxhsum* | $(GREP) XXH64_LE
 	./xxhsum --tag -H2 --little-endian xxhsum* | $(GREP) XXH128_LE
-	./xxhsum       -H3 --little-endian xxhsum* | $(GREP) XXH3_LE
+	./xxhsum --tag -H3 --little-endian xxhsum* | $(GREP) XXH3_LE
 	./xxhsum --tag -H32 --little-endian xxhsum* | $(GREP) XXH32_LE
 	./xxhsum --tag -H64 --little-endian xxhsum* | $(GREP) XXH64_LE
 	./xxhsum --tag -H128 --little-endian xxhsum* | $(GREP) XXH128_LE

--- a/cli/xxhsum.1
+++ b/cli/xxhsum.1
@@ -1,120 +1,181 @@
+.
 .TH "XXHSUM" "1" "July 2023" "xxhsum 0.8.2" "User Commands"
+.
 .SH "NAME"
 \fBxxhsum\fR \- print or check xxHash non\-cryptographic checksums
+.
 .SH "SYNOPSIS"
-\fBxxhsum\fR [\fIOPTION\fR]\|\.\|\.\|\. [\fIFILE\fR]\|\.\|\.\|\.
-.br
-\fBxxhsum \-b\fR [\fIOPTION\fR]\|\.\|\.\|\.
+\fBxxhsum\fR [\fIOPTION\fR]\.\.\. [\fIFILE\fR]\.\.\. \fBxxhsum \-b\fR [\fIOPTION\fR]\.\.\.
+.
 .P
-\fBxxh32sum\fR is equivalent to \fBxxhsum \-H0\fR, \fBxxh64sum\fR is equivalent to \fBxxhsum \-H1\fR, \fBxxh128sum\fR is equivalent to \fBxxhsum \-H2\fR\.
+\fBxxh32sum\fR is equivalent to \fBxxhsum \-H0\fR, \fBxxh64sum\fR is equivalent to \fBxxhsum \-H1\fR, \fBxxh128sum\fR is equivalent to \fBxxhsum \-H2\fR, \fBxxh3sum\fR is equivalent to \fBxxhsum \-H3\fR\.
+.
 .SH "DESCRIPTION"
-Print or check xxHash (32, 64 or 128 bits) checksums\.
-.br
-When no \fIFILE\fR, read standard input, except if it's the console\. When \fIFILE\fR is \fB\-\fR, read standard input even if it's the console\.
+Print or check xxHash (32, 64 or 128 bits) checksums\. When no \fIFILE\fR, read standard input, except if it\'s the console\. When \fIFILE\fR is \fB\-\fR, read standard input even if it\'s the console\.
+.
 .P
 \fBxxhsum\fR supports a command line syntax similar but not identical to md5sum(1)\. Differences are:
-.IP "\[ci]" 4
-\fBxxhsum\fR doesn't have text mode switch (\fB\-t\fR)
-.IP "\[ci]" 4
-\fBxxhsum\fR doesn't have short binary mode switch (\fB\-b\fR)
-.IP "\[ci]" 4
+.
+.IP "\(bu" 4
+\fBxxhsum\fR doesn\'t have text mode switch (\fB\-t\fR)
+.
+.IP "\(bu" 4
+\fBxxhsum\fR doesn\'t have short binary mode switch (\fB\-b\fR)
+.
+.IP "\(bu" 4
 \fBxxhsum\fR always treats files as binary file
-.IP "\[ci]" 4
+.
+.IP "\(bu" 4
 \fBxxhsum\fR has a hash selection switch (\fB\-H\fR)
+.
 .IP "" 0
+.
 .P
 As xxHash is a fast non\-cryptographic checksum algorithm, \fBxxhsum\fR should not be used for security related purposes\.
+.
 .P
 \fBxxhsum \-b\fR invokes benchmark mode\. See OPTIONS and EXAMPLES for details\.
+.
 .SH "OPTIONS"
+.
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Displays xxhsum version and exits
+.
 .TP
 \fB\-H\fR\fIHASHTYPE\fR
-Hash selection\. \fIHASHTYPE\fR means \fB0\fR=XXH32, \fB1\fR=XXH64, \fB2\fR=XXH128, \fB3\fR=XXH3\. Note that \fB\-H3\fR triggers \fB\-\-tag\fR, which can't be skipped (this is to reduce risks of confusion with \fB\-H2\fR (\fBXXH64\fR))\. Alternatively, \fIHASHTYPE\fR \fB32\fR=XXH32, \fB64\fR=XXH64, \fB128\fR=XXH128\. Default value is \fB1\fR (XXH64)
+Hash selection\. \fIHASHTYPE\fR means \fB0\fR=XXH32, \fB1\fR=XXH64, \fB2\fR=XXH128, \fB3\fR=XXH3\. Alternatively, \fIHASHTYPE\fR \fB32\fR=XXH32, \fB64\fR=XXH64, \fB128\fR=XXH128\. Default value is \fB1\fR (XXH64)
+.
 .TP
 \fB\-\-binary\fR
 Read in binary mode\.
+.
 .TP
 \fB\-\-tag\fR
 Output in the BSD style\.
+.
 .TP
 \fB\-\-little\-endian\fR
 Set output hexadecimal checksum value as little endian convention\. By default, value is displayed as big endian\.
+.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Displays help and exits
+.
 .SS "The following options are useful only when verifying checksums (\-c):"
+.
 .TP
 \fB\-c\fR, \fB\-\-check\fR \fIFILE\fR
 Read xxHash sums from \fIFILE\fR and check them
+.
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
-Don't print OK for each successfully verified file
+Don\'t print OK for each successfully verified file
+.
 .TP
 \fB\-\-strict\fR
 Return an error code if any line in the file is invalid, not just if some checksums are wrong\. This policy is disabled by default, though UI will prompt an informational message if any line in the file is detected invalid\.
+.
 .TP
 \fB\-\-status\fR
-Don't output anything\. Status code shows success\.
+Don\'t output anything\. Status code shows success\.
+.
 .TP
 \fB\-w\fR, \fB\-\-warn\fR
 Emit a warning message about each improperly formatted checksum line\.
+.
 .SS "The following options are useful only benchmark purpose:"
+.
 .TP
 \fB\-b\fR
 Benchmark mode\. See EXAMPLES for details\.
+.
 .TP
 \fB\-b#\fR
-Specify ID of variant to be tested\. Multiple variants can be selected, separated by a ',' comma\.
+Specify ID of variant to be tested\. Multiple variants can be selected, separated by a \',\' comma\.
+.
 .TP
 \fB\-B\fR\fIBLOCKSIZE\fR
-Only useful for benchmark mode (\fB\-b\fR)\. See \fIEXAMPLES\fR for details\. \fIBLOCKSIZE\fR specifies benchmark mode's test data block size in bytes\. Default value is 102400
+Only useful for benchmark mode (\fB\-b\fR)\. See \fIEXAMPLES\fR for details\. \fIBLOCKSIZE\fR specifies benchmark mode\'s test data block size in bytes\. Default value is 102400
+.
 .TP
 \fB\-i\fR\fIITERATIONS\fR
 Only useful for benchmark mode (\fB\-b\fR)\. See \fIEXAMPLES\fR for details\. \fIITERATIONS\fR specifies number of iterations in benchmark\. Single iteration lasts approximately 1000 milliseconds\. Default value is 3
+.
 .SH "EXIT STATUS"
-\fBxxhsum\fR exit \fB0\fR on success, \fB1\fR if at least one file couldn't be read or doesn't have the same checksum as the \fB\-c\fR option\.
+\fBxxhsum\fR exit \fB0\fR on success, \fB1\fR if at least one file couldn\'t be read or doesn\'t have the same checksum as the \fB\-c\fR option\.
+.
 .SH "EXAMPLES"
 Output xxHash (64bit) checksum values of specific files to standard output
+.
 .IP "" 4
+.
 .nf
+
 $ xxhsum \-H1 foo bar baz
+.
 .fi
+.
 .IP "" 0
+.
 .P
 Output xxHash (32bit and 64bit) checksum values of specific files to standard output, and redirect it to \fBxyz\.xxh32\fR and \fBqux\.xxh64\fR
+.
 .IP "" 4
+.
 .nf
+
 $ xxhsum \-H0 foo bar baz > xyz\.xxh32
 $ xxhsum \-H1 foo bar baz > qux\.xxh64
+.
 .fi
+.
 .IP "" 0
+.
 .P
 Read xxHash sums from specific files and check them
+.
 .IP "" 4
+.
 .nf
+
 $ xxhsum \-c xyz\.xxh32 qux\.xxh64
+.
 .fi
+.
 .IP "" 0
+.
 .P
 Benchmark xxHash algorithm\. By default, \fBxxhsum\fR benchmarks xxHash main variants on a synthetic sample of 100 KB, and print results into standard output\. The first column is the algorithm, the second column is the source data size in bytes, the third column is the number of hashes generated per second (throughput), and finally the last column translates speed in megabytes per second\.
+.
 .IP "" 4
+.
 .nf
+
 $ xxhsum \-b
+.
 .fi
+.
 .IP "" 0
+.
 .P
 In the following example, the sample to hash is set to 16384 bytes, the variants to be benched are selected by their IDs, and each benchmark test is repeated 10 times, for increased accuracy\.
+.
 .IP "" 4
+.
 .nf
+
 $ xxhsum \-b1,2,3 \-i10 \-B16384
+.
 .fi
+.
 .IP "" 0
+.
 .SH "BUGS"
 Report bugs at: https://github\.com/Cyan4973/xxHash/issues/
+.
 .SH "AUTHOR"
 Yann Collet
+.
 .SH "SEE ALSO"
 md5sum(1)

--- a/cli/xxhsum.1.md
+++ b/cli/xxhsum.1.md
@@ -4,18 +4,19 @@ xxhsum(1) -- print or check xxHash non-cryptographic checksums
 SYNOPSIS
 --------
 
-`xxhsum` [*OPTION*]... [*FILE*]...  
+`xxhsum` [*OPTION*]... [*FILE*]...
 `xxhsum -b` [*OPTION*]...
 
 `xxh32sum` is equivalent to `xxhsum -H0`,
 `xxh64sum` is equivalent to `xxhsum -H1`,
-`xxh128sum` is equivalent to `xxhsum -H2`.
+`xxh128sum` is equivalent to `xxhsum -H2`,
+`xxh3sum` is equivalent to `xxhsum -H3`.
 
 
 DESCRIPTION
 -----------
 
-Print or check xxHash (32, 64 or 128 bits) checksums.  
+Print or check xxHash (32, 64 or 128 bits) checksums.
 When no *FILE*, read standard input, except if it's the console.
 When *FILE* is `-`, read standard input even if it's the console.
 
@@ -39,8 +40,6 @@ OPTIONS
 
 * `-H`*HASHTYPE*:
   Hash selection. *HASHTYPE* means `0`=XXH32, `1`=XXH64, `2`=XXH128, `3`=XXH3.
-  Note that `-H3` triggers `--tag`, which can't be skipped
-  (this is to reduce risks of confusion with `-H2` (`XXH64`)).
   Alternatively, *HASHTYPE* `32`=XXH32, `64`=XXH64, `128`=XXH128.
   Default value is `1` (XXH64)
 

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1229,6 +1229,7 @@ XSUM_API int XSUM_main(int argc, const char* argv[])
     if (strstr(exename,  "xxh32sum") != NULL) { algo = g_defaultAlgo = algo_xxh32;  algoBitmask = algo_bitmask_xxh32;  }
     if (strstr(exename,  "xxh64sum") != NULL) { algo = g_defaultAlgo = algo_xxh64;  algoBitmask = algo_bitmask_xxh64;  }
     if (strstr(exename, "xxh128sum") != NULL) { algo = g_defaultAlgo = algo_xxh128; algoBitmask = algo_bitmask_xxh128; }
+    if (strstr(exename,   "xxh3sum") != NULL) { algo = g_defaultAlgo = algo_xxh3;   algoBitmask = algo_bitmask_xxh3;  }
 
     for (i=1; i<argc; i++) {
         const char* argument = argv[i];


### PR DESCRIPTION
using a `XXH3_` prefix.

The format can be generated and checked (`-c`).

Added `xxh3sum` symlink that automatically generates and checks `XXH3` checksums.

Closes #645 .
