### PR TITLE
remove macos-11 tests from github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,7 +475,7 @@ jobs:
         make clean; LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make check
 
 
-  # macOS, { 11, 12 }
+  # macOS
 
   macos-general:
     name: ${{ matrix.system.os }}
@@ -484,8 +484,8 @@ jobs:
       fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
       matrix:
         system: [
-          { os: macos-11    },
-          { os: macos-12    },
+          { os: macos-12     },
+          { os: macos-latest },
         ]
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5


### PR DESCRIPTION
Github has announced they will soon deprecate `macos-11`

Replaced by `macos-latest`