### PR TITLE
Add Haskell FFI bindings

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,8 @@ The following versions produce xxHash-compatible results in different languages.
 |__Lua__ (jit, XXH32)       |szensk             |https://github.com/szensk/luaxxhash
 |__Lua__ (jit, XXH64)       |Soojin Nam         |https://github.com/sjnam/luajit-xxHash
 |__OCaml__                  |Pieter Goetschalckx|http://opam.ocaml.org/packages/xxhash/
-|__Haskell__                |Christian Marie    |http://hackage.haskell.org/package/xxhash
+|__Haskell__                |Henri Verroken     |http://hackage.haskell.org/package/xxhash-ffi
+|__Haskell__ (port)         |Christian Marie    |http://hackage.haskell.org/package/xxhash
 |__Dart__ (XXH3)            |SamJakob           |https://pub.dev/packages/xxh3
 |__Erlang__                 |Pierre Matri       |https://github.com/pierresforge/erlang-xxhash
 |__Erlang__ (XXH3)          |Ali Farhadi        |https://github.com/farhadi/xxh3


### PR DESCRIPTION
http://hackage.haskell.org/package/xxhash is a port and fairly outdated, while http://hackage.haskell.org/package/xxhash-ffi are up-to-date FFI bindings to the C library.