### PR TITLE
Add RISC-V RVV implementation

### DIFF
--- a/cli/xsum_arch.h
+++ b/cli/xsum_arch.h
@@ -161,6 +161,8 @@
 #  else
 #    define XSUM_ARCH "wasm/asmjs"
 #  endif
+#elif defined(__riscv)
+#  define XSUM_ARCH "riscv"
 #else
 #  define XSUM_ARCH "unknown"
 #endif

--- a/xxhash.h
+++ b/xxhash.h
@@ -3701,6 +3701,8 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
 #    include <immintrin.h>
 #  elif defined(__SSE2__)
 #    include <emmintrin.h>
+#  elif defined(__riscv_vector)
+#    include <riscv_vector.h>
 #  endif
 #endif
 
@@ -3823,6 +3825,7 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
                        */
     XXH_VSX    = 5,  /*!< VSX and ZVector for POWER8/z13 (64-bit) */
     XXH_SVE    = 6,  /*!< SVE for some ARMv8-A and ARMv9-A */
+    XXH_RVV    = 7,  /*!< RVV for RISC-V */
 };
 /*!
  * @ingroup tuning
@@ -3845,6 +3848,7 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  define XXH_NEON   4
 #  define XXH_VSX    5
 #  define XXH_SVE    6
+#  define XXH_RVV    7
 #endif
 
 #ifndef XXH_VECTOR    /* can be defined on command line */
@@ -3869,6 +3873,8 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
      || (defined(__s390x__) && defined(__VEC__)) \
      && defined(__GNUC__) /* TODO: IBM XL */
 #    define XXH_VECTOR XXH_VSX
+#  elif defined(__riscv_vector)
+#    define XXH_VECTOR XXH_RVV
 #  else
 #    define XXH_VECTOR XXH_SCALAR
 #  endif
@@ -3905,6 +3911,8 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  elif XXH_VECTOR == XXH_AVX512  /* avx512 */
 #     define XXH_ACC_ALIGN 64
 #  elif XXH_VECTOR == XXH_SVE   /* sve */
+#     define XXH_ACC_ALIGN 64
+# elif XXH_VECTOR == XXH_RVV   /* rvv */
 #     define XXH_ACC_ALIGN 64
 #  endif
 #endif
@@ -5548,6 +5556,83 @@ XXH3_accumulate_sve(xxh_u64* XXH_RESTRICT acc,
 
 #endif
 
+#if (XXH_VECTOR == XXH_RVV)
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512_rvv(  void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT input,
+                    const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 63) == 0);
+    // Try to set vector lenght to 512 bits.
+    // If this length is unavailable, then maximum available will be used
+    size_t vl = vsetvl_e64m1(8);
+
+    uint64_t* const xacc = (uint64_t*) acc;
+    uint64_t* const xinput = (uint64_t*) input;
+    uint64_t* const xsecret = (uint64_t*) secret;
+    uint64_t swap_mask[8] = {1, 0, 3, 2, 5, 4, 7, 6};
+    vuint64m1_t xswap_mask = vle64_v_u64m1(swap_mask, vl);
+
+    // vuint64m1_t is sizeless.
+    // But we can assume that vl can be only 2, 4 or 8
+    for(size_t i = 0; i < XXH_STRIPE_LEN/(8 * vl); i++){
+        /* data_vec    = input[i]; */
+        vuint64m1_t data_vec = vreinterpret_v_u8m1_u64m1(vle8_v_u8m1((uint8_t*)(xinput + vl * i), vl * 8));
+        /* key_vec     = secret[i]; */
+        vuint64m1_t key_vec = vreinterpret_v_u8m1_u64m1(vle8_v_u8m1((uint8_t*)(xsecret + vl * i), vl * 8));
+        /* data_key    = data_vec ^ key_vec; */
+        vuint64m1_t data_key = vxor_vv_u64m1(data_vec, key_vec, vl);
+        /* data_key_lo = data_key >> 32; */
+        vuint64m1_t data_key_lo = vsrl_vx_u64m1(data_key, 32, vl);
+        /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
+        vuint64m1_t product = vmul_vv_u64m1(vand_vx_u64m1(data_key, 0xffffffff, vl), vand_vx_u64m1(data_key_lo, 0xffffffff, vl), vl);
+        /* acc_vec = xacc[i]; */
+        vuint64m1_t acc_vec = vle64_v_u64m1(xacc + vl * i, vl);
+        acc_vec = vadd_vv_u64m1(acc_vec, product, vl);
+        /* swap high and low halves */
+        vuint64m1_t data_swap = vrgather_vv_u64m1(data_vec, xswap_mask, vl);
+        acc_vec = vadd_vv_u64m1(acc_vec, data_swap, vl);
+        vse64_v_u64m1(xacc + vl * i, acc_vec, vl);
+    }
+}
+XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(rvv)
+
+XXH_FORCE_INLINE void
+XXH3_scrambleAcc_rvv(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 63) == 0);
+
+    // Try to set vector lenght to 512 bits.
+    // If this length is unavailable, then maximum available will be used
+    size_t vl = vsetvl_e64m1(8);
+    uint64_t* const xacc = (uint64_t*) acc;
+    uint64_t* const xsecret = (uint64_t*) secret;
+
+    uint64_t prime[8] = {XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1};
+    vuint64m1_t vprime = vle64_v_u64m1(prime, vl);
+
+    // vuint64m1_t is sizeless.
+    // But we can assume that vl can be only 2, 4 or 8
+    for(size_t i = 0; i < XXH_STRIPE_LEN/(8 * vl); i++){
+        /* xacc[i] ^= (xacc[i] >> 47) */
+        vuint64m1_t acc_vec = vle64_v_u64m1(xacc + vl * i, vl);
+        vuint64m1_t shifted = vsrl_vx_u64m1(acc_vec, 47, vl);
+        vuint64m1_t data_vec = vxor_vv_u64m1(acc_vec, shifted, vl);
+        /* xacc[i] ^= xsecret[i]; */
+        vuint64m1_t key_vec = vreinterpret_v_u8m1_u64m1(vle8_v_u8m1((uint8_t*)(xsecret + vl * i), vl * 8));
+        vuint64m1_t data_key = vxor_vv_u64m1(data_vec, key_vec, vl);
+
+        /* xacc[i] *= XXH_PRIME32_1; */
+        vuint64m1_t prod_even = vmul_vv_u64m1(vand_vx_u64m1(data_key, 0xffffffff, vl), vprime, vl);
+        vuint64m1_t prod_odd = vmul_vv_u64m1(vsrl_vx_u64m1(data_key, 32, vl), vprime, vl);
+        vuint64m1_t prod = vadd_vv_u64m1(prod_even, vsll_vx_u64m1(prod_odd, 32, vl), vl);
+        vse64_v_u64m1(xacc + vl * i, prod, vl);
+    }
+}
+
+#endif
+
 /* scalar variants - universal */
 
 #if defined(__aarch64__) && (defined(__GNUC__) || defined(__clang__))
@@ -5777,6 +5862,14 @@ typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
 #define XXH3_accumulate     XXH3_accumulate_sve
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_scalar
 #define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
+#elif (XXH_VECTOR == XXH_RVV)
+
+#define XXH3_accumulate_512 XXH3_accumulate_512_rvv
+#define XXH3_accumulate     XXH3_accumulate_rvv
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_rvv
+#define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
 
 #else /* scalar */
 


### PR DESCRIPTION
Add RVV support. Current implementation targets both RVV 0.7.1 and RVV 1.0, this is bad for two reason:
* we need some workarounds with macros' because of `__riscv` prefix for intrinsics in newer compilers
* we need more instructions because some useful ones were unavailable in RVV 0.7.1
 
RVV 1.0 can only be tested with QEMU because there is no boards with up-to-date vectors. QEMU also cannot be used for performance testing because it executes all vector ops on scalar registers. 

I've tested RVV 0.7.1 on Lichee Pi4A using cross-compilation with Xuantie GCC toolchain. Default `xxhsum -b` results were uninformative for me, so here's full benchmarks.
With `-DXXH_VECTOR=XXH_SCALAR`:
```sh
➜ ./xxhsum --benchmark-all
xxhsum 0.8.2 by Yann Collet
compiled as 64-bit riscv little endian with GCC 10.2.0
Sample of 100 KB...
 1#XXH32                         :     102400 ->    17771 it/s ( 1735.5 MB/s)
 2#XXH32 unaligned               :     102400 ->     9218 it/s (  900.2 MB/s)
 3#XXH64                         :     102400 ->    29864 it/s ( 2916.4 MB/s)
 4#XXH64 unaligned               :     102400 ->    11421 it/s ( 1115.3 MB/s)
 5#XXH3_64b                      :     102400 ->     6608 it/s (  645.3 MB/s)
 6#XXH3_64b unaligned            :     102400 ->     6613 it/s (  645.8 MB/s)
 7#XXH3_64b w/seed               :     102400 ->     6613 it/s (  645.8 MB/s)
 8#XXH3_64b w/seed unaligned     :     102400 ->     6615 it/s (  646.0 MB/s)
 9#XXH3_64b w/secret             :     102400 ->     2671 it/s (  260.8 MB/s)
10#XXH3_64b w/secret unaligned   :     102400 ->     2669 it/s (  260.7 MB/s)
11#XXH128                        :     102400 ->     6597 it/s (  644.2 MB/s)
12#XXH128 unaligned              :     102400 ->     6607 it/s (  645.2 MB/s)
13#XXH128 w/seed                 :     102400 ->     6605 it/s (  645.0 MB/s)
14#XXH128 w/seed unaligned       :     102400 ->     6611 it/s (  645.6 MB/s)
15#XXH128 w/secret               :     102400 ->     2668 it/s (  260.5 MB/s)
16#XXH128 w/secret unaligned     :     102400 ->     2668 it/s (  260.6 MB/s)
17#XXH32_stream                  :     102400 ->     7556 it/s (  737.8 MB/s)
18#XXH32_stream unaligned        :     102400 ->     7646 it/s (  746.7 MB/s)
19#XXH64_stream                  :     102400 ->    10274 it/s ( 1003.3 MB/s)
20#XXH64_stream unaligned        :     102400 ->    10234 it/s (  999.4 MB/s)
21#XXH3_stream                   :     102400 ->     2732 it/s (  266.8 MB/s)
22#XXH3_stream unaligned         :     102400 ->     2724 it/s (  266.0 MB/s)
23#XXH3_stream w/seed            :     102400 ->     2728 it/s (  266.4 MB/s)
24#XXH3_stream w/seed unaligned  :     102400 ->     2720 it/s (  265.6 MB/s)
25#XXH128_stream                 :     102400 ->     2730 it/s (  266.6 MB/s)
26#XXH128_stream unaligned       :     102400 ->     2724 it/s (  266.0 MB/s)
27#XXH128_stream w/seed          :     102400 ->     2726 it/s (  266.2 MB/s)
28#XXH128_stream w/seed unaligne :     102400 ->     2719 it/s (  265.5 MB/s)
```
With `-DXXH_VECTOR=XXH_RVV`:
```sh
➜ ./xxhsum --benchmark-all -i10
xxhsum 0.8.2 by Yann Collet
compiled as 64-bit riscv little endian with GCC 10.2.0
Sample of 100 KB...
 1#XXH32                         :     102400 ->    17779 it/s ( 1736.2 MB/s)
 2#XXH32 unaligned               :     102400 ->     8977 it/s (  876.7 MB/s)
 3#XXH64                         :     102400 ->    32211 it/s ( 3145.6 MB/s)
 4#XXH64 unaligned               :     102400 ->     9707 it/s (  947.9 MB/s)
 5#XXH3_64b                      :     102400 ->     4840 it/s (  472.6 MB/s)
 6#XXH3_64b unaligned            :     102400 ->     4676 it/s (  456.6 MB/s)
 7#XXH3_64b w/seed               :     102400 ->     4717 it/s (  460.6 MB/s)
 8#XXH3_64b w/seed unaligned     :     102400 ->     4620 it/s (  451.2 MB/s)
 9#XXH3_64b w/secret             :     102400 ->     4521 it/s (  441.5 MB/s)
10#XXH3_64b w/secret unaligned   :     102400 ->     4420 it/s (  431.7 MB/s)
11#XXH128                        :     102400 ->     4759 it/s (  464.7 MB/s)
12#XXH128 unaligned              :     102400 ->     4651 it/s (  454.2 MB/s)
13#XXH128 w/seed                 :     102400 ->     4671 it/s (  456.2 MB/s)
14#XXH128 w/seed unaligned       :     102400 ->     4564 it/s (  445.7 MB/s)
15#XXH128 w/secret               :     102400 ->     4428 it/s (  432.4 MB/s)
16#XXH128 w/secret unaligned     :     102400 ->     4335 it/s (  423.3 MB/s)
17#XXH32_stream                  :     102400 ->     7542 it/s (  736.5 MB/s)
18#XXH32_stream unaligned        :     102400 ->     7630 it/s (  745.2 MB/s)
19#XXH64_stream                  :     102400 ->    10239 it/s (  999.9 MB/s)
20#XXH64_stream unaligned        :     102400 ->    10217 it/s (  997.7 MB/s)
21#XXH3_stream                   :     102400 ->     4910 it/s (  479.5 MB/s)
22#XXH3_stream unaligned         :     102400 ->     4737 it/s (  462.6 MB/s)
23#XXH3_stream w/seed            :     102400 ->     4908 it/s (  479.3 MB/s)
24#XXH3_stream w/seed unaligned  :     102400 ->     4730 it/s (  461.9 MB/s)
25#XXH128_stream                 :     102400 ->     4906 it/s (  479.1 MB/s)
26#XXH128_stream unaligned       :     102400 ->     4732 it/s (  462.1 MB/s)
27#XXH128_stream w/seed          :     102400 ->     4903 it/s (  478.8 MB/s)
28#XXH128_stream w/seed unaligne :     102400 ->     4726 it/s (  461.5 MB/s)
```
As soon as I get a board with RVV 1.0, I'll try to adjust code and benchmark it, but for now let it be a draft.