### PR TITLE
Update MANDIR for FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -565,7 +565,7 @@ else
 PKGCONFIGDIR ?= $(LIBDIR)/pkgconfig
 endif
 
-ifneq (,$(filter $(UNAME),OpenBSD FreeBSD NetBSD DragonFly SunOS))
+ifneq (,$(filter $(UNAME),OpenBSD NetBSD DragonFly SunOS))
 MANDIR  ?= $(PREFIX)/man/man1
 else
 MANDIR  ?= $(man1dir)


### PR DESCRIPTION
FreeBSD uses share/man/ rather than man/ now.

Reference:	https://cgit.freebsd.org/ports/tree/devel/xxhash/Makefile#n17