### PR TITLE
memxxx() redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The following macros can be set at compilation time to modify `libxxhash`'s beha
                    But one-shot hashing (like `XXH32()`) or streaming using statically allocated states
                    still work as expected.
                    This build flag is useful for embedded environments without dynamic allocation.
+- `XXH_memcpy`, `XXH_memset`, `XXH_memcmp` : redirect `memcpy()`, `memset()` and `memcmp()` to some user-selected symbol at compile time.
+                   Redirecting all 3 removes the need to include `<string.h>` standard library.
 - `XXH_DEBUGLEVEL` : When set to any value >= 1, enables `assert()` statements.
                      This (slightly) slows down execution, but may help finding bugs during debugging sessions.
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -2425,7 +2425,7 @@ static void* XXH_memset(void* dest, int value, size_t size)
  * @internal
  * @brief XXH_memcmp() macro can be redirected at compile time
  */
-static void* XXH_memcmp(void* dest, const void* src, size_t size)
+static int XXH_memcmp(void* dest, const void* src, size_t size)
 {
     return memcmp(dest,src,size);
 }

--- a/xxhash.h
+++ b/xxhash.h
@@ -2394,16 +2394,44 @@ static void XXH_free(void* p) { free(p); }
 
 #endif  /* XXH_NO_STDLIB */
 
-#include <string.h>
-
+#ifndef XXH_memcpy
+#  include <string.h>
 /*!
  * @internal
- * @brief Modify this function to use a different routine than memcpy().
+ * @brief XXH_memcpy() macro can be redirected at compile time
  */
 static void* XXH_memcpy(void* dest, const void* src, size_t size)
 {
     return memcpy(dest,src,size);
 }
+#endif
+
+#ifndef XXH_memset
+#  include <string.h>
+/*!
+ * @internal
+ * @brief XXH_memset() macro can be redirected at compile time
+ */
+static void* XXH_memset(void* dest, int value, size_t size)
+{
+    return memset(dest,value,size);
+}
+#endif
+
+#ifndef XXH_memcmp
+/* Note: only needed by XXH128 */
+#  include <string.h>
+/*!
+ * @internal
+ * @brief XXH_memcmp() macro can be redirected at compile time
+ */
+static void* XXH_memcmp(void* dest, const void* src, size_t size)
+{
+    return memcmp(dest,src,size);
+}
+#endif
+
+
 
 #include <limits.h>   /* ULLONG_MAX */
 
@@ -3224,7 +3252,7 @@ XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dstState, const XXH32_state_t
 XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed)
 {
     XXH_ASSERT(statePtr != NULL);
-    memset(statePtr, 0, sizeof(*statePtr));
+    XXH_memset(statePtr, 0, sizeof(*statePtr));
     XXH32_initAccs(statePtr->acc, seed);
     return XXH_OK;
 }
@@ -3721,7 +3749,7 @@ XXH_PUBLIC_API void XXH64_copyState(XXH_NOESCAPE XXH64_state_t* dstState, const 
 XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH_NOESCAPE XXH64_state_t* statePtr, XXH64_hash_t seed)
 {
     XXH_ASSERT(statePtr != NULL);
-    memset(statePtr, 0, sizeof(*statePtr));
+    XXH_memset(statePtr, 0, sizeof(*statePtr));
     XXH64_initAccs(statePtr->acc, seed);
     return XXH_OK;
 }
@@ -6409,7 +6437,7 @@ XXH3_reset_internal(XXH3_state_t* statePtr,
     XXH_ASSERT(offsetof(XXH3_state_t, nbStripesPerBlock) > initStart);
     XXH_ASSERT(statePtr != NULL);
     /* set members from bufferedSize to nbStripesPerBlock (excluded) to 0 */
-    memset((char*)statePtr + initStart, 0, initLength);
+    XXH_memset((char*)statePtr + initStart, 0, initLength);
     statePtr->acc[0] = XXH_PRIME32_3;
     statePtr->acc[1] = XXH_PRIME64_1;
     statePtr->acc[2] = XXH_PRIME64_2;
@@ -7183,14 +7211,12 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (XXH_NOESCAPE const XXH3_state_
 #endif /* !XXH_NO_STREAM */
 /* 128-bit utility functions */
 
-#include <string.h>   /* memcmp, memcpy */
-
 /* return : 1 is equal, 0 if different */
 /*! @ingroup XXH3_family */
 XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)
 {
     /* note : XXH128_hash_t is compact, it has no padding byte */
-    return !(memcmp(&h1, &h2, sizeof(h1)));
+    return !(XXH_memcmp(&h1, &h2, sizeof(h1)));
 }
 
 /* This prototype is compatible with stdlib's qsort().
@@ -7274,7 +7300,7 @@ XXH3_generateSecret(XXH_NOESCAPE void* secretBuffer, size_t secretSize, XXH_NOES
     {   size_t pos = 0;
         while (pos < secretSize) {
             size_t const toCopy = XXH_MIN((secretSize - pos), customSeedSize);
-            memcpy((char*)secretBuffer + pos, customSeed, toCopy);
+            XXH_memcpy((char*)secretBuffer + pos, customSeed, toCopy);
             pos += toCopy;
     }   }
 
@@ -7299,7 +7325,7 @@ XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed)
     XXH_ALIGN(XXH_SEC_ALIGN) xxh_u8 secret[XXH_SECRET_DEFAULT_SIZE];
     XXH3_initCustomSecret(secret, seed);
     XXH_ASSERT(secretBuffer != NULL);
-    memcpy(secretBuffer, secret, XXH_SECRET_DEFAULT_SIZE);
+    XXH_memcpy(secretBuffer, secret, XXH_SECRET_DEFAULT_SIZE);
 }
 
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -2395,40 +2395,31 @@ static void XXH_free(void* p) { free(p); }
 #endif  /* XXH_NO_STDLIB */
 
 #ifndef XXH_memcpy
-#  include <string.h>
 /*!
  * @internal
  * @brief XXH_memcpy() macro can be redirected at compile time
  */
-static void* XXH_memcpy(void* dest, const void* src, size_t size)
-{
-    return memcpy(dest,src,size);
-}
+#  include <string.h>
+#  define XXH_memcpy memcpy
 #endif
 
 #ifndef XXH_memset
-#  include <string.h>
 /*!
  * @internal
  * @brief XXH_memset() macro can be redirected at compile time
  */
-static void* XXH_memset(void* dest, int value, size_t size)
-{
-    return memset(dest,value,size);
-}
+#  include <string.h>
+#  define XXH_memset memset
 #endif
 
 #ifndef XXH_memcmp
-/* Note: only needed by XXH128 */
-#  include <string.h>
 /*!
  * @internal
  * @brief XXH_memcmp() macro can be redirected at compile time
+ * Note: only needed by XXH128.
  */
-static int XXH_memcmp(void* dest, const void* src, size_t size)
-{
-    return memcmp(dest,src,size);
-}
+#  include <string.h>
+#  define XXH_memcmp memcmp
 #endif
 
 


### PR DESCRIPTION
makes it possible to redirect calls to `memcpy()`, `memcmp()` and `memset()`
to any user-selected symbol at compile time
using new build macros `XXH_memcpy()`, `XXH_memcmp()` and `XXH_memset()`.