### PR TITLE
Fix #1042

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ build_script:
         Set-Location $buildDir
         
         # Configure CMake for this architecture with fast Debug builds
-        cmake .. -A $arch -DXXHASH_C_FLAGS="/WX" -DCMAKE_C_FLAGS_DEBUG="/Od /Zi /MDd"
+        cmake .. -A $arch -DXXHASH_C_FLAGS="/W4 /WX" -DCMAKE_C_FLAGS_DEBUG="/Od /Zi /MDd"
         
         # Build Debug configuration (fast compilation, no optimizations)
         Write-Host "Building Debug configuration for $arch..."
@@ -76,14 +76,14 @@ build_script:
         # Build Debug with SSE2 if Win32 (x64 has SSE2 by default, ARM doesn't support it)
         if ($arch -eq "Win32") {
           Write-Host "Building Debug configuration with SSE2 for $arch..."
-          cmake .. -A $arch -DXXHASH_C_FLAGS="/WX /arch:SSE2" -DCMAKE_C_FLAGS_DEBUG="/Od /Zi /MDd"
+          cmake .. -A $arch -DXXHASH_C_FLAGS="/W4 /WX /arch:SSE2" -DCMAKE_C_FLAGS_DEBUG="/Od /Zi /MDd"
           cmake --build . --config Debug
         }
 
         # Build Debug with AVX2 if enabled and supported
         if ($env:AVX2_ENABLED -eq "true" -and $arch -ne "ARM") {
           Write-Host "Building Debug configuration with AVX2 for $arch..."
-          cmake .. -A $arch -DXXHASH_C_FLAGS="/WX /arch:AVX2"
+          cmake .. -A $arch -DXXHASH_C_FLAGS="/W4 /WX /arch:AVX2" -DCMAKE_C_FLAGS_DEBUG="/Od /Zi /MDd"
           cmake --build . --config Debug
         }
         

--- a/cli/xsum_config.h
+++ b/cli/xsum_config.h
@@ -50,6 +50,10 @@
 #  endif
 #endif
 
+#if defined(_MSC_VER)
+#  pragma warning(disable : 4127) /* disable: C4127: conditional expression is constant */
+#endif
+
 /* Under Linux at least, pull in the *64 commands */
 #ifndef _LARGEFILE64_SOURCE
 #  define _LARGEFILE64_SOURCE

--- a/xxhash.h
+++ b/xxhash.h
@@ -5273,10 +5273,18 @@ XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTR
     (void)(&XXH_writeLE64);
     {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / sizeof(__m128i);
 
-#       if defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER < 1900
-        /* MSVC 32bit mode does not support _mm_set_epi64x before 2015 */
-        XXH_ALIGN(16) const xxh_i64 seed64x2[2] = { (xxh_i64)seed64, (xxh_i64)(0U - seed64) };
-        __m128i const seed = _mm_load_si128((__m128i const*)seed64x2);
+#       if defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER <= 1900
+        /* MSVC 32bit mode does not support _mm_set_epi64x before 2015
+         * and some specific variants of 2015 may also lack it */
+        /* Cast to unsigned 64-bit first to avoid signed arithmetic issues */
+        xxh_u64 const seed64_unsigned = (xxh_u64)seed64;
+        xxh_u64 const neg_seed64 = (xxh_u64)(0ULL - seed64_unsigned);
+        __m128i const seed = _mm_set_epi32(
+            (int)(neg_seed64 >> 32),      /* high 32 bits of negated seed */
+            (int)(neg_seed64),            /* low 32 bits of negated seed */
+            (int)(seed64_unsigned >> 32), /* high 32 bits of original seed */
+            (int)(seed64_unsigned)        /* low 32 bits of original seed */
+        );
 #       else
         __m128i const seed = _mm_set_epi64x((xxh_i64)(0U - seed64), (xxh_i64)seed64);
 #       endif


### PR DESCRIPTION
Fix diverse minor issues for MSVC,
including a specific issue involving a specific version of MSVC 2015 compiling in 32-bit mode with SSE2 enabled (see #1042)