### PR TITLE
make sure dispatch is unset when it does not apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ detect_x86_arch = $(shell $(CC) -dumpmachine | grep -E 'i[3-6]86|x86_64')
 ifneq ($(strip $(call detect_x86_arch)),)
     #note: can be overridden at compile time, by setting DISPATCH=0
     DISPATCH ?= 1
+else
+    DISPATCH = 0
 endif
 
 ifeq ($(NODE_JS),1)


### PR DESCRIPTION
This allows to have it set explicitly without breaking anything on other architectures.