### PR TITLE
allow removal of extern "C" guards in C++ mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The following macros can be set at compilation time to modify `libxxhash`'s beha
                    This build flag is useful for embedded environments without dynamic allocation.
 - `XXH_memcpy`, `XXH_memset`, `XXH_memcmp` : redirect `memcpy()`, `memset()` and `memcmp()` to some user-selected symbol at compile time.
                    Redirecting all 3 removes the need to include `<string.h>` standard library.
+- `XXH_NO_EXTERNC_GUARD`: When `xxhash.h` is compiled in C++ mode, removes the `extern "C" { .. }` block guard.
 - `XXH_DEBUGLEVEL` : When set to any value >= 1, enables `assert()` statements.
                      This (slightly) slows down execution, but may help finding bugs during debugging sessions.
 

--- a/xxhash.h
+++ b/xxhash.h
@@ -241,7 +241,7 @@
  * xxHash prototypes and implementation
  */
 
-#if defined (__cplusplus)
+#if defined(__cplusplus) && !defined(XXH_NO_EXTERNC_GUARD)
 extern "C" {
 #endif
 
@@ -7338,6 +7338,6 @@ XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed)
 #endif  /* XXH_IMPLEMENTATION */
 
 
-#if defined (__cplusplus)
+#if defined (__cplusplus) && !defined(XXH_NO_EXTERNC_GUARD)
 } /* extern "C" */
 #endif


### PR DESCRIPTION
using new build macro `XXH_NO_EXTERNC_GUARD`.

This can be useful in some complex C++ compilation scenarios.