### PR TITLE
add GCC >=15 __builtin_stdc_rotate_left suppor to rotl

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -2746,6 +2746,9 @@ static int XXH_isLittleEndian(void)
                                && XXH_HAS_BUILTIN(__builtin_rotateleft64)
 #  define XXH_rotl32 __builtin_rotateleft32
 #  define XXH_rotl64 __builtin_rotateleft64
+#elif XXH_HAS_BUILTIN(__builtin_stdc_rotate_left)
+#  define XXH_rotl32 __builtin_stdc_rotate_left
+#  define XXH_rotl64 __builtin_stdc_rotate_left
 /* Note: although _rotl exists for minGW (GCC under windows), performance seems poor */
 #elif defined(_MSC_VER)
 #  define XXH_rotl32(x,r) _rotl(x,r)


### PR DESCRIPTION
GCC does not support the clang builtins but does have type generic, type-checking __builtin_stdc_rotate_left.

The only advantage of this is that the builtin evaluates the arguments only once.