### PR TITLE
Add LoongArch SX SIMD extension implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,7 @@ jobs:
           { name: 'RISC-V',          xcc_pkg: gcc-riscv64-linux-gnu,        xcc: riscv64-linux-gnu-gcc,        xemu_pkg: qemu-system-riscv64,xemu: qemu-riscv64-static, os: ubuntu-latest, },
           # SPARC64 qemu emulation seems broken on Ubuntu-22
           { name: 'SPARC',           xcc_pkg: gcc-sparc64-linux-gnu,        xcc: sparc64-linux-gnu-gcc,        xemu_pkg: qemu-system-sparc,  xemu: qemu-sparc64-static, os: ubuntu-20.04, },
+          { name: 'LoongArch',       xcc_pkg: gcc-14-loongarch64-linux-gnu,    xcc: loongarch64-linux-gnu-gcc-14, xemu_pkg: qemu-system-loongarch64, xemu: qemu-loongarch64-static, os: ubuntu-24.04, },
 
           { name: 'ARM, gcc-10',     xcc_pkg: gcc-10-arm-linux-gnueabi,     xcc: arm-linux-gnueabi-gcc-10,     xemu_pkg: qemu-system-arm,   xemu: qemu-arm-static,     os: ubuntu-20.04, },
           { name: 'AARCH64, gcc-10', xcc_pkg: gcc-10-aarch64-linux-gnu,     xcc: aarch64-linux-gnu-gcc-10,     xemu_pkg: qemu-system-arm,   xemu: qemu-aarch64-static, os: ubuntu-20.04, },
@@ -474,6 +475,11 @@ jobs:
       run: |
         make clean; LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make check
 
+    - name: LoongArch (XXH_VECTOR=[ scalar, LSX ])
+      if: ${{ startsWith(matrix.name, 'LoongArch') }}
+      run: |
+        CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+        CPPFLAGS=-DXXH_VECTOR=XXH_LSX CFLAGS="-O3 -march=la464 -mlsx" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
   # macOS
 

--- a/cli/xsum_arch.h
+++ b/cli/xsum_arch.h
@@ -161,6 +161,8 @@
 #  else
 #    define XSUM_ARCH "wasm/asmjs"
 #  endif
+#elif defined(__loongarch_lp64)
+#  define XSUM_ARCH "loongarch"
 #else
 #  define XSUM_ARCH "unknown"
 #endif

--- a/xxhash.h
+++ b/xxhash.h
@@ -3749,6 +3749,8 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
 #    include <immintrin.h>
 #  elif defined(__SSE2__)
 #    include <emmintrin.h>
+#  elif defined(__loongarch_sx)
+#    include <lsxintrin.h>
 #  endif
 #endif
 
@@ -3871,6 +3873,7 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
                        */
     XXH_VSX    = 5,  /*!< VSX and ZVector for POWER8/z13 (64-bit) */
     XXH_SVE    = 6,  /*!< SVE for some ARMv8-A and ARMv9-A */
+    XXH_LSX    = 7,  /*!< LSX (128-bit SIMD) for LoongArch64 */
 };
 /*!
  * @ingroup tuning
@@ -3893,6 +3896,7 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  define XXH_NEON   4
 #  define XXH_VSX    5
 #  define XXH_SVE    6
+#  define XXH_LSX    7
 #endif
 
 #ifndef XXH_VECTOR    /* can be defined on command line */
@@ -3917,6 +3921,8 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
      || (defined(__s390x__) && defined(__VEC__)) \
      && defined(__GNUC__) /* TODO: IBM XL */
 #    define XXH_VECTOR XXH_VSX
+#  elif defined(__loongarch_sx)
+#    define XXH_VECTOR XXH_LSX
 #  else
 #    define XXH_VECTOR XXH_SCALAR
 #  endif
@@ -3953,6 +3959,8 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  elif XXH_VECTOR == XXH_AVX512  /* avx512 */
 #     define XXH_ACC_ALIGN 64
 #  elif XXH_VECTOR == XXH_SVE   /* sve */
+#     define XXH_ACC_ALIGN 64
+#  elif XXH_VECTOR == XXH_LSX   /* lsx */
 #     define XXH_ACC_ALIGN 64
 #  endif
 #endif
@@ -5591,6 +5599,71 @@ XXH3_accumulate_sve(xxh_u64* XXH_RESTRICT acc,
 
 #endif
 
+#if (XXH_VECTOR == XXH_LSX)
+#define _LSX_SHUFFLE(z, y, x, w) (((z) << 6) | ((y) << 4) | ((x) << 2) | (w))
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512_lsx( void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT input,
+                    const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+    {
+        __m128i* const xacc    =       (__m128i *) acc;
+        const __m128i* const xinput  = (const __m128i *) input;
+        const __m128i* const xsecret = (const __m128i *) secret;
+
+        for (size_t i = 0; i < XXH_STRIPE_LEN / sizeof(__m128i); i++) {
+            /* data_vec = xinput[i]; */
+            __m128i const data_vec = __lsx_vld(xinput + i, 0);
+            /* key_vec = xsecret[i]; */
+            __m128i const key_vec = __lsx_vld(xsecret + i, 0);
+            /* data_key = data_vec ^ key_vec; */
+            __m128i const data_key = __lsx_vxor_v(data_vec, key_vec);
+            /* data_key_lo = data_key >> 32; */
+            __m128i const data_key_lo = __lsx_vsrli_d(data_key, 32);
+            // __m128i const data_key_lo = __lsx_vsrli_d(data_key, 32);
+            /* product = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
+            __m128i const product = __lsx_vmulwev_d_wu(data_key, data_key_lo);
+            /* xacc[i] += swap(data_vec); */
+            __m128i const data_swap = __lsx_vshuf4i_w(data_vec, _LSX_SHUFFLE(1, 0, 3, 2));
+            __m128i const sum = __lsx_vadd_d(xacc[i], data_swap);
+            /* xacc[i] += product; */
+            xacc[i] = __lsx_vadd_d(product, sum);
+        }
+    }
+}
+XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(lsx)
+
+XXH_FORCE_INLINE void
+XXH3_scrambleAcc_lsx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+    {
+        __m128i* const xacc = (__m128i*) acc;
+        const __m128i* const xsecret = (const __m128i *) secret;
+        const __m128i prime32 = __lsx_vreplgr2vr_w((int)XXH_PRIME32_1);
+
+        for (size_t i = 0; i < XXH_STRIPE_LEN / sizeof(__m128i); i++) {
+            /* xacc[i] ^= (xacc[i] >> 47) */
+            __m128i const acc_vec = xacc[i];
+            __m128i const shifted = __lsx_vsrli_d(acc_vec, 47);
+            __m128i const data_vec = __lsx_vxor_v(acc_vec, shifted);
+            /* xacc[i] ^= xsecret[i]; */
+            __m128i const key_vec = __lsx_vld(xsecret + i, 0);
+            __m128i const data_key = __lsx_vxor_v(data_vec, key_vec);
+
+            /* xacc[i] *= XXH_PRIME32_1; */
+            __m128i const data_key_hi = __lsx_vsrli_d(data_key, 32);
+            __m128i const prod_lo = __lsx_vmulwev_d_wu(data_key, prime32);
+            __m128i const prod_hi = __lsx_vmulwev_d_wu(data_key_hi, prime32);
+            xacc[i] = __lsx_vadd_d(prod_lo, __lsx_vslli_d(prod_hi, 32));
+        }
+    }
+}
+
+#endif
+
 /* scalar variants - universal */
 
 #if defined(__aarch64__) && (defined(__GNUC__) || defined(__clang__))
@@ -5819,6 +5892,12 @@ typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
 #define XXH3_accumulate_512 XXH3_accumulate_512_sve
 #define XXH3_accumulate     XXH3_accumulate_sve
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_scalar
+#define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
+#elif (XXH_VECTOR == XXH_LSX)
+#define XXH3_accumulate_512 XXH3_accumulate_512_lsx
+#define XXH3_accumulate     XXH3_accumulate_lsx
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_lsx
 #define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
 
 #else /* scalar */


### PR DESCRIPTION
Add LoongArch SX SIMD extension support to xxHash, which is a new RISC ISA just like RISC-V. The code itself is basically a rewritten of the SSE2 one, tested on Loongson 3A6000 processor, here are the results.

**Scalar**
```
./xxhsum --benchmark-all
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit unknown little endian with GCC 14.1.1 20240720
Sample of 100 KB...
 1#XXH32                         :     102400 ->    60583 it/s ( 5916.3 MB/s)
 2#XXH32 unaligned               :     102400 ->    58909 it/s ( 5752.8 MB/s)
 3#XXH64                         :     102400 ->   117056 it/s (11431.2 MB/s)
 4#XXH64 unaligned               :     102400 ->   118304 it/s (11553.1 MB/s)
 5#XXH3_64b                      :     102400 ->   142790 it/s (13944.4 MB/s)
 6#XXH3_64b unaligned            :     102400 ->   136549 it/s (13334.9 MB/s)
 7#XXH3_64b w/seed               :     102400 ->   117327 it/s (11457.8 MB/s)
 8#XXH3_64b w/seed unaligned     :     102400 ->   114720 it/s (11203.1 MB/s)
 9#XXH3_64b w/secret             :     102400 ->   144445 it/s (14106.0 MB/s)
10#XXH3_64b w/secret unaligned   :     102400 ->   138076 it/s (13483.9 MB/s)
11#XXH128                        :     102400 ->   114568 it/s (11188.3 MB/s)
12#XXH128 unaligned              :     102400 ->   111621 it/s (10900.5 MB/s)
13#XXH128 w/seed                 :     102400 ->   144003 it/s (14062.8 MB/s)
14#XXH128 w/seed unaligned       :     102400 ->   137411 it/s (13419.1 MB/s)
15#XXH128 w/secret               :     102400 ->   151320 it/s (14777.3 MB/s)
16#XXH128 w/secret unaligned     :     102400 ->   143261 it/s (13990.4 MB/s)
17#XXH32_stream                  :     102400 ->    60783 it/s ( 5935.8 MB/s)
18#XXH32_stream unaligned        :     102400 ->    56481 it/s ( 5515.7 MB/s)
19#XXH64_stream                  :     102400 ->   116072 it/s (11335.1 MB/s)
20#XXH64_stream unaligned        :     102400 ->   105525 it/s (10305.2 MB/s)
21#XXH3_stream                   :     102400 ->   116267 it/s (11354.2 MB/s)
22#XXH3_stream unaligned         :     102400 ->   112994 it/s (11034.6 MB/s)
23#XXH3_stream w/seed            :     102400 ->   115983 it/s (11326.5 MB/s)
24#XXH3_stream w/seed unaligned  :     102400 ->   112852 it/s (11020.7 MB/s)
25#XXH128_stream                 :     102400 ->   116232 it/s (11350.8 MB/s)
26#XXH128_stream unaligned       :     102400 ->   112905 it/s (11025.8 MB/s)
27#XXH128_stream w/seed          :     102400 ->   116081 it/s (11336.1 MB/s)
28#XXH128_stream w/seed unaligne :     102400 ->   112789 it/s (11014.6 MB/s)
```
**LoongArch SX**
```
./xxhsum --benchmark-all
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit loongarch little endian with GCC 14.1.1 20240720
Sample of 100 KB...
 1#XXH32                         :     102400 ->    60569 it/s ( 5915.0 MB/s)
 2#XXH32 unaligned               :     102400 ->    58907 it/s ( 5752.6 MB/s)
 3#XXH64                         :     102400 ->   117053 it/s (11431.0 MB/s)
 4#XXH64 unaligned               :     102400 ->   118289 it/s (11551.6 MB/s)
 5#XXH3_64b                      :     102400 ->   199076 it/s (19441.0 MB/s)
 6#XXH3_64b unaligned            :     102400 ->   189993 it/s (18554.0 MB/s)
 7#XXH3_64b w/seed               :     102400 ->   199722 it/s (19504.1 MB/s)
 8#XXH3_64b w/seed unaligned     :     102400 ->   189672 it/s (18522.7 MB/s)
 9#XXH3_64b w/secret             :     102400 ->   183999 it/s (17968.7 MB/s)
10#XXH3_64b w/secret unaligned   :     102400 ->   176080 it/s (17195.3 MB/s)
11#XXH128                        :     102400 ->   198883 it/s (19422.2 MB/s)
12#XXH128 unaligned              :     102400 ->   189925 it/s (18547.3 MB/s)
13#XXH128 w/seed                 :     102400 ->   198877 it/s (19421.6 MB/s)
14#XXH128 w/seed unaligned       :     102400 ->   188807 it/s (18438.2 MB/s)
15#XXH128 w/secret               :     102400 ->   183770 it/s (17946.3 MB/s)
16#XXH128 w/secret unaligned     :     102400 ->   175811 it/s (17169.0 MB/s)
17#XXH32_stream                  :     102400 ->    60782 it/s ( 5935.7 MB/s)
18#XXH32_stream unaligned        :     102400 ->    56488 it/s ( 5516.4 MB/s)
19#XXH64_stream                  :     102400 ->   116075 it/s (11335.4 MB/s)
20#XXH64_stream unaligned        :     102400 ->   105448 it/s (10297.7 MB/s)
21#XXH3_stream                   :     102400 ->   199438 it/s (19476.4 MB/s)
22#XXH3_stream unaligned         :     102400 ->   190148 it/s (18569.2 MB/s)
23#XXH3_stream w/seed            :     102400 ->   198714 it/s (19405.7 MB/s)
24#XXH3_stream w/seed unaligned  :     102400 ->   189577 it/s (18513.3 MB/s)
25#XXH128_stream                 :     102400 ->   199140 it/s (19447.3 MB/s)
26#XXH128_stream unaligned       :     102400 ->   190063 it/s (18560.8 MB/s)
27#XXH128_stream w/seed          :     102400 ->   198738 it/s (19408.0 MB/s)
28#XXH128_stream w/seed unaligne :     102400 ->   189668 it/s (18522.3 MB/s)
```
**Reference**
LoongArch Intrinsics Document: https://jia.je/unofficial-loongarch-intrinsics-guide/

**Resolve**
https://github.com/loongson-community/discussions/issues/72