### PR TITLE
update cmake minimum version to 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,26 +343,26 @@ jobs:
         cat build/libxxhash.pc | grep "libdir=/usr/lib"
         cat build/libxxhash.pc | grep "includedir=/usr/include"
 
-    - name: cmake minimum version v3.5 test
+    - name: cmake minimum version v3.10 test
       run: |
         mkdir -p cmake_bins
         cd cmake_bins
-        wget https://cmake.org/files/v3.5/cmake-3.5.0-Linux-i386.tar.gz
-        tar xzf cmake-3.5.0-Linux-i386.tar.gz
+        wget https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz
+        tar xzf cmake-3.10.0-Linux-x86_64.tar.gz
         cd ../cmake_unofficial
         rm -rf build
         pwd
         ls
         mkdir -p build
         cd build
-        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --version
-        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake ..
-        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --build .
+        ../../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --version
+        ../../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake ..
+        ../../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --build .
         mkdir -p test_install_dir
-        DESTDIR=test_install_dir ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --install .
+        DESTDIR=test_install_dir ../../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --install .
         rm -rf *
-        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake -DCMAKE_BUILD_TYPE=Debug ..
-        ../../cmake_bins/cmake-3.5.0-Linux-i386/bin/cmake --build .
+        ../../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake -DCMAKE_BUILD_TYPE=Debug ..
+        ../../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --build .
 
 
 

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # For details, see <https://creativecommons.org/publicdomain/zero/1.0/>.
 
-cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.10 FATAL_ERROR)
 
 set(XXHASH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
@@ -71,12 +71,9 @@ mark_as_advanced(XXHASH_BUNDLED_MODE)
 include(CMakeDependentOption)
 CMAKE_DEPENDENT_OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON "NOT XXHASH_BUNDLED_MODE" OFF)
 
-if("${CMAKE_VERSION}" VERSION_LESS "3.10")
-  # Can not enable DISPATCH mode since it fails to recognize architecture.
-else()
-  CMAKE_HOST_SYSTEM_INFORMATION(RESULT PLATFORM QUERY OS_PLATFORM)
-  message(STATUS "Architecture: ${PLATFORM}")
-endif()
+# detect architecture for DISPATCH mode
+CMAKE_HOST_SYSTEM_INFORMATION(RESULT PLATFORM QUERY OS_PLATFORM)
+message(STATUS "Architecture: ${PLATFORM}")
 
 # libxxhash
 if((DEFINED DISPATCH) AND (DEFINED PLATFORM))


### PR DESCRIPTION
since most recent versions of `cmake` start complaining about older minimum versions.

`cmake` `3.10` is the version shipped with Ubuntu 18.04, which seems the oldest distribution worth supporting in 2025.