### PR TITLE
Fix Visual warnings in xxh_x86dispatch.c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,24 @@ jobs:
       run: |
         .\cmake_unofficial\build\Release\xxhsum.exe -bi1
 
+    - name: Build ${{ matrix.system.os }}, ${{ matrix.arch }}, with DISPATCH
+      # DISPATCH only if target arch is x64 or Win32.
+      if: ${{ ( matrix.arch == 'x64' || matrix.arch == 'Win32' ) }}
+      run: |
+        cd cmake_unofficial
+        mkdir build-visual-dispatch
+        cd build-visual-dispatch
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64
+        cmake --build . --config Release
+
+    - name: Runtime Test (DISPATCH)
+      # Run benchmark for testing only if target arch is x64 or Win32.
+      if: ${{ ( matrix.arch == 'x64' || matrix.arch == 'Win32' ) }}
+      run: |
+        .\cmake_unofficial\build-visual-dispatch\Release\xxhsum.exe -V | grep autoVec
+        .\cmake_unofficial\build-visual-dispatch\Release\xxhsum.exe -bi1
+
+
     - name: Build ${{ matrix.system.os }}, clang-cl, ${{ matrix.arch }}
       if: ${{ matrix.system.clangcl == 'true' }}
       run: |
@@ -560,22 +578,6 @@ jobs:
       run: |
         .\cmake_unofficial\build-clang-cl\Release\xxhsum.exe -bi1
 
-    - name: Build ${{ matrix.system.os }}, clang-cl, ${{ matrix.arch }}, with DISPATCH
-      # DISPATCH only if target arch is x64 or Win32.
-      if: ${{ matrix.system.clangcl == 'true' && ( matrix.arch == 'x64' || matrix.arch == 'Win32' ) }}
-      run: |
-        cd cmake_unofficial
-        mkdir build-clang-cl-dispatch
-        cd build-clang-cl-dispatch
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64 -DCMAKE_GENERATOR_TOOLSET=ClangCL
-        cmake --build . --config Release
-
-    - name: Runtime Test (clang-cl + DISPATCH)
-      # Run benchmark for testing only if target arch is x64 or Win32.
-      if: ${{ matrix.system.clangcl == 'true' && ( matrix.arch == 'x64' || matrix.arch == 'Win32' ) }}
-      run: |
-        .\cmake_unofficial\build-clang-cl-dispatch\Release\xxhsum.exe -V | grep autoVec
-        .\cmake_unofficial\build-clang-cl-dispatch\Release\xxhsum.exe -bi1
 
 
   # Windows, { mingw64, mingw32 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,7 +552,7 @@ jobs:
         cd cmake_unofficial
         mkdir build-visual-dispatch
         cd build-visual-dispatch
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64 -DCMAKE_C_FLAGS="/WX"
         cmake --build . --config Release
 
     - name: Runtime Test (DISPATCH)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,7 +536,7 @@ jobs:
         cd cmake_unofficial
         mkdir build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -A ${{ matrix.arch }} -DXXHASH_C_FLAGS="/WX"
+        cmake .. -DCMAKE_BUILD_TYPE=Release -A ${{ matrix.arch }} -DCMAKE_C_FLAGS="/W4 /WX"
         cmake --build . --config Release
 
     - name: Test
@@ -552,7 +552,7 @@ jobs:
         cd cmake_unofficial
         mkdir build-visual-dispatch
         cd build-visual-dispatch
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64 -DCMAKE_C_FLAGS="/WX"
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DDISPATCH=ON -A x64 -DCMAKE_C_FLAGS="/W4 /WX"
         cmake --build . --config Release
 
     - name: Runtime Test (DISPATCH)

--- a/xxh_x86dispatch.c
+++ b/xxh_x86dispatch.c
@@ -729,8 +729,8 @@ static XXH_CONSTRUCTOR void XXH_setDispatch(void)
 /*! @cond Doxygen ignores this part */
 
 static XXH64_hash_t
-XXH3_hashLong_64b_defaultSecret_selection(const void* input, size_t len,
-                                          XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
+XXH3_hashLong_64b_defaultSecret_selection(const void* XXH_RESTRICT input, size_t len,
+                                          XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
 {
     (void)seed64; (void)secret; (void)secretLen;
     if (XXH_DISPATCH_MAYBE_NULL && XXH_g_dispatch.hashLong64_default == NULL)
@@ -744,8 +744,8 @@ XXH64_hash_t XXH3_64bits_dispatch(XXH_NOESCAPE const void* input, size_t len)
 }
 
 static XXH64_hash_t
-XXH3_hashLong_64b_withSeed_selection(const void* input, size_t len,
-                                     XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
+XXH3_hashLong_64b_withSeed_selection(const void* XXH_RESTRICT input, size_t len,
+                                     XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
 {
     (void)secret; (void)secretLen;
     if (XXH_DISPATCH_MAYBE_NULL && XXH_g_dispatch.hashLong64_seed == NULL)
@@ -759,8 +759,8 @@ XXH64_hash_t XXH3_64bits_withSeed_dispatch(XXH_NOESCAPE const void* input, size_
 }
 
 static XXH64_hash_t
-XXH3_hashLong_64b_withSecret_selection(const void* input, size_t len,
-                                       XXH64_hash_t seed64, const xxh_u8* secret, size_t secretLen)
+XXH3_hashLong_64b_withSecret_selection(const void* XXH_RESTRICT input, size_t len,
+                                       XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
 {
     (void)seed64;
     if (XXH_DISPATCH_MAYBE_NULL && XXH_g_dispatch.hashLong64_secret == NULL)


### PR DESCRIPTION
and added a test that checks compilation of `xxhsum` with `DISPATCH=1` using Visual compiler backend.

fix #959