### PR TITLE
Xxhsum improved help

### DIFF
--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1396,15 +1396,15 @@ static int XSUM_usage(const char* exename)
     XSUM_log( "Usage: %s [options] [files] \n\n", exename);
     XSUM_log( "When no filename provided or when '-' is provided, uses stdin as input. \n");
     XSUM_log( "\nOptions: \n");
-    XSUM_log( "  -H#             select an xxhash algorithm (default: %i) \n", (int)g_defaultAlgo);
-    XSUM_log( "                  0: XXH32 \n");
-    XSUM_log( "                  1: XXH64 \n");
-    XSUM_log( "                  2: XXH128 (also called XXH3_128bits) \n");
-    XSUM_log( "                  3: XXH3 (also called XXH3_64bits) \n");
-    XSUM_log( "  -c, --check     read xxHash checksum from [files] and check them \n");
-    XSUM_log( "      --files-from  generate hashes for files listed in [files] \n");
-    XSUM_log( "      --filelist  generate hashes for files listed in [files] \n");
-    XSUM_log( "  -h, --help      display a long help page about advanced options \n");
+    XSUM_log( "  -H#                  select an xxhash algorithm (default: %i) \n", (int)g_defaultAlgo);
+    XSUM_log( "                       0: XXH32 \n");
+    XSUM_log( "                       1: XXH64 \n");
+    XSUM_log( "                       2: XXH128 (also called XXH3_128bits) \n");
+    XSUM_log( "                       3: XXH3 (also called XXH3_64bits) \n");
+    XSUM_log( "  -c, --check          read xxHash checksum from [files] and check them \n");
+    XSUM_log( "      --files-from     generate hashes for files listed in [files] \n");
+    XSUM_log( "      --filelist       generate hashes for files listed in [files] \n");
+    XSUM_log( "  -h, --help           display a long help page about advanced options \n");
     return 0;
 }
 

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1412,7 +1412,7 @@ static int XSUM_usage(const char* exename)
 static int XSUM_usage_advanced(const char* exename)
 {
     XSUM_usage(exename);
-    XSUM_log( "\nAdvanced :\n");
+    XSUM_log( "\nAdvanced: \n");
     XSUM_log( "  -V, --version        Display version information \n");
     XSUM_log( "      --tag            Produce BSD-style checksum lines \n");
     XSUM_log( "      --little-endian  Checksum values use little endian convention (default: big endian) \n");

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1394,8 +1394,7 @@ static int XSUM_usage(const char* exename)
     XSUM_log( WELCOME_MESSAGE(exename) );
     XSUM_log( "Create or verify checksums using fast non-cryptographic algorithm xxHash \n\n" );
     XSUM_log( "Usage: %s [options] [files] \n\n", exename);
-    XSUM_log( "When no filename provided or when '-' is provided, uses stdin as input. \n");
-    XSUM_log( "\nOptions: \n");
+    XSUM_log( "Options: \n");
     XSUM_log( "  -H#                  select an xxhash algorithm (default: %i) \n", (int)g_defaultAlgo);
     XSUM_log( "                       0: XXH32 \n");
     XSUM_log( "                       1: XXH64 \n");

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1394,7 +1394,8 @@ static int XSUM_usage(const char* exename)
     XSUM_log( WELCOME_MESSAGE(exename) );
     XSUM_log( "Create or verify checksums using fast non-cryptographic algorithm xxHash \n\n" );
     XSUM_log( "Usage: %s [options] [files] \n\n", exename);
-    XSUM_log( "Options: \n");
+    XSUM_log( "When no filename provided or when '-' is provided, uses stdin as input. \n");
+    XSUM_log( "\nOptions: \n");
     XSUM_log( "  -H#                  select an xxhash algorithm (default: %i) \n", (int)g_defaultAlgo);
     XSUM_log( "                       0: XXH32 \n");
     XSUM_log( "                       1: XXH64 \n");

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1408,7 +1408,6 @@ static int XSUM_usage(const char* exename)
     return 0;
 }
 
-
 static int XSUM_usage_advanced(const char* exename)
 {
     XSUM_usage(exename);

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1402,6 +1402,7 @@ static int XSUM_usage(const char* exename)
     XSUM_log( "                  2: XXH128 (also called XXH3_128bits) \n");
     XSUM_log( "                  3: XXH3 (also called XXH3_64bits) \n");
     XSUM_log( "  -c, --check     read xxHash checksum from [files] and check them \n");
+    XSUM_log( "      --files-from  generate hashes for files listed in [files] \n");
     XSUM_log( "      --filelist  generate hashes for files listed in [files] \n");
     XSUM_log( "  -h, --help      display a long help page about advanced options \n");
     return 0;


### PR DESCRIPTION
some fixes to the help message for `xxhsum`

* show help message for option `--files-from` (it was undocumented)
* align the help under "Options" with the column under "Advanced"
