### PR TITLE
chore: Improve document

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,6 +38,7 @@ EXPAND_ONLY_PREDEF     = YES
 # Predefine some macros to clean up the output.
 PREDEFINED             = "XXH_DOXYGEN=" \
                          "XXH_PUBLIC_API=" \
+                         "XXH_NOESCAPE=" \
                          "XXH_FORCE_INLINE=static inline" \
                          "XXH_NO_INLINE=static" \
                          "XXH_RESTRICT=restrict" \

--- a/Doxyfile-internal
+++ b/Doxyfile-internal
@@ -38,6 +38,7 @@ EXPAND_ONLY_PREDEF     = YES
 # Predefine some macros to clean up the output.
 PREDEFINED             = "XXH_DOXYGEN=" \
                          "XXH_PUBLIC_API=" \
+                         "XXH_NOESCAPE=" \
                          "XXH_FORCE_INLINE=static inline" \
                          "XXH_NO_INLINE=static" \
                          "XXH_RESTRICT=restrict" \


### PR DESCRIPTION
Apply same format for all doxygen documents.
Now, every document has the following structure.

```
Signature of the function

@brief   description
@params  parameters
@pre     preconditions
@returns possible return values
@note	 notes
@see-also
```

### Old style
<img width="454" alt="image" src="https://github.com/Cyan4973/xxHash/assets/898396/b23b45ba-5f92-49c4-aaee-f4aa358ce064">

### New style
<img width="447" alt="image" src="https://github.com/Cyan4973/xxHash/assets/898396/30c45997-0c7b-4837-8be0-794a877f62e5">
