### PR TITLE
removed the console line cleaning operation (using `stderr`)

### DIFF
--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -490,7 +490,6 @@ static int XSUM_hashFiles(const char* fnList[], int fnTotal,
 
     for (fnNb=0; fnNb<fnTotal; fnNb++)
         result |= XSUM_hashFile(fnList[fnNb], hashType, displayEndianness, convention);
-    XSUM_logVerbose(2, "\r%70s\r", "");
     return result;
 }
 


### PR DESCRIPTION
since it's captured by tools redirecting `stderr`.

fixes #968