### PR TITLE
Ensure XXH_INLINE_ALL fully inlines all XXH32_ and XXH64_ symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,8 @@ cxxtest: clean
 	@echo ---- test C++ compilation ----
 	CC="$(CXX) -Wno-deprecated" $(MAKE) all CFLAGS="-O3 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror -fPIC"
 
+# In strict C90 mode, there is no `long long` type support,
+# consequently, only XXH32 can be compiled.
 .PHONY: c90test
 ifeq ($(NO_C90_TEST),true)
 c90test:
@@ -453,9 +455,19 @@ preview-man: man
 test: DEBUGFLAGS += -DXXH_DEBUGLEVEL=1
 test: all namespaceTest check test-xxhsum-c c90test test-tools noxxh3test nostdlibtest
 
-.PHONY: test-inline
-test-inline:
+# this test checks that including "xxhash.h" multiple times and with different directives still compiles properly
+.PHONY: test-multiInclude
+test-multiInclude:
 	$(MAKE) -C tests test_multiInclude
+
+.PHONY: test-inline-notexposed
+test-inline-notexposed: xxhsum_inlinedXXH
+	$(NM) xxhsum_inlinedXXH | $(GREP) "t _XXH32_" ; test $$? -eq 1  # no XXH32 symbol should be left
+	$(NM) xxhsum_inlinedXXH | $(GREP) "t _XXH64_" ; test $$? -eq 1  # no XXH64 symbol should be left
+
+.PHONY: test-inline
+test-inline: test-inline-notexposed test-multiInclude
+
 
 .PHONY: test-all
 test-all: CFLAGS += -Werror
@@ -640,7 +652,8 @@ install_man:
 	$(Q)ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh3sum.1
 
 .PHONY: install
-install: install_libxxhash.a install_libxxhash install_libxxhash.includes install_libxxhash.pc install_xxhsum install_man ## install libraries, CLI, links and man page
+## install libraries, CLI, links and man pages
+install: install_libxxhash.a install_libxxhash install_libxxhash.includes install_libxxhash.pc install_xxhsum install_man
 	@echo xxhash installation completed
 
 .PHONY: uninstall

--- a/xxhash.h
+++ b/xxhash.h
@@ -3458,7 +3458,7 @@ static xxh_u64 XXH64_avalanche(xxh_u64 hash)
  * @return The finalized hash
  * @see XXH32_finalize().
  */
-static XXH_PUREF xxh_u64
+XXH_FORCE_INLINE XXH_PUREF xxh_u64
 XXH64_finalize(xxh_u64 hash, const xxh_u8* ptr, size_t len, XXH_alignment align)
 {
     if (ptr==NULL) XXH_ASSERT(len == 0);

--- a/xxhash.h
+++ b/xxhash.h
@@ -2418,6 +2418,12 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  define XXH_NO_INLINE static
 #endif
 
+#if defined(XXH_INLINE_ALL)
+#  define XXH_STATIC XXH_FORCE_INLINE
+#else
+#  define XXH_STATIC static
+#endif
+
 #if XXH3_INLINE_SECRET
 #  define XXH3_WITH_SECRET_INLINE XXH_FORCE_INLINE
 #else
@@ -3458,7 +3464,7 @@ static xxh_u64 XXH64_avalanche(xxh_u64 hash)
  * @return The finalized hash
  * @see XXH32_finalize().
  */
-XXH_FORCE_INLINE XXH_PUREF xxh_u64
+XXH_STATIC XXH_PUREF xxh_u64
 XXH64_finalize(xxh_u64 hash, const xxh_u8* ptr, size_t len, XXH_alignment align)
 {
     if (ptr==NULL) XXH_ASSERT(len == 0);


### PR DESCRIPTION
fix #902 with `XXH64_finalize()`, detected by @simonhf

adds a corresponding test
