### PR TITLE
added VS2019 to Appveyor CI tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,31 +12,24 @@ clone_depth: 2
 
 environment:
   matrix:
-    # Legacy Visual Studio 2013 build (not supported by GitHub Actions)
-    - COMPILER: "visual"
-      ARCHITECTURES: "Win32,x64"
-      AVX2_ENABLED: "false"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2013"
-      TEST_XXHSUM: "true"
-      
-    # Legacy Visual Studio 2015 build (not supported by GitHub Actions)
-    - COMPILER: "visual"
-      ARCHITECTURES: "Win32,x64"
-      AVX2_ENABLED: "true"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
-      TEST_XXHSUM: "true"
-      
     # Visual Studio 2017 build (not supported by GitHub Actions) - both Win32 and x64
     - COMPILER: "visual"
-      ARCHITECTURES: "Win32,x64"
-      AVX2_ENABLED: "true"
+      ARCHS: "Win32,x64"
+      AVX2: "true"
       APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
       TEST_XXHSUM: "true"
-      
+
+    # Visual Studio 2019 build (no longer supported by GitHub Actions) - Win32 and x64
+    - COMPILER: "visual"
+      ARCHS: "Win32,x64"
+      AVX2: "true"
+      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      TEST_XXHSUM: "true"
+
     # ARM build (no testing - cannot run on x86/x64 CI)
     - COMPILER: "visual"
-      ARCHITECTURES: "ARM"
-      AVX2_ENABLED: "false"
+      ARCHS: "ARM"
+      AVX2: "false"
       TEST_XXHSUM: "false"
 
 # ==============================================================================
@@ -48,31 +41,31 @@ build_script:
   - echo "Building Visual Studio configurations"
   - echo "========================================"
 
-  # Visual Studio build process  
+  # Visual Studio build process
   - ps: |
       Set-Location "build/cmake"
-      
+
       # Split architectures and build each one
-      $architectures = $env:ARCHITECTURES -split ","
-      
+      $architectures = $env:ARCHS -split ","
+
       foreach ($arch in $architectures) {
         $arch = $arch.Trim()
         Write-Host "========================================"
         Write-Host "Building for architecture: $arch"
         Write-Host "========================================"
-        
+
         # Create architecture-specific build directory
         $buildDir = "build_$arch"
         New-Item -Path $buildDir -ItemType Directory -Force | Out-Null
         Set-Location $buildDir
-        
+
         # Configure CMake for this architecture with fast Debug builds
         cmake .. -A $arch -DXXHASH_C_FLAGS="/W4 /WX" -DCMAKE_C_FLAGS_DEBUG="/Od /Zi /MDd"
-        
+
         # Build Debug configuration (fast compilation, no optimizations)
         Write-Host "Building Debug configuration for $arch..."
         cmake --build . --config Debug
-        
+
         # Build Debug with SSE2 if Win32 (x64 has SSE2 by default, ARM doesn't support it)
         if ($arch -eq "Win32") {
           Write-Host "Building Debug configuration with SSE2 for $arch..."
@@ -81,22 +74,22 @@ build_script:
         }
 
         # Build Debug with AVX2 if enabled and supported
-        if ($env:AVX2_ENABLED -eq "true" -and $arch -ne "ARM") {
+        if ($env:AVX2 -eq "true" -and $arch -ne "ARM") {
           Write-Host "Building Debug configuration with AVX2 for $arch..."
           cmake .. -A $arch -DXXHASH_C_FLAGS="/W4 /WX /arch:AVX2" -DCMAKE_C_FLAGS_DEBUG="/Od /Zi /MDd"
           cmake --build . --config Debug
         }
-        
+
         # Build Release configuration
         Write-Host "Building Release configuration for $arch..."
         cmake --build . --config Release
-        
+
         # Go back to cmake directory for next architecture
         Set-Location ..
       }
 
 # ==============================================================================
-#                              Test Scripts  
+#                              Test Scripts
 # ==============================================================================
 
 test_script:
@@ -104,25 +97,25 @@ test_script:
   - ps: |
       if ($env:TEST_XXHSUM -eq "true") {
         Set-Location "build/cmake"
-        
+
         # Split architectures and test each one
-        $architectures = $env:ARCHITECTURES -split ","
-        
+        $architectures = $env:ARCHS -split ","
+
         foreach ($arch in $architectures) {
           $arch = $arch.Trim()
-          
+
           # Only test architectures that can run on CI (x86/x64)
           if ($arch -eq "ARM") {
             Write-Host "Skipping testing for $arch (cannot run on x86/x64 CI)"
             continue
           }
-          
+
           Write-Host "========================================"
           Write-Host "Testing Visual Studio $arch"
           Write-Host "========================================"
-          
+
           Set-Location "build_$arch"
-          
+
           # Test Release configuration only
           Write-Host "Testing Release binary for $arch..."
           Set-Location "Release"
@@ -132,11 +125,11 @@ test_script:
             exit 1
           }
           Write-Host "Release binary test completed successfully for $arch"
-          
+
           # Go back to cmake directory for next architecture
           Set-Location "../.."
         }
-        
+
         Write-Host "------- All xxhsum testing completed successfully -------"
       }
 


### PR DESCRIPTION
since it's no longer supported by Github Actions.

On the other hand, since Appveyor is our longest CI test, it's necessary to keep its execution time low.

For this reason, older configs (VS2013 and VS2015) are removed.

Appveyor remains the longest job to wait for, but at least it's shorter now (7mn -> 5mn)