### PR TITLE
Refactor make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,15 +137,12 @@ $(eval $(call c_program,xxhsum_inlinedXXH,$(CLI_OBJS)))
 libxxhash.a:
 $(eval $(call static_library,libxxhash.a,xxhash.o))
 
-$(LIBXXH): LDFLAGS += -shared
+$(LIBXXH): LDFLAGS += $(SONAME_FLAGS)
 ifeq (,$(filter Windows%,$(OS)))
 $(LIBXXH): CFLAGS += -fPIC
 endif
-ifeq ($(LIBXXH_DISPATCH),1)
-$(LIBXXH): xxh_x86dispatch.c
-endif
-$(LIBXXH): xxhash.c
-	$(CC) $(FLAGS) $^ $(LDFLAGS) $(SONAME_FLAGS) -o $@
+LIBXXHASH_OBJS := xxhash.o $(if $(filter 1,$(LIBXXH_DISPATCH)),xxh_x86dispatch.o)
+$(eval $(call c_dynamic_library,$(LIBXXH),$(LIBXXHASH_OBJS)))
 
 libxxhash.$(SHARED_EXT_MAJOR): $(LIBXXH)
 	$(LN) -sf $< $@

--- a/Makefile
+++ b/Makefile
@@ -338,27 +338,27 @@ test-cli-ignore-missing:
 	$(MAKE) -C tests test_cli_ignore_missing
 
 .PHONY: armtest
-armtest: clean
+armtest:
 	@echo ---- test ARM compilation ----
 	CC=arm-linux-gnueabi-gcc MOREFLAGS="-Werror -static" $(MAKE) xxhsum
 
 .PHONY: arm64test
-arm64test: clean
+arm64test:
 	@echo ---- test ARM64 compilation ----
 	CC=aarch64-linux-gnu-gcc MOREFLAGS="-Werror -static" $(MAKE) xxhsum
 
 .PHONY: clangtest
-clangtest: clean
+clangtest:
 	@echo ---- test clang compilation ----
 	CC=clang MOREFLAGS="-Werror -Wconversion -Wno-sign-conversion" $(MAKE) all
 
 .PHONY: gcc-og-test
-gcc-og-test: clean
+gcc-og-test:
 	@echo ---- test gcc -Og compilation ----
 	CFLAGS="-Og -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror -fPIC" CPPFLAGS="-DXXH_NO_INLINE_HINTS" MOREFLAGS="-Werror" $(MAKE) all
 
 .PHONY: cxxtest
-cxxtest: clean
+cxxtest:
 	@echo ---- test C++ compilation ----
 	CC="$(CXX) -Wno-deprecated" $(MAKE) all CFLAGS="-O3 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror -fPIC"
 
@@ -414,7 +414,6 @@ usan: CC=clang
 usan: CXX=clang++
 usan:  ## check CLI runtime for undefined behavior, using clang's sanitizer
 	@echo ---- check undefined behavior - sanitize ----
-	$(MAKE) clean
 	$(MAKE) test CC=$(CC) CXX=$(CXX) MOREFLAGS="-g -fsanitize=undefined -fno-sanitize-recover=all"
 
 .PHONY: staticAnalyze

--- a/build/make/README.md
+++ b/build/make/README.md
@@ -47,6 +47,9 @@ $(eval $(call cxx_program,test, test.o cxxdeps/objcxx.o))
 
 lib.a:
 $(eval $(call static_library,lib.a, lib.o cdeps/obj.o))
+
+lib.so:
+$(eval $(call c_dynamic_library,lib.so, lib.o cdeps/obj.o))
 ```
 
 ### 4 · Build any config you like

--- a/build/make/multiconf.make
+++ b/build/make/multiconf.make
@@ -131,7 +131,7 @@ $$(CACHE_ROOT)/%/$(1) : $(1:.o=.S) $(2) | $$(CACHE_ROOT)/%/.
 
 endef # addTargetAsmObject
 
-define addTargetCxxObject  # targetName, addlDeps
+define addTargetCppObject  # targetName, addlDeps
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2))))
 
 .PRECIOUS: $$(CACHE_ROOT)/%/$(1)
@@ -139,28 +139,44 @@ $$(CACHE_ROOT)/%/$(1) : $(1:.o=.cpp) $(2) | $$(CACHE_ROOT)/%/.
 	@echo CXX $$@
 	$$(CXX) $$(CPPFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(1:.o=.d) -c $$< -o $$@
 
-endef # addTargetCxxObject
+endef # addTargetCppObject
+
+define addTargetCcObject  # targetName, addlDeps
+$$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2))))
+
+.PRECIOUS: $$(CACHE_ROOT)/%/$(1)
+$$(CACHE_ROOT)/%/$(1) : $(1:.o=.cc) $(2) | $$(CACHE_ROOT)/%/.
+	@echo CXX $$@
+	$$(CXX) $$(CPPFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(1:.o=.d) -c $$< -o $$@
+
+endef # addTargetCcObject
 
 # Create targets for individual object files
 C_SRCDIRS += .
 vpath %.c $(C_SRCDIRS)
 CXX_SRCDIRS += .
 vpath %.cpp $(CXX_SRCDIRS)
+vpath %.cc $(CXX_SRCDIRS)
 ASM_SRCDIRS += .
 vpath %.S $(ASM_SRCDIRS)
 
 # If C_SRCDIRS, CXX_SRCDIRS and ASM_SRCDIRS are not defined, use C_SRCS, CXX_SRCS and ASM_SRCS
 C_SRCS   ?= $(notdir $(foreach dir,$(C_SRCDIRS),$(wildcard $(dir)/*.c)))
-CXX_SRCS ?= $(notdir $(foreach dir,$(CXX_SRCDIRS),$(wildcard $(dir)/*.cpp)))
+CPP_SRCS ?= $(notdir $(foreach dir,$(CXX_SRCDIRS),$(wildcard $(dir)/*.cpp)))
+CC_SRCS ?= $(notdir $(foreach dir,$(CXX_SRCDIRS),$(wildcard $(dir)/*.cc)))
+CXX_SRCS ?= $(CPP_SRCS) $(CC_SRCS)
 ASM_SRCS ?= $(notdir $(foreach dir,$(ASM_SRCDIRS),$(wildcard $(dir)/*.S)))
 
 # If C_SRCS, CXX_SRCS and ASM_SRCS are not defined, use C_OBJS, CXX_OBJS and ASM_OBJS
 C_OBJS   ?= $(patsubst %.c,%.o,$(C_SRCS))
-CXX_OBJS ?= $(patsubst %.cpp,%.o,$(CXX_SRCS))
+CPP_OBJS ?= $(patsubst %.cpp,%.o,$(CPP_SRCS))
+CC_OBJS ?= $(patsubst %.cc,%.o,$(CC_SRCS))
+CXX_OBJS ?= $(CPP_OBJS) $(CC_OBJS) # Note: not used
 ASM_OBJS ?= $(patsubst %.S,%.o,$(ASM_SRCS))
 
 $(foreach OBJ,$(C_OBJS),$(eval $(call addTargetCObject,$(OBJ))))
-$(foreach OBJ,$(CXX_OBJS),$(eval $(call addTargetCxxObject,$(OBJ))))
+$(foreach OBJ,$(CPP_OBJS),$(eval $(call addTargetCppObject,$(OBJ))))
+$(foreach OBJ,$(CC_OBJS),$(eval $(call addTargetCcObject,$(OBJ))))
 $(foreach OBJ,$(ASM_OBJS),$(eval $(call addTargetAsmObject,$(OBJ))))
 
 # --------------------------------------------------------------------------------------------

--- a/build/make/multiconf.make
+++ b/build/make/multiconf.make
@@ -59,8 +59,7 @@ $(VERBOSE).SILENT:
 # Directory where object files will be built
 CACHE_ROOT ?= cachedObjs
 
-# Dependency management
-DEPFLAGS = -MT $@ -MMD -MP -MF
+# --------------------------------------------------------------------------------------------
 
 # Automatic determination of build artifacts cache directory, keyed on build
 # flags, so that we can do incremental, parallel builds of different binaries
@@ -84,20 +83,14 @@ else
   HASH_FUNC = $(firstword $(shell echo $(2) | $(HASH) ))
 endif
 
-# OSX linker doen't support --whole-archive and --no-whole-archive, so we are using -force_load and
-# -load_hidden instead
-ifeq ($(UNAME), Darwin)
-	WHOLE_ARCHIVE = -force_load
-	NO_WHOLE_ARCHIVE = -load_hidden
-else
-	WHOLE_ARCHIVE = --whole-archive
-	NO_WHOLE_ARCHIVE = --no-whole-archive
-endif
-
 
 MKDIR ?= mkdir
-RANLIB ?= ranlib
 LN ?= ln
+
+# --------------------------------------------------------------------------------------------
+
+# Dependency management
+DEPFLAGS = -MT $@ -MMD -MP -MF
 
 # Include dependency files
 include $(wildcard $(CACHE_ROOT)/**/*.d)

--- a/build/make/multiconf.make
+++ b/build/make/multiconf.make
@@ -170,8 +170,8 @@ $(foreach OBJ,$(ASM_OBJS),$(eval $(call addTargetAsmObject,$(OBJ))))
 
 define static_library  # targetName, targetDeps, addlDeps, addRecipe, hashSuffix
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5))))
-
 ALL_PROGRAMS += $(1)
+
 $$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)
 	@echo AR $$@
 	$$(AR) $$(ARFLAGS) $$@ $$^
@@ -182,6 +182,21 @@ $(1) : ARFLAGS = rcs
 $(1) : $$(CACHE_ROOT)/$$(call HASH_FUNC,$(1),$(2) $$(CPPFLAGS) $$(CC) $$(CFLAGS) $$(CXX) $$(CXXFLAGS) $$(AR) $$(ARFLAGS) $(5))/$(1)
 	$$(LN) -sf $$< $$@
 endef # static_library
+
+
+define c_dynamic_library  # targetName, targetDeps, addlDeps, addRecipe, hashSuffix
+$$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5))))
+ALL_PROGRAMS += $(1)
+
+$$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)
+	@echo LD $$@
+	$$(CC) $$(CPPFLAGS) $$(CFLAGS) $$(LDFLAGS) -shared -o $$@ $$^ $$(LDLIBS)
+	$(4)
+
+.PHONY: $(1)
+$(1) : $$(CACHE_ROOT)/$$(call HASH_FUNC,$(1),$(2) $$(CPPFLAGS) $$(CC) $$(CFLAGS) $$(LDFLAGS) $$(LDLIBS) $(5))/$(1)
+	$$(LN) -sf $$< $$@
+endef # c_dynamic_library
 
 
 define program_base  # targetName, targetDeps, addlDeps, addRecipe, hashSuffix, compiler, flags

--- a/build/make/multiconf.make
+++ b/build/make/multiconf.make
@@ -112,9 +112,7 @@ $(CACHE_ROOT)/%/. :
 
 
 define addTargetCObject  # targetName, addlDeps
-ifeq ($$(V),2)
-$$(info $$(call $(0),$(1),$(2)))
-endif
+$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2)))) #debug print
 
 .PRECIOUS: $$(CACHE_ROOT)/%/$(1)
 $$(CACHE_ROOT)/%/$(1) : $(1:.o=.c) $(2) | $$(CACHE_ROOT)/%/.
@@ -124,9 +122,7 @@ $$(CACHE_ROOT)/%/$(1) : $(1:.o=.c) $(2) | $$(CACHE_ROOT)/%/.
 endef # addTargetCObject
 
 define addTargetAsmObject  # targetName, addlDeps
-ifeq ($$(V),2)
-$$(info $$(call $(0),$(1),$(2)))
-endif
+$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2))))
 
 .PRECIOUS: $$(CACHE_ROOT)/%/$(1)
 $$(CACHE_ROOT)/%/$(1) : $(1:.o=.S) $(2) | $$(CACHE_ROOT)/%/.
@@ -136,9 +132,7 @@ $$(CACHE_ROOT)/%/$(1) : $(1:.o=.S) $(2) | $$(CACHE_ROOT)/%/.
 endef # addTargetAsmObject
 
 define addTargetCxxObject  # targetName, addlDeps
-ifeq ($$(V),2)
-$$(info $$(call $(0),$(1),$(2)))
-endif
+$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2))))
 
 .PRECIOUS: $$(CACHE_ROOT)/%/$(1)
 $$(CACHE_ROOT)/%/$(1) : $(1:.o=.cpp) $(2) | $$(CACHE_ROOT)/%/.
@@ -175,9 +169,7 @@ $(foreach OBJ,$(ASM_OBJS),$(eval $(call addTargetAsmObject,$(OBJ))))
 # The cache directory is automatically derived from CACHE_ROOT and list of flags and compilers.
 
 define static_library  # targetName, targetDeps, addlDeps, addRecipe, hashSuffix
-ifeq ($$(V),2)
-$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5)))
-endif
+$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5))))
 
 ALL_PROGRAMS += $(1)
 $$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)
@@ -193,9 +185,7 @@ endef # static_library
 
 
 define program_base  # targetName, targetDeps, addlDeps, addRecipe, hashSuffix, compiler, flags
-ifeq ($$(V),2)
-$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5),$(6),$(7)))
-endif
+$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5),$(6),$(7))))
 
 ALL_PROGRAMS += $(1)
 $$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)

--- a/build/make/multiconf.make
+++ b/build/make/multiconf.make
@@ -112,7 +112,7 @@ $(CACHE_ROOT)/%/. :
 
 
 define addTargetCObject  # targetName, addlDeps
-$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2)))) #debug print
+$$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2)))) #debug print
 
 .PRECIOUS: $$(CACHE_ROOT)/%/$(1)
 $$(CACHE_ROOT)/%/$(1) : $(1:.o=.c) $(2) | $$(CACHE_ROOT)/%/.
@@ -122,7 +122,7 @@ $$(CACHE_ROOT)/%/$(1) : $(1:.o=.c) $(2) | $$(CACHE_ROOT)/%/.
 endef # addTargetCObject
 
 define addTargetAsmObject  # targetName, addlDeps
-$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2))))
+$$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2))))
 
 .PRECIOUS: $$(CACHE_ROOT)/%/$(1)
 $$(CACHE_ROOT)/%/$(1) : $(1:.o=.S) $(2) | $$(CACHE_ROOT)/%/.
@@ -132,7 +132,7 @@ $$(CACHE_ROOT)/%/$(1) : $(1:.o=.S) $(2) | $$(CACHE_ROOT)/%/.
 endef # addTargetAsmObject
 
 define addTargetCxxObject  # targetName, addlDeps
-$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2))))
+$$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2))))
 
 .PRECIOUS: $$(CACHE_ROOT)/%/$(1)
 $$(CACHE_ROOT)/%/$(1) : $(1:.o=.cpp) $(2) | $$(CACHE_ROOT)/%/.
@@ -169,7 +169,7 @@ $(foreach OBJ,$(ASM_OBJS),$(eval $(call addTargetAsmObject,$(OBJ))))
 # The cache directory is automatically derived from CACHE_ROOT and list of flags and compilers.
 
 define static_library  # targetName, targetDeps, addlDeps, addRecipe, hashSuffix
-$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5))))
+$$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5))))
 
 ALL_PROGRAMS += $(1)
 $$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)
@@ -185,7 +185,7 @@ endef # static_library
 
 
 define program_base  # targetName, targetDeps, addlDeps, addRecipe, hashSuffix, compiler, flags
-$$(intcmp $$(V),2,,$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5),$(6),$(7))))
+$$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5),$(6),$(7))))
 
 ALL_PROGRAMS += $(1)
 $$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,13 +23,12 @@
 #   - xxHash source repository: https://github.com/Cyan4973/xxHash
 # ################################################################
 
+MAKEFLAGS += --no-print-directory
 CFLAGS += -Wall -Wextra -Wundef -g
 
 CP = cp
 NM = nm
 GREP = grep
-XXHSUM_DIR = ..
-XXHSUM = $(XXHSUM_DIR)/xxhsum
 
 # Define *.exe as extension for Windows systems
 ifneq (,$(filter Windows%,$(OS)))
@@ -47,6 +46,9 @@ endif
 .PHONY: default
 default: all
 
+C_SRCDIRS = . .. ../cli
+include ../build/make/multiconf.make
+
 .PHONY: all
 all: test
 
@@ -55,34 +57,33 @@ test: test_multiInclude test_unicode test_sanity
 
 .PHONY: test_multiInclude
 test_multiInclude:
-	@$(MAKE) clean
 	# compile without xxhash.o, ensure symbols exist within target
 	# Note: built using only default rules
 	$(MAKE) multiInclude
-	@$(MAKE) clean
+	$(RM) multiInclude
 	# compile with xxhash.o, to detect duplicated symbols
 	$(MAKE) multiInclude_withxxhash
-	@$(MAKE) clean
+	$(RM) multiInclude_withxxhash
 	# compile with XXH_NAMESPACE before XXH_INLINE_ALL
 	CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude
 	# no symbol prefixed TESTN_ should exist
 	! $(NM) multiInclude | $(GREP) TESTN_
-	$(MAKE) clean
+	$(RM) multiInclude
 	# compile xxhash.o with XXH_NAMESPACE
 	CPPFLAGS=-DXXH_NAMESPACE=TESTN_ $(MAKE) multiInclude_withxxhash
 	# symbols prefixed TESTN_ should exist in xxhash.o (though not be invoked)
 	$(NM) multiInclude_withxxhash | $(GREP) TESTN_
-	$(MAKE) clean
+	$(RM) multiInclude_withxxhash
 
 .PHONY: test_ppc_redefine
-test_ppc_redefine: ppc_define.c
-	@$(MAKE) clean
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $^
+test_ppc_redefine: ppc_define.o
 
-.PHONY: $(XXHSUM)
-$(XXHSUM):
-	$(MAKE) -C $(XXHSUM_DIR) xxhsum
-	$(CP) $(XXHSUM) .
+XXHSUM_OBJS = xxhash.o $(notdir $(patsubst %.c,%.o,$(wildcard ../cli/*.c)))
+xxhsum:
+$(eval $(call c_program,xxhsum,$(XXHSUM_OBJS)))
+
+generate_unicode_test:
+$(eval $(call c_program,generate_unicode_test,generate_unicode_test.o))
 
 # Make sure that Unicode filenames work.
 # https://github.com/Cyan4973/xxHash/issues/293
@@ -92,24 +93,23 @@ test_unicode:
 	@echo "Skipping Unicode test, your terminal doesn't appear to support UTF-8."
 	@echo "Try with ENABLE_UNICODE=1"
 else
-test_unicode: $(XXHSUM) generate_unicode_test.c
+test_unicode: generate_unicode_test xxhsum
 	# Generate a Unicode filename test dynamically
 	# to keep UTF-8 out of the source tree.
-	$(CC) $(CFLAGS) $(LDFLAGS) generate_unicode_test.c -o generate_unicode_test$(EXT)
 	./generate_unicode_test$(EXT)
 	$(SHELL) ./unicode_test.sh
 endif
 
 .PHONY: test_filename_escape
-test_filename_escape: $(XXHSUM)
+test_filename_escape: xxhsum
 	./filename-escape.sh
 
 .PHONY: test_cli_comment_line
-test_cli_comment_line: $(XXHSUM)
+test_cli_comment_line: xxhsum
 	$(SHELL) ./cli-comment-line.sh
 
 .PHONY: test_cli_ignore_missing
-test_cli_ignore_missing: $(XXHSUM)
+test_cli_ignore_missing: xxhsum
 	$(SHELL) ./cli-ignore-missing.sh
 
 .PHONY: test_sanity
@@ -117,19 +117,19 @@ test_sanity: sanity_test.c
 	$(CC) $(CFLAGS) $(LDFLAGS) sanity_test.c -o sanity_test$(EXT)
 	$(RUN_ENV) ./sanity_test$(EXT)
 
+sanity_test_vectors_generator:
+$(eval $(call c_program,sanity_test_vectors_generator,sanity_test_vectors_generator.o))
+
 .PHONY: sanity_test_vectors.h
-sanity_test_vectors.h: sanity_test_vectors_generator.c
-	$(CC) $(CFLAGS) $(LDFLAGS) sanity_test_vectors_generator.c -o sanity_test_vectors_generator$(EXT)
+sanity_test_vectors.h: sanity_test_vectors_generator
 	./sanity_test_vectors_generator$(EXT)
 
-xxhash.o: ../xxhash.c ../xxhash.h
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -c -o $@ $<
+multiInclude_withxxhash:
+$(eval $(call c_program,multiInclude_withxxhash,multiInclude.o xxhash.o))
 
-multiInclude_withxxhash: multiInclude.o xxhash.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
-
+.PHONY: clean
 clean:
 	@$(RM) *.o
-	@$(RM) multiInclude multiInclude_withxxhash
-	@$(RM) *.unicode generate_unicode_test$(EXT) unicode_test.* xxhsum*
+	@$(RM) multiInclude
+	@$(RM) *.unicode unicode_test.*
 	@$(RM) sanity_test$(EXT) sanity_test_vectors_generator$(EXT)

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -50,8 +50,9 @@ collisionsTest: CFLAGS := -O3 $(CFLAGS)
 $(eval $(call cxx_program,collisionsTest,main.o pool.o threading.o sort.o $(HASH_OBJ)))
 
 .PHONY: debug
+debug: CPPFLAGS += -DDEBUG -DXXH_NO_INLINE_HINTS
 debug:
-	CFLAGS='$(CFLAGS) -g3 -Og -DDEBUG' CXXFLAGS='$(CXXFLAGS) -g3 -Og -DDEBUG' $(MAKE) collisionsTest
+	CFLAGS='$(CFLAGS) -g3 -Og' CXXFLAGS='$(CXXFLAGS) -g3 -Og' CPPFLAGS='$(CPPFLAGS)' $(MAKE) collisionsTest
 
 .PHONY: check
 check: test

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -36,27 +36,22 @@ HASH_SRC := $(wildcard allcodecs/*.c) $(wildcard allcodecs/*.cc) $(wildcard allc
 HASH_OBJ := $(addsuffix .o,$(basename $(HASH_SRC)))
 
 .PHONY: default
-default: release
+default: collisionsTest
 
 C_SRCDIRS = $(shell find allcodecs -type d)
 CXX_SRCDIRS = $(shell find allcodecs -type d)
 include ../../build/make/multiconf.make
 
 .PHONY: all
-all: release
+all: collisionsTest
 
-collisionsTest:
+collisionsTest: CXXFLAGS := -O3 $(CXXFLAGS)
+collisionsTest: CFLAGS := -O3 $(CFLAGS)
 $(eval $(call cxx_program,collisionsTest,main.o pool.o threading.o sort.o $(HASH_OBJ)))
 
-.PHONY: release
-release: CXXFLAGS += -O3
-release: CFLAGS += -O3
-release: collisionsTest
-
 .PHONY: debug
-debug: CXXFLAGS += -g3 -O0 -DDEBUG
-debug: CFLAGS += -g3 -O0 -DDEBUG
-debug: collisionsTest
+debug:
+	CFLAGS='$(CFLAGS) -g3 -Og -DDEBUG' CXXFLAGS='$(CXXFLAGS) -g3 -Og -DDEBUG' $(MAKE) collisionsTest
 
 .PHONY: check
 check: test

--- a/tests/collisions/Makefile
+++ b/tests/collisions/Makefile
@@ -23,9 +23,8 @@
 #  - xxHash source repository: https://github.com/Cyan4973/xxHash
 #
 
-SRC_DIRS = ./ ../../ allcodecs/
-VPATH = $(SRC_DIRS)
-CPPFLAGS += $(addprefix -I ,$(SRC_DIRS))
+HEADER_DIRS = ./ ../../ allcodecs/
+CPPFLAGS += $(addprefix -I ,$(HEADER_DIRS))
 CFLAGS   += -Wall -Wextra -Wconversion \
             -std=c11
 CXXFLAGS += -Wall -Wextra -Wconversion \
@@ -33,25 +32,28 @@ CXXFLAGS += -Wall -Wextra -Wconversion \
 LDFLAGS  += -pthread
 TESTHASHES = 3200000
 
-HASH_SRC := $(sort $(wildcard allcodecs/*.c allcodecs/*.cc))
-HASH_OBJ := $(patsubst %.c,%.o,$(HASH_SRC))
-
+HASH_SRC := $(wildcard allcodecs/*.c) $(wildcard allcodecs/*.cc) $(wildcard allcodecs/*.cpp)
+HASH_OBJ := $(addsuffix .o,$(basename $(HASH_SRC)))
 
 .PHONY: default
 default: release
 
+C_SRCDIRS = $(shell find allcodecs -type d)
+CXX_SRCDIRS = $(shell find allcodecs -type d)
+include ../../build/make/multiconf.make
+
 .PHONY: all
 all: release
 
-collisionsTest: main.o pool.o threading.o sort.o $(HASH_OBJ)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ $(LDFLAGS) -o $@
+collisionsTest:
+$(eval $(call cxx_program,collisionsTest,main.o pool.o threading.o sort.o $(HASH_OBJ)))
 
-main.o: hashes.h xxhash.h
-
+.PHONY: release
 release: CXXFLAGS += -O3
 release: CFLAGS += -O3
 release: collisionsTest
 
+.PHONY: debug
 debug: CXXFLAGS += -g3 -O0 -DDEBUG
 debug: CFLAGS += -g3 -O0 -DDEBUG
 debug: collisionsTest
@@ -75,4 +77,3 @@ test: debug
 .PHONY: clean
 clean:
 	$(RM) *.o allcodecs/*.o
-	$(RM) collisionsTest

--- a/tests/multiInclude.c
+++ b/tests/multiInclude.c
@@ -61,15 +61,16 @@
 
 void hash_advanced(void)
 {
+    const char input[] = "Hello World !";
     XXH3_state_t state;   /* this type is part of experimental API */
 
     XXH3_64bits_reset(&state);
-    const char input[] = "Hello World !";
 
     XXH3_64bits_update(&state, input, sizeof(input));
 
-    XXH64_hash_t const h = XXH3_64bits_digest(&state);
-    printf("hash '%s': %08x%08x \n", input, (unsigned)(h >> 32), (unsigned)h);
+    {   XXH64_hash_t const h = XXH3_64bits_digest(&state);
+        printf("hash '%s': %08x%08x \n", input, (unsigned)(h >> 32), (unsigned)h);
+    }
 }
 
 int main(void)

--- a/tests/sanity_test.c
+++ b/tests/sanity_test.c
@@ -286,7 +286,7 @@ static XSUM_U64 SANITY_TEST_computeRandSeed(size_t step)
  * Technically, XXH3_64bits_update is identical to XXH3_128bits_update as of
  * v0.8.0, but we treat them as separate.
  */
-typedef XXH_errorcode (*SANITY_TEST_XXH3_update_t)(XXH3_state_t* state, const void* input, size_t length);
+typedef XXH_errorcode (*SANITY_TEST_XXH3_update_t)(XXH_NOESCAPE XXH3_state_t* state, XXH_NOESCAPE const void* input, size_t length);
 
 
 /* TODO : Share this function with xsum_sanity_check.c */


### PR DESCRIPTION
- dynamic library created via `multiconf.make`
- `multiconf.make` supports both `.cc` and `.cpp` suffixes for C++ units
- `collisionsTest` now compiles with `multiconf.make`