### PR TITLE
remove VS2019 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,7 +538,6 @@ jobs:
       matrix:
         system: [
           { os: windows-2022, vc: "VC++ 2022", clangcl: 'true', },
-          { os: windows-2019, vc: "VC++ 2019", clangcl: 'true', },
         ]
         arch: [ x64, Win32, ARM64 ]
     # make every PowerShell step start with `$ErrorActionPreference = 'Stop'`


### PR DESCRIPTION
VS2019 is no longer supported by Github Actions