### PR TITLE
Add option to generate hashes from list of files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,12 +47,14 @@ tmp*
 tests/*.unicode
 tests/unicode_test*
 *.txt
+!CMakeLists.txt
 *.xxhsum
 
 # editor artifacts
 .clang_complete
 *.swp
 .vscode/
+.vs/
 
 # Doxygen
 doxygen/

--- a/.gitignore
+++ b/.gitignore
@@ -47,14 +47,12 @@ tmp*
 tests/*.unicode
 tests/unicode_test*
 *.txt
-!CMakeLists.txt
 *.xxhsum
 
 # editor artifacts
 .clang_complete
 *.swp
 .vscode/
-.vs/
 
 # Doxygen
 doxygen/

--- a/cli/xxhsum.1.md
+++ b/cli/xxhsum.1.md
@@ -5,6 +5,7 @@ SYNOPSIS
 --------
 
 `xxhsum` [*OPTION*]... [*FILE*]...
+
 `xxhsum -b` [*OPTION*]...
 
 `xxh32sum` is equivalent to `xxhsum -H0`,
@@ -56,16 +57,23 @@ OPTIONS
 * `-h`, `--help`:
   Displays help and exits
 
-### The following options are useful only when verifying checksums (-c):
+### The following options are useful only when using lists in *FILE* (-c and -g):
 
 * `-c`, `--check` *FILE*:
   Read xxHash sums from *FILE* and check them
 
+* `-g`, `--generate` *FILE*:
+  Read filenames from *FILE* and generate hashes for them.
+  Valid *FILE*s have one filename per line, which can include embedded spaces, etc with no need for quotes, escapes, etc.
+  Note that a line commencing with '\\' will enable the convention used in the encoding of filenames against output hashes,
+  whereby subsequent \\\\, \n and \r seqeuences are converted to the single
+  character 0x5C, 0x0A and 0x0D respectively.
+
 * `-q`, `--quiet`:
-  Don't print OK for each successfully verified file
+  Don't print OK for each successfully processed line of *FILE*
 
 * `--strict`:
-  Return an error code if any line in the file is invalid,
+  Return an error code if any line in *FILE** is invalid,
   not just if some checksums are wrong.
   This policy is disabled by default,
   though UI will prompt an informational message
@@ -75,7 +83,7 @@ OPTIONS
   Don't output anything. Status code shows success.
 
 * `-w`, `--warn`:
-  Emit a warning message about each improperly formatted checksum line.
+  Emit a warning message about each improperly formatted line in *FILE*.
 
 ### The following options are useful only benchmark purpose:
 
@@ -118,6 +126,19 @@ output, and redirect it to `xyz.xxh32` and `qux.xxh64`
 Read xxHash sums from specific files and check them
 
     $ xxhsum -c xyz.xxh32 qux.xxh64
+
+Produce a list of files, then generate hashes for that list
+
+    $ find . -type f -name '*.[ch]' > c-files.txt
+    $ xxhsum --quiet -g c-files.txt
+
+Read the list of files from standard input to avoid the need for an intermediate file
+
+    $ find . -type f -name '*.[ch]' | xxhsum --quiet -g -
+
+Note that if shell expansion, length of argument list, clarity of use of spaces in filenames, etc allow it then the same output as the previous example can be generated like this
+
+    $ xxhsum `find . -name '*.[ch]'`
 
 Benchmark xxHash algorithm.
 By default, `xxhsum` benchmarks xxHash main variants

--- a/cli/xxhsum.1.md
+++ b/cli/xxhsum.1.md
@@ -57,12 +57,12 @@ OPTIONS
 * `-h`, `--help`:
   Displays help and exits
 
-### The following options are useful only when using lists in *FILE* (-c and -g):
+### The following options are useful only when using lists in *FILE* (--check and --files-from):
 
 * `-c`, `--check` *FILE*:
   Read xxHash sums from *FILE* and check them
 
-* `-g`, `--generate` *FILE*:
+* `--files-from` *FILE*:
   Read filenames from *FILE* and generate hashes for them.
   Valid *FILE*s have one filename per line, which can include embedded spaces, etc with no need for quotes, escapes, etc.
   Note that a line commencing with '\\' will enable the convention used in the encoding of filenames against output hashes,
@@ -70,7 +70,7 @@ OPTIONS
   character 0x5C, 0x0A and 0x0D respectively.
 
 * `-q`, `--quiet`:
-  Don't print OK for each successfully processed line of *FILE*
+   Don't print OK for each successfully verified hash (only for --check)
 
 * `--strict`:
   Return an error code if any line in *FILE** is invalid,
@@ -130,11 +130,11 @@ Read xxHash sums from specific files and check them
 Produce a list of files, then generate hashes for that list
 
     $ find . -type f -name '*.[ch]' > c-files.txt
-    $ xxhsum --quiet -g c-files.txt
+    $ xxhsum --files-from c-files.txt
 
 Read the list of files from standard input to avoid the need for an intermediate file
 
-    $ find . -type f -name '*.[ch]' | xxhsum --quiet -g -
+    $ find . -type f -name '*.[ch]' | xxhsum --files-from -
 
 Note that if shell expansion, length of argument list, clarity of use of spaces in filenames, etc allow it then the same output as the previous example can be generated like this
 

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -388,7 +388,7 @@ typedef enum { big_endian, little_endian} Display_endianness;
 
 typedef enum { display_gnu, display_bsd } Display_convention;
 
-typedef void (*XSUM_displayLine_f)(const char*, const void*, AlgoSelected);  /* filename display signature */
+typedef void (*XSUM_displayLine_f)(const char*, const void*, AlgoSelected);  /* line display signature */
 
 typedef enum {
     LineStatus_hashOk,
@@ -501,18 +501,15 @@ static int XSUM_hashFiles(const char* fnList[], int fnTotal,
             break;
         case LineStatus_isDirectory:
             XSUM_log("xxhsum: %s: Is a directory \n", stdinName);
-            result = 1;
             break;
         case LineStatus_failedToOpen:
             XSUM_log("Error: Could not open '%s': %s. \n", stdinName, strerror(errno));
-            result = 1;
             break;
         case LineStatus_memoryError:
             XSUM_log("\nError: Out of memory.\n");
-            result = 1;
             break;
         }
-        
+
         if (filestatus != LineStatus_hashOk)
             result = 1;
     }
@@ -1165,7 +1162,7 @@ static ParseLineResult XSUM_parseGenLine(ParsedLine * parsedLine,
     }
 
     parsedLine->filename = filename;
-    
+
     return ParseLine_ok;
 }
 
@@ -1387,19 +1384,20 @@ static int XSUM_generateFiles(const char* fnList[], int fnTotal,
     Display_convention convention,
     XSUM_U32 statusOnly,
     XSUM_U32 ignoreMissing,
-    XSUM_U32 warn)
+    XSUM_U32 warn,
+    XSUM_U32 quiet)
 {
     int ok = 1;
 
     /* Special case for stdinName "-",
      * note: stdinName is not a string.  It's special pointer. */
     if (fnTotal == 0) {
-        ok &= XSUM_generateFile(stdinName, hashType, displayEndianness, convention, statusOnly, ignoreMissing, warn, (XSUM_logLevel < 2) /*quiet*/);
+        ok &= XSUM_generateFile(stdinName, hashType, displayEndianness, convention, statusOnly, ignoreMissing, warn, quiet);
     }
     else {
         int fnNb;
         for (fnNb = 0; fnNb < fnTotal; fnNb++)
-            ok &= XSUM_generateFile(fnList[fnNb], hashType, displayEndianness, convention, statusOnly, ignoreMissing, warn, (XSUM_logLevel < 2) /*quiet*/);
+            ok &= XSUM_generateFile(fnList[fnNb], hashType, displayEndianness, convention, statusOnly, ignoreMissing, warn, quiet);
     }
     return ok ? 0 : 1;
 }
@@ -1684,7 +1682,7 @@ XSUM_API int XSUM_main(int argc, const char* argv[])
         return XSUM_checkFiles(argv+filenamesStart, argc-filenamesStart,
                           displayEndianness, strictMode, statusOnly, ignoreMissing, warn, (XSUM_logLevel < 2) /*quiet*/, algoBitmask);
     } else if (fileCheckMode == 2) {
-        return XSUM_generateFiles(argv + filenamesStart, argc - filenamesStart, algo, displayEndianness, convention, statusOnly, ignoreMissing, warn);
+        return XSUM_generateFiles(argv + filenamesStart, argc - filenamesStart, algo, displayEndianness, convention, statusOnly, ignoreMissing, warn, (XSUM_logLevel < 2) /*quiet*/);
     } else {
         return XSUM_hashFiles(argv+filenamesStart, argc-filenamesStart, algo, displayEndianness, convention);
     }


### PR DESCRIPTION
Use --generate (-g) option to consume [files] on command line as containers of lists of files to generate hashes for