### PR TITLE
updated internal check in xxhsum

### DIFF
--- a/cli/xsum_sanity_check.c
+++ b/cli/xsum_sanity_check.c
@@ -452,10 +452,6 @@ static void XSUM_testXXH3(const void* data, const XSUM_testdata64_t* testData)
 }
 
 
-#ifndef XXH3_MIDSIZE_MAX
-# define XXH3_MIDSIZE_MAX 240
-#endif
-
 static void XSUM_testXXH3_withSecret(const void* data, const void* secret,
                                      size_t secretSize, const XSUM_testdata64_t* testData)
 {

--- a/cli/xsum_sanity_check.c
+++ b/cli/xsum_sanity_check.c
@@ -390,7 +390,17 @@ static void XSUM_testXXH3(const void* data, const XSUM_testdata64_t* testData)
         XXH3_generateSecret_fromSeed(secret, seed);
         {   XSUM_U64 const Dresult = XXH3_64bits_withSecretandSeed(data, len, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
             XSUM_checkResult64(Dresult, Nresult);
-    }   }
+        }
+
+        /* check that XXH3_64bits_withSecretandSeed()
+         * results in exactly the same return value as XXH3_64bits_withSeed()
+         * when len <= XXH3_MIDSIZE_MAX, whatever the content of @secret */
+        memset(secret, 0x99, 9);
+        if (len <= XXH3_MIDSIZE_MAX) {
+            XSUM_U64 const Dresult = XXH3_64bits_withSecretandSeed(data, len, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+            XSUM_checkResult64(Dresult, Nresult);
+        }
+    }
 
     /* streaming API test */
     {   XXH3_state_t* const state = XXH3_createState();
@@ -423,6 +433,17 @@ static void XSUM_testXXH3(const void* data, const XSUM_testdata64_t* testData)
             (void)XXH3_64bits_reset_withSecretandSeed(state, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
             (void)XXH3_64bits_update(state, data, len);
             XSUM_checkResult64(XXH3_64bits_digest(state), Nresult);
+
+            /* check that XXH3_64bits_withSecretandSeed()
+             * results in exactly the same return value as XXH3_64bits_withSeed()
+             * when len <= XXH3_MIDSIZE_MAX, whatever the content of @secret */
+            if (len <= XXH3_MIDSIZE_MAX) {
+                /* single ingestion */
+                memset(secret, 0x99, 9);
+                (void)XXH3_64bits_reset_withSecretandSeed(state, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+                (void)XXH3_64bits_update(state, data, len);
+                XSUM_checkResult64(XXH3_64bits_digest(state), Nresult);
+            }
         }
 
         XXH3_freeState(state);
@@ -478,10 +499,11 @@ static void XSUM_testXXH3_withSecret(const void* data, const void* secret,
         }
 
         /* check that XXH3_64bits_reset_withSecretandSeed()
-         * results in exactly the same return value as XXH3_64bits_reset_withSecret() */
+         * results in exactly the same return value as XXH3_64bits_reset_withSecret()
+         * when len > XXH3_MIDSIZE_MAX, whatever the value of @seed */
          if (len > XXH3_MIDSIZE_MAX) {
             /* single ingestion */
-            (void)XXH3_64bits_reset_withSecretandSeed(state, secret, secretSize, 0);
+            (void)XXH3_64bits_reset_withSecretandSeed(state, secret, secretSize, 17);
             (void)XXH3_64bits_update(state, data, len);
             XSUM_checkResult64(XXH3_64bits_digest(state), Nresult);
         }
@@ -524,7 +546,17 @@ static void XSUM_testXXH128(const void* data, const XSUM_testdata128_t* testData
         XXH3_generateSecret_fromSeed(secret, seed);
         {   XXH128_hash_t const Dresult = XXH3_128bits_withSecretandSeed(data, len, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
             XSUM_checkResult128(Dresult, Nresult);
-    }   }
+        }
+
+        /* check that XXH3_128bits_withSecretandSeed()
+         * results in exactly the same return value as XXH3_128bits_withSeed()
+         * if len <= XXH3_MIDSIZE_MAX, whatever the content of @secret */
+        memset(secret, 0x99, 9);
+        if (len <= XXH3_MIDSIZE_MAX) {
+            XXH128_hash_t const Dresult = XXH3_128bits_withSecretandSeed(data, len, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+            XSUM_checkResult128(Dresult, Nresult);
+        }
+    }
 
     /* streaming API test */
     {   XXH3_state_t *state = XXH3_createState();
@@ -558,6 +590,17 @@ static void XSUM_testXXH128(const void* data, const XSUM_testdata128_t* testData
             (void)XXH3_128bits_reset_withSecretandSeed(state, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
             (void)XXH3_128bits_update(state, data, len);
             XSUM_checkResult128(XXH3_128bits_digest(state), Nresult);
+
+            /* check that XXH3_128bits_reset_withSecretandSeed()
+             * results in exactly the same return value as XXH3_128bits_reset_withSeed()
+             * if len <= XXH3_MIDSIZE_MAX, whatever the content of @secret */
+            if (len <= XXH3_MIDSIZE_MAX) {
+                /* single ingestion */
+                memset(secret, 0x99, 9);
+                (void)XXH3_128bits_reset_withSecretandSeed(state, secret, XXH3_SECRET_DEFAULT_SIZE, seed);
+                (void)XXH3_128bits_update(state, data, len);
+                XSUM_checkResult128(XXH3_128bits_digest(state), Nresult);
+            }
         }
 
         XXH3_freeState(state);

--- a/xxhash.h
+++ b/xxhash.h
@@ -1924,6 +1924,11 @@ XXH_PUBLIC_API XXH_errorcode XXH3_generateSecret(XXH_NOESCAPE void* secretBuffer
 XXH_PUBLIC_API void XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed);
 
 /*!
+ * @brief Maximum size of "short" key in bytes.
+ */
+#define XXH3_MIDSIZE_MAX 240
+
+/*!
  * @brief Calculates 64/128-bit seeded variant of XXH3 hash of @p data.
  *
  * @param data       The block of data to be hashed, at least @p len bytes in size.
@@ -4700,11 +4705,6 @@ XXH3_len_17to128_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
         return XXH3_avalanche(acc);
     }
 }
-
-/*!
- * @brief Maximum size of "short" key in bytes.
- */
-#define XXH3_MIDSIZE_MAX 240
 
 XXH_NO_INLINE XXH_PUREF XXH64_hash_t
 XXH3_len_129to240_64b(const xxh_u8* XXH_RESTRICT input, size_t len,


### PR DESCRIPTION
to catch bugs such as https://github.com/Cyan4973/xxHash/pull/894 .

Also : made `XXH3_MIDSIZE_MAX` part of `xxhash.h` header