### PR TITLE
changed INSTALL_DIR into MAKE_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ endif
 
 INSTALL_PROGRAM ?= $(INSTALL)
 INSTALL_DATA    ?= $(INSTALL) -m 644
-INSTALL_DIR     ?= $(INSTALL) -d -m 755
+MAKE_DIR        ?= $(INSTALL) -d -m 755
 
 
 # Escape special symbols by putting each character into its separate class
@@ -593,12 +593,12 @@ libxxhash.pc: libxxhash.pc.in
 
 install_libxxhash.a: libxxhash.a
 	@echo Installing libxxhash.a
-	$(Q)$(INSTALL_DIR) $(DESTDIR)$(LIBDIR)
+	$(Q)$(MAKE_DIR) $(DESTDIR)$(LIBDIR)
 	$(Q)$(INSTALL_DATA) libxxhash.a $(DESTDIR)$(LIBDIR)
 
 install_libxxhash: libxxhash
 	@echo Installing libxxhash
-	$(Q)$(INSTALL_DIR) $(DESTDIR)$(LIBDIR)
+	$(Q)$(MAKE_DIR) $(DESTDIR)$(LIBDIR)
 	$(Q)$(INSTALL_PROGRAM) $(LIBXXH) $(DESTDIR)$(LIBDIR)
 	$(Q)ln -sf $(LIBXXH) $(DESTDIR)$(LIBDIR)/libxxhash.$(SHARED_EXT_MAJOR)
 	$(Q)ln -sf $(LIBXXH) $(DESTDIR)$(LIBDIR)/libxxhash.$(SHARED_EXT)
@@ -613,12 +613,12 @@ endif
 
 install_libxxhash.pc: libxxhash.pc
 	@echo Installing pkgconfig
-	$(Q)$(INSTALL_DIR) $(DESTDIR)$(PKGCONFIGDIR)/
+	$(Q)$(MAKE_DIR) $(DESTDIR)$(PKGCONFIGDIR)/
 	$(Q)$(INSTALL_DATA) libxxhash.pc $(DESTDIR)$(PKGCONFIGDIR)/
 
 install_xxhsum: xxhsum
 	@echo Installing xxhsum
-	$(Q)$(INSTALL_DIR) $(DESTDIR)$(BINDIR)/
+	$(Q)$(MAKE_DIR) $(DESTDIR)$(BINDIR)/
 	$(Q)$(INSTALL_PROGRAM) xxhsum $(DESTDIR)$(BINDIR)/xxhsum
 	$(Q)ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh32sum
 	$(Q)ln -sf xxhsum $(DESTDIR)$(BINDIR)/xxh64sum
@@ -627,7 +627,7 @@ install_xxhsum: xxhsum
 
 install_man:
 	@echo Installing man pages
-	$(Q)$(INSTALL_DIR) $(DESTDIR)$(MANDIR)/
+	$(Q)$(MAKE_DIR) $(DESTDIR)$(MANDIR)/
 	$(Q)$(INSTALL_DATA) $(MAN) $(DESTDIR)$(MANDIR)/xxhsum.1
 	$(Q)ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh32sum.1
 	$(Q)ln -sf xxhsum.1 $(DESTDIR)$(MANDIR)/xxh64sum.1


### PR DESCRIPTION
`INSTALL_DIR` is apparently used by `cmake`:
https://cmake.org/cmake/help/latest/module/ExternalProject.html

fix #911