### PR TITLE
clib: add clib.json

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,0 +1,12 @@
+{
+  "name": "xxhash",
+  "version": "0.8.2",
+  "repo": "Cyan4973/xxhash",
+  "description": "Extremely fast non-cryptographic hash algorithm",
+  "keywords": ["xxhash", "hashing"],
+  "license": "BSD-2-Clause",
+  "src": [
+    "xxhash.c",
+    "xxhash.h"
+  ]
+}


### PR DESCRIPTION
Adding support for https://github.com/clibs/clib a c package manager

When done you may want to add to https://github.com/clibs/clib/wiki/Packages#hashing so it is discoverable


