### PR TITLE
Add RVV Optimizations for RISC-V Architecture Platforms

### DIFF
--- a/cli/xsum_arch.h
+++ b/cli/xsum_arch.h
@@ -162,6 +162,8 @@
 #  else
 #    define XSUM_ARCH "wasm/asmjs"
 #  endif
+#elif defined(__riscv)
+#    define XSUM_ARCH "riscv"
 #elif defined(__loongarch_lp64)
 #  if defined(__loongarch_asx)
 #    define XSUM_ARCH "loongarch64 + lasx"

--- a/tests/bench/Makefile
+++ b/tests/bench/Makefile
@@ -52,8 +52,8 @@ benchHash_avx2: CXXFLAGS += -mavx2
 benchHash_avx512: CFLAGS   += -mavx512f
 benchHash_avx512: CXXFLAGS += -mavx512f
 
-benchHash_rvv: CFLAGS   += -march=rv64gcv -O3
-benchHash_rvv: CXXFLAGS += -march=rv64gcv -O3
+benchHash_rvv: CFLAGS   += -march=rv64gcv -O2
+benchHash_rvv: CXXFLAGS += -march=rv64gcv -O2
 
 benchHash_hw: CPPFLAGS += -DHARDWARE_SUPPORT
 benchHash_hw: CFLAGS   += -mavx2 -maes

--- a/tests/bench/Makefile
+++ b/tests/bench/Makefile
@@ -52,11 +52,14 @@ benchHash_avx2: CXXFLAGS += -mavx2
 benchHash_avx512: CFLAGS   += -mavx512f
 benchHash_avx512: CXXFLAGS += -mavx512f
 
+benchHash_rvv: CFLAGS   += -march=rv64gcv -O3
+benchHash_rvv: CXXFLAGS += -march=rv64gcv -O3
+
 benchHash_hw: CPPFLAGS += -DHARDWARE_SUPPORT
 benchHash_hw: CFLAGS   += -mavx2 -maes
 benchHash_hw: CXXFLAGS += -mavx2 -mpclmul -std=c++14
 
-benchHash benchHash32 benchHash_avx2 benchHash_avx512 benchHash_nosimd benchHash_hw: $(OBJ_LIST)
+benchHash benchHash32 benchHash_avx2 benchHash_avx512 benchHash_nosimd benchHash_hw benchHash_rvv: $(OBJ_LIST)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ $(LDFLAGS) -o $@
 
 
@@ -68,4 +71,4 @@ benchHash.o: benchHash.h
 
 
 clean:
-	$(RM) *.o benchHash benchHash32 benchHash_avx2 benchHash_avx512 benchHash_hw
+	$(RM) *.o benchHash benchHash32 benchHash_avx2 benchHash_avx512 benchHash_hw benchHash_rvv

--- a/xxhash.h
+++ b/xxhash.h
@@ -1126,7 +1126,7 @@ XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const
 #  define XXH_SVE    6 /*!< SVE for some ARMv8-A and ARMv9-A */
 #  define XXH_LSX    7 /*!< LSX (128-bit SIMD) for LoongArch64 */
 #  define XXH_LASX   8 /*!< LASX (256-bit SIMD) for LoongArch64 */
-
+#  define XXH_RVV    9 /*!< RVV (RISC-V Vector) for RISC-V */
 
 /*-**********************************************************************
 *  XXH3 64-bit variant
@@ -3882,6 +3882,8 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
 #    include <lsxintrin.h>
 #  elif defined(__loongarch_sx)
 #    include <lsxintrin.h>
+#  elif defined(__riscv_vector)
+#    include <riscv_vector.h>
 #  endif
 #endif
 
@@ -4020,6 +4022,8 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
 #    define XXH_VECTOR XXH_LASX
 #  elif defined(__loongarch_sx)
 #    define XXH_VECTOR XXH_LSX
+#  elif defined(__riscv_vector)
+#    define XXH_VECTOR XXH_RVV
 #  else
 #    define XXH_VECTOR XXH_SCALAR
 #  endif
@@ -4060,6 +4064,8 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
 #  elif XXH_VECTOR == XXH_LASX   /* lasx */
 #     define XXH_ACC_ALIGN 64
 #  elif XXH_VECTOR == XXH_LSX   /* lsx */
+#     define XXH_ACC_ALIGN 64
+#  elif XXH_VECTOR == XXH_RVV   /* rvv */
 #     define XXH_ACC_ALIGN 64
 #  endif
 #endif
@@ -5825,6 +5831,93 @@ XXH3_scrambleAcc_lasx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 
 #endif
 
+#if (XXH_VECTOR == XXH_RVV)
+
+#if ((defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13) || \
+        (defined(__clang__) && __clang_major__ < 16))
+    #define RVV_OP(op) op
+#else
+    #define concat2(X, Y) X ## Y
+    #define concat(X, Y) concat2(X, Y)
+    #define RVV_OP(op) concat(__riscv_, op)
+#endif
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512_rvv(  void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT input,
+                    const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 63) == 0);
+    // Try to set vector lenght to 512 bits.
+    // If this length is unavailable, then maximum available will be used
+    size_t vl = RVV_OP(vsetvl_e64m1)(8);
+
+    uint64_t* const xacc = (uint64_t*) acc;
+    uint64_t* const xinput = (uint64_t*) input;
+    uint64_t* const xsecret = (uint64_t*) secret;
+    uint64_t swap_mask[8] = {1, 0, 3, 2, 5, 4, 7, 6};
+    vuint64m1_t xswap_mask = RVV_OP(vle64_v_u64m1)(swap_mask, vl);
+
+    // vuint64m1_t is sizeless.
+    // But we can assume that vl can be only 2, 4 or 8
+    for(size_t i = 0; i < XXH_STRIPE_LEN/(8 * vl); i++){
+        /* data_vec    = input[i]; */
+        vuint64m1_t data_vec = RVV_OP(vreinterpret_v_u8m1_u64m1)(RVV_OP(vle8_v_u8m1)((uint8_t*)(xinput + vl * i), vl * 8));
+        /* key_vec     = secret[i]; */
+        vuint64m1_t key_vec = RVV_OP(vreinterpret_v_u8m1_u64m1)(RVV_OP(vle8_v_u8m1)((uint8_t*)(xsecret + vl * i), vl * 8));
+        /* data_key    = data_vec ^ key_vec; */
+        vuint64m1_t data_key = RVV_OP(vxor_vv_u64m1)(data_vec, key_vec, vl);
+        /* data_key_lo = data_key >> 32; */
+        vuint64m1_t data_key_lo = RVV_OP(vsrl_vx_u64m1)(data_key, 32, vl);
+        /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
+        vuint64m1_t product = RVV_OP(vmul_vv_u64m1)(RVV_OP(vand_vx_u64m1)(data_key, 0xffffffff, vl), RVV_OP(vand_vx_u64m1)(data_key_lo, 0xffffffff, vl), vl);
+        /* acc_vec = xacc[i]; */
+        vuint64m1_t acc_vec = RVV_OP(vle64_v_u64m1)(xacc + vl * i, vl);
+        acc_vec = RVV_OP(vadd_vv_u64m1)(acc_vec, product, vl);
+        /* swap high and low halves */
+        vuint64m1_t data_swap = RVV_OP(vrgather_vv_u64m1)(data_vec, xswap_mask, vl);
+        acc_vec = RVV_OP(vadd_vv_u64m1)(acc_vec, data_swap, vl);
+        RVV_OP(vse64_v_u64m1)(xacc + vl * i, acc_vec, vl);
+    }
+}
+XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(rvv)
+
+XXH_FORCE_INLINE void
+XXH3_scrambleAcc_rvv(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 63) == 0);
+
+    // Try to set vector lenght to 512 bits.
+    // If this length is unavailable, then maximum available will be used
+    size_t vl = RVV_OP(vsetvl_e64m1)(8);
+    uint64_t* const xacc = (uint64_t*) acc;
+    uint64_t* const xsecret = (uint64_t*) secret;
+
+    uint64_t prime[8] = {XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1};
+    vuint64m1_t vprime = RVV_OP(vle64_v_u64m1)(prime, vl);
+
+    // vuint64m1_t is sizeless.
+    // But we can assume that vl can be only 2, 4 or 8
+    for(size_t i = 0; i < XXH_STRIPE_LEN/(8 * vl); i++){
+        /* xacc[i] ^= (xacc[i] >> 47) */
+        vuint64m1_t acc_vec = RVV_OP(vle64_v_u64m1)(xacc + vl * i, vl);
+        vuint64m1_t shifted = RVV_OP(vsrl_vx_u64m1)(acc_vec, 47, vl);
+        vuint64m1_t data_vec = RVV_OP(vxor_vv_u64m1)(acc_vec, shifted, vl);
+        /* xacc[i] ^= xsecret[i]; */
+        vuint64m1_t key_vec = RVV_OP(vreinterpret_v_u8m1_u64m1)(RVV_OP(vle8_v_u8m1)((uint8_t*)(xsecret + vl * i), vl * 8));
+        vuint64m1_t data_key = RVV_OP(vxor_vv_u64m1)(data_vec, key_vec, vl);
+
+        /* xacc[i] *= XXH_PRIME32_1; */
+        vuint64m1_t prod_even = RVV_OP(vmul_vv_u64m1)(RVV_OP(vand_vx_u64m1)(data_key, 0xffffffff, vl), vprime, vl);
+        vuint64m1_t prod_odd = RVV_OP(vmul_vv_u64m1)(RVV_OP(vsrl_vx_u64m1)(data_key, 32, vl), vprime, vl);
+        vuint64m1_t prod = RVV_OP(vadd_vv_u64m1)(prod_even, RVV_OP(vsll_vx_u64m1)(prod_odd, 32, vl), vl);
+        RVV_OP(vse64_v_u64m1)(xacc + vl * i, prod, vl);
+    }
+}
+
+#endif
+
+
 /* scalar variants - universal */
 
 #if defined(__aarch64__) && (defined(__GNUC__) || defined(__clang__))
@@ -6065,6 +6158,12 @@ typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
 #define XXH3_accumulate_512 XXH3_accumulate_512_lsx
 #define XXH3_accumulate     XXH3_accumulate_lsx
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_lsx
+#define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
+#elif (XXH_VECTOR == XXH_RVV)
+#define XXH3_accumulate_512 XXH3_accumulate_512_rvv
+#define XXH3_accumulate     XXH3_accumulate_rvv
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_rvv
 #define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
 
 #else /* scalar */


### PR DESCRIPTION
This Pull Request aims to build upon the previously closed PR (This Pull Request aims to build upon the previously closed PR (#898) by focusing on optimizing xxHash performance for platforms based on the RISC-V architecture through Vector Extension (RVV) optimizations. ) by focusing on optimizing xxHash performance for platforms based on the RISC-V architecture through Vector Extension (RVV) optimizations.And this PR has pass check on qemu with vlen=128,256,512.
For illustration, here are some benchmark numbers, on a Spacemit(R) X60 @1.6 Ghz
command line:`CFLAGS="-march=rv64gcv -O2 -DXXH_FORCE_MEMORY_ACCESS=0" make check`
```
OK. (passes 49948 tests)
5ffb01494ce73724  stdin
5ffb01494ce73724  xxhash.c
517f15e1d01f6dae  xxhash.h
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10681 it/s ( 1043.1 MB/s)
 3#XXH64                         :     102400 ->    14610 it/s ( 1426.8 MB/s)
 5#XXH3_64b                      :     102400 ->     9376 it/s (  915.7 MB/s)
11#XXH128                        :     102400 ->     9370 it/s (  915.1 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10726 it/s ( 1047.4 MB/s)
 2#XXH32 unaligned               :     102400 ->     5159 it/s (  503.8 MB/s)
 3#XXH64                         :     102400 ->    14595 it/s ( 1425.3 MB/s)
 4#XXH64 unaligned               :     102400 ->     8807 it/s (  860.1 MB/s)
 5#XXH3_64b                      :     102400 ->     9389 it/s (  916.9 MB/s)
 6#XXH3_64b unaligned            :     102400 ->     9304 it/s (  908.6 MB/s)
 7#XXH3_64b w/seed               :     102400 ->     9385 it/s (  916.5 MB/s)
 8#XXH3_64b w/seed unaligned     :     102400 ->     9306 it/s (  908.8 MB/s)
 9#XXH3_64b w/secret             :     102400 ->     8980 it/s (  876.9 MB/s)
10#XXH3_64b w/secret unaligned   :     102400 ->     8913 it/s (  870.4 MB/s)
11#XXH128                        :     102400 ->     9350 it/s (  913.1 MB/s)
12#XXH128 unaligned              :     102400 ->     9254 it/s (  903.7 MB/s)
13#XXH128 w/seed                 :     102400 ->     9341 it/s (  912.2 MB/s)
14#XXH128 w/seed unaligned       :     102400 ->     9257 it/s (  904.0 MB/s)
15#XXH128 w/secret               :     102400 ->     8925 it/s (  871.6 MB/s)
16#XXH128 w/secret unaligned     :     102400 ->     8844 it/s (  863.7 MB/s)
17#XXH32_stream                  :     102400 ->     2556 it/s (  249.6 MB/s)
18#XXH32_stream unaligned        :     102400 ->     2537 it/s (  247.8 MB/s)
19#XXH64_stream                  :     102400 ->     5110 it/s (  499.0 MB/s)
20#XXH64_stream unaligned        :     102400 ->     4960 it/s (  484.4 MB/s)
21#XXH3_stream                   :     102400 ->     9250 it/s (  903.3 MB/s)
22#XXH3_stream unaligned         :     102400 ->     9184 it/s (  896.9 MB/s)
23#XXH3_stream w/seed            :     102400 ->     9249 it/s (  903.3 MB/s)
24#XXH3_stream w/seed unaligned  :     102400 ->     9163 it/s (  894.8 MB/s)
25#XXH128_stream                 :     102400 ->     9236 it/s (  902.0 MB/s)
26#XXH128_stream unaligned       :     102400 ->     9150 it/s (  893.5 MB/s)
27#XXH128_stream w/seed          :     102400 ->     9215 it/s (  899.9 MB/s)
28#XXH128_stream w/seed unaligne :     102400 ->     9121 it/s (  890.7 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10700 it/s ( 1044.9 MB/s)
 2#XXH32 unaligned               :     102400 ->     5164 it/s (  504.3 MB/s)
 3#XXH64                         :     102400 ->    14587 it/s ( 1424.5 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
 1#XXH32                         :       1855 ->   569155 it/s ( 1006.9 MB/s)
 3#XXH64                         :       1855 ->   717551 it/s ( 1269.4 MB/s)
 5#XXH3_64b                      :       1855 ->   494573 it/s (  874.9 MB/s)
11#XXH128                        :       1855 ->   464638 it/s (  822.0 MB/s)
623b23d3  xxhash.c
7615c59c2d746e27e873a692555aca2b  xxhash.c
XXH3_e873a692555aca2b  xxhash.c
Wrong parameters

```
command line:`CFLAGS="-O2 -DXXH_FORCE_MEMORY_ACCESS=0" make check`
```
OK. (passes 49948 tests)
5ffb01494ce73724  stdin
5ffb01494ce73724  xxhash.c
517f15e1d01f6dae  xxhash.h
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10664 it/s ( 1041.4 MB/s)
 3#XXH64                         :     102400 ->    14958 it/s ( 1460.7 MB/s)
 5#XXH3_64b                      :     102400 ->     3326 it/s (  324.8 MB/s)
11#XXH128                        :     102400 ->     3353 it/s (  327.4 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10733 it/s ( 1048.1 MB/s)
 2#XXH32 unaligned               :     102400 ->     4332 it/s (  423.0 MB/s)
 3#XXH64                         :     102400 ->    14954 it/s ( 1460.3 MB/s)
 4#XXH64 unaligned               :     102400 ->     5013 it/s (  489.6 MB/s)
 5#XXH3_64b                      :     102400 ->     3361 it/s (  328.2 MB/s)
 6#XXH3_64b unaligned            :     102400 ->     3317 it/s (  323.9 MB/s)
 7#XXH3_64b w/seed               :     102400 ->     3256 it/s (  317.9 MB/s)
 8#XXH3_64b w/seed unaligned     :     102400 ->     3270 it/s (  319.3 MB/s)
 9#XXH3_64b w/secret             :     102400 ->     2306 it/s (  225.2 MB/s)
10#XXH3_64b w/secret unaligned   :     102400 ->     2332 it/s (  227.7 MB/s)
11#XXH128                        :     102400 ->     3350 it/s (  327.2 MB/s)
12#XXH128 unaligned              :     102400 ->     3314 it/s (  323.6 MB/s)
13#XXH128 w/seed                 :     102400 ->     3397 it/s (  331.7 MB/s)
14#XXH128 w/seed unaligned       :     102400 ->     3362 it/s (  328.3 MB/s)
15#XXH128 w/secret               :     102400 ->     2306 it/s (  225.2 MB/s)
16#XXH128 w/secret unaligned     :     102400 ->     2331 it/s (  227.6 MB/s)
17#XXH32_stream                  :     102400 ->     2357 it/s (  230.2 MB/s)
18#XXH32_stream unaligned        :     102400 ->     2350 it/s (  229.5 MB/s)
19#XXH64_stream                  :     102400 ->     3421 it/s (  334.0 MB/s)
20#XXH64_stream unaligned        :     102400 ->     3360 it/s (  328.1 MB/s)
21#XXH3_stream                   :     102400 ->     2145 it/s (  209.4 MB/s)
22#XXH3_stream unaligned         :     102400 ->     2124 it/s (  207.4 MB/s)
23#XXH3_stream w/seed            :     102400 ->     2143 it/s (  209.3 MB/s)
24#XXH3_stream w/seed unaligned  :     102400 ->     2123 it/s (  207.4 MB/s)
25#XXH128_stream                 :     102400 ->     2144 it/s (  209.4 MB/s)
26#XXH128_stream unaligned       :     102400 ->     2122 it/s (  207.3 MB/s)
27#XXH128_stream w/seed          :     102400 ->     2131 it/s (  208.1 MB/s)
28#XXH128_stream w/seed unaligne :     102400 ->     2112 it/s (  206.2 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10740 it/s ( 1048.9 MB/s)
 2#XXH32 unaligned               :     102400 ->     4339 it/s (  423.7 MB/s)
 3#XXH64                         :     102400 ->    14962 it/s ( 1461.2 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
 1#XXH32                         :       1855 ->   570131 it/s ( 1008.6 MB/s)
 3#XXH64                         :       1855 ->   719562 it/s ( 1273.0 MB/s)
 5#XXH3_64b                      :       1855 ->   171493 it/s (  303.4 MB/s)
11#XXH128                        :       1855 ->   166760 it/s (  295.0 MB/s)
623b23d3  xxhash.c
7615c59c2d746e27e873a692555aca2b  xxhash.c
XXH3_e873a692555aca2b  xxhash.c
Wrong parameters
```
by the way,when I use `CFLAGS="-march=rv64gcv -O3 -DXXH_FORCE_MEMORY_ACCESS=0" make check`, Performance with -O3 optimization is unexpectedly lower than with -O2.
```
OK. (passes 49948 tests)
5ffb01494ce73724  stdin
5ffb01494ce73724  xxhash.c
517f15e1d01f6dae  xxhash.h
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10669 it/s ( 1041.9 MB/s)
 3#XXH64                         :     102400 ->    14569 it/s ( 1422.7 MB/s)
 5#XXH3_64b                      :     102400 ->     8255 it/s (  806.1 MB/s)
11#XXH128                        :     102400 ->     8347 it/s (  815.1 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10715 it/s ( 1046.4 MB/s)
 2#XXH32 unaligned               :     102400 ->     5157 it/s (  503.7 MB/s)
 3#XXH64                         :     102400 ->    14530 it/s ( 1418.9 MB/s)
 4#XXH64 unaligned               :     102400 ->     8788 it/s (  858.2 MB/s)
 5#XXH3_64b                      :     102400 ->     8343 it/s (  814.7 MB/s)
 6#XXH3_64b unaligned            :     102400 ->     8270 it/s (  807.6 MB/s)
 7#XXH3_64b w/seed               :     102400 ->     8300 it/s (  810.5 MB/s)
 8#XXH3_64b w/seed unaligned     :     102400 ->     8231 it/s (  803.8 MB/s)
 9#XXH3_64b w/secret             :     102400 ->     7944 it/s (  775.8 MB/s)
10#XXH3_64b w/secret unaligned   :     102400 ->     7866 it/s (  768.1 MB/s)
11#XXH128                        :     102400 ->     8287 it/s (  809.3 MB/s)
12#XXH128 unaligned              :     102400 ->     8212 it/s (  802.0 MB/s)
13#XXH128 w/seed                 :     102400 ->     8240 it/s (  804.7 MB/s)
14#XXH128 w/seed unaligned       :     102400 ->     8187 it/s (  799.5 MB/s)
15#XXH128 w/secret               :     102400 ->     7884 it/s (  769.9 MB/s)
16#XXH128 w/secret unaligned     :     102400 ->     7820 it/s (  763.6 MB/s)
17#XXH32_stream                  :     102400 ->     2555 it/s (  249.5 MB/s)
18#XXH32_stream unaligned        :     102400 ->     2538 it/s (  247.9 MB/s)
19#XXH64_stream                  :     102400 ->     5106 it/s (  498.7 MB/s)
20#XXH64_stream unaligned        :     102400 ->     4963 it/s (  484.7 MB/s)
21#XXH3_stream                   :     102400 ->     8255 it/s (  806.2 MB/s)
22#XXH3_stream unaligned         :     102400 ->     8184 it/s (  799.2 MB/s)
23#XXH3_stream w/seed            :     102400 ->     8235 it/s (  804.2 MB/s)
24#XXH3_stream w/seed unaligned  :     102400 ->     8171 it/s (  797.9 MB/s)
25#XXH128_stream                 :     102400 ->     8264 it/s (  807.0 MB/s)
26#XXH128_stream unaligned       :     102400 ->     8192 it/s (  800.0 MB/s)
27#XXH128_stream w/seed          :     102400 ->     8249 it/s (  805.5 MB/s)
28#XXH128_stream w/seed unaligne :     102400 ->     8174 it/s (  798.2 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
Sample of 100 KB...
 1#XXH32                         :     102400 ->    10746 it/s ( 1049.4 MB/s)
 2#XXH32 unaligned               :     102400 ->     5157 it/s (  503.6 MB/s)
 3#XXH64                         :     102400 ->    14556 it/s ( 1421.5 MB/s)
xxhsum 0.8.3 by Yann Collet
compiled as 64-bit riscv little endian with GCC 14.2.1 20240801 (openEuler 14.2.1-6.oe2403sp1)
 1#XXH32                         :       1855 ->   573313 it/s ( 1014.2 MB/s)
 3#XXH64                         :       1855 ->   724917 it/s ( 1282.4 MB/s)
 5#XXH3_64b                      :       1855 ->   443729 it/s (  785.0 MB/s)
11#XXH128                        :       1855 ->   426737 it/s (  754.9 MB/s)
623b23d3  xxhash.c
7615c59c2d746e27e873a692555aca2b  xxhash.c
XXH3_e873a692555aca2b  xxhash.c
Wrong parameters
```
I still find reason about it

