### PR TITLE
Fix IDE snags with Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,12 +47,14 @@ tmp*
 tests/*.unicode
 tests/unicode_test*
 *.txt
+!CMakeLists.txt
 *.xxhsum
 
 # editor artifacts
 .clang_complete
 *.swp
 .vscode/
+.vs/
 
 # Doxygen
 doxygen/


### PR DESCRIPTION
- Bug / quirk of VS causes CMakeLists.txt to be ignored if *.txt appears in .gitignore
- .vs/ artefacts should not be tracked in giit