### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/libxxhash.pc.in
+++ b/libxxhash.pc.in
@@ -11,5 +11,6 @@ Name: xxhash
 Description: extremely fast hash algorithm
 URL: http://www.xxhash.com/
 Version: @VERSION@
+License: BSD-2-clause
 Libs: -L${libdir} -lxxhash
 Cflags: -I${includedir}


### PR DESCRIPTION
The pkg-config file has License variable that allows you to set the license for the software. 
This sets BSD-2-Clause to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116