### PR TITLE
circumvent Visual Studio 2019 "partial" support of C11

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -1688,8 +1688,7 @@ struct XXH64_state_s {
 #ifndef XXH_NO_XXH3
 
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* >= C11 */
-#  include <stdalign.h>
-#  define XXH_ALIGN(n)      alignas(n)
+#  define XXH_ALIGN(n)      _Alignas(n)
 #elif defined(__cplusplus) && (__cplusplus >= 201103L) /* >= C++11 */
 /* In C++ alignas() is a keyword */
 #  define XXH_ALIGN(n)      alignas(n)


### PR DESCRIPTION
use `_Alignas()` instead, to not rely on including `<stdalign.h>` since some versions of VS2019 do not provide it
despite claiming `C11` compliance.

fix #955