### PR TITLE
add riscv rvv ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,10 +474,16 @@ jobs:
         CPPFLAGS="-DXXH_VECTOR=XXH_SCALAR" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
         CPPFLAGS=-DXXH_VECTOR=XXH_VSX CFLAGS="-O3 -march=arch11 -mzvector" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
-    - name: MIPS-M68K-RISCV-SPARC (XXH_VECTOR=[ scalar ])
-      if: ${{ startsWith(matrix.name, 'MIPS') || startsWith(matrix.name, 'M68K') || startsWith(matrix.name, 'RISC-V') || startsWith(matrix.name, 'SPARC') }}
+    - name: MIPS-M68K-SPARC (XXH_VECTOR=[ scalar ])
+      if: ${{ startsWith(matrix.name, 'MIPS') || startsWith(matrix.name, 'M68K') || startsWith(matrix.name, 'SPARC') }}
       run: |
         make clean; LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make check
+
+    - name: RISCV (XXH_VECTOR=[scalar, rvv])
+      if: ${{startsWith(matrix.name, 'RISC-V')}}
+      run: |
+        make clean; LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make check
+        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
 
     - name: LoongArch (XXH_VECTOR=[ scalar, LSX ])
       if: ${{ startsWith(matrix.name, 'LoongArch') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,9 +483,9 @@ jobs:
       if: ${{startsWith(matrix.name, 'RISC-V')}}
       run: |
         make clean; LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make check
-        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=128" make clean check
-        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=256" make clean check
-        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=512" make clean check
+        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=128,rvv_ta_all_1s=on,rvv_ma_all_1s=on" make clean check
+        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=256,rvv_ta_all_1s=on,rvv_ma_all_1s=on" make clean check
+        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=512,rvv_ta_all_1s=on,rvv_ma_all_1s=on" make clean check
 
     - name: LoongArch (XXH_VECTOR=[ scalar, LSX ])
       if: ${{ startsWith(matrix.name, 'LoongArch') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,9 @@ jobs:
       if: ${{startsWith(matrix.name, 'RISC-V')}}
       run: |
         make clean; LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make check
-        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV=$XEMU make clean check
+        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=128" make clean check
+        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=256" make clean check
+        CPPFLAGS="-march=rv64gcv -O2 -DXXH_VECTOR=XXH_RVV" LDFLAGS="-static" CC=$XCC RUN_ENV="$XEMU -cpu rv64,v=true,vlen=512" make clean check
 
     - name: LoongArch (XXH_VECTOR=[ scalar, LSX ])
       if: ${{ startsWith(matrix.name, 'LoongArch') }}

--- a/xxhash.h
+++ b/xxhash.h
@@ -5953,7 +5953,7 @@ XXH3_initCustomSecret_rvv(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
                                     seed64, (uint64_t)(-(int64_t)seed64), \
                                     seed64, (uint64_t)(-(int64_t)seed64)};
             // Cast the default secret to a signed 64-bit pointer for vectorized access
-            const int64_t* const xXXH3_kSecret = (const int64_t*)XXH3_kSecret;
+            const int64_t* const xXXH3_kSecret = (const int64_t*)((const void*)XXH3_kSecret);
             size_t vl = 0;
             for (size_t i=0; i < XXH3_kSecret_64b_len; i += vl) {
 


### PR DESCRIPTION
This PR introduces CI testing for RISC-V RVV (Vector Extension) to validate the correctness of the RVV code across various vector lengths: vlen=128, 256, and 512. 
Additionally, it addresses a bug related to "cast increases required alignment of target type".