### PR TITLE
cleanup RVV implementation

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -4057,7 +4057,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
 #  elif XXH_VECTOR == XXH_LSX   /* lsx */
 #     define XXH_ACC_ALIGN 64
 #  elif XXH_VECTOR == XXH_RVV   /* rvv */
-#     define XXH_ACC_ALIGN 64
+#     define XXH_ACC_ALIGN 64   /* could be 8, but 64 may be faster */
 #  endif
 #endif
 
@@ -5721,8 +5721,9 @@ XXH3_accumulate_512_lsx( void* XXH_RESTRICT acc,
         __m128i* const xacc    =       (__m128i *) acc;
         const __m128i* const xinput  = (const __m128i *) input;
         const __m128i* const xsecret = (const __m128i *) secret;
+        size_t i;
 
-        for (size_t i = 0; i < XXH_STRIPE_LEN / sizeof(__m128i); i++) {
+        for (i = 0; i < XXH_STRIPE_LEN / sizeof(__m128i); i++) {
             /* data_vec = xinput[i]; */
             __m128i const data_vec = __lsx_vld(xinput + i, 0);
             /* key_vec = xsecret[i]; */
@@ -5752,8 +5753,9 @@ XXH3_scrambleAcc_lsx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
         __m128i* const xacc = (__m128i*) acc;
         const __m128i* const xsecret = (const __m128i *) secret;
         const __m128i prime32 = __lsx_vreplgr2vr_d(XXH_PRIME32_1);
+        size_t i;
 
-        for (size_t i = 0; i < XXH_STRIPE_LEN / sizeof(__m128i); i++) {
+        for (i = 0; i < XXH_STRIPE_LEN / sizeof(__m128i); i++) {
             /* xacc[i] ^= (xacc[i] >> 47) */
             __m128i const acc_vec = xacc[i];
             __m128i const shifted = __lsx_vsrli_d(acc_vec, 47);
@@ -5780,11 +5782,12 @@ XXH3_accumulate_512_lasx( void* XXH_RESTRICT acc,
 {
     XXH_ASSERT((((size_t)acc) & 31) == 0);
     {
+        size_t i;
         __m256i* const xacc    =       (__m256i *) acc;
         const __m256i* const xinput  = (const __m256i *) input;
         const __m256i* const xsecret = (const __m256i *) secret;
 
-        for (size_t i = 0; i < XXH_STRIPE_LEN / sizeof(__m256i); i++) {
+        for (i = 0; i < XXH_STRIPE_LEN / sizeof(__m256i); i++) {
             /* data_vec = xinput[i]; */
             __m256i const data_vec = __lasx_xvld(xinput + i, 0);
             /* key_vec = xsecret[i]; */
@@ -5814,8 +5817,9 @@ XXH3_scrambleAcc_lasx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
         __m256i* const xacc = (__m256i*) acc;
         const __m256i* const xsecret = (const __m256i *) secret;
         const __m256i prime32 = __lasx_xvreplgr2vr_d(XXH_PRIME32_1);
+        size_t i;
 
-        for (size_t i = 0; i < XXH_STRIPE_LEN / sizeof(__m256i); i++) {
+        for (i = 0; i < XXH_STRIPE_LEN / sizeof(__m256i); i++) {
             /* xacc[i] ^= (xacc[i] >> 47) */
             __m256i const acc_vec = xacc[i];
             __m256i const shifted = __lasx_xvsrli_d(acc_vec, 47);
@@ -5833,13 +5837,15 @@ XXH3_scrambleAcc_lasx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 #endif
 
 #if (XXH_VECTOR == XXH_RVV)
+    #define XXH_CONCAT2(X, Y) X ## Y
+    #define XXH_CONCAT(X, Y) XXH_CONCAT2(X, Y)
 #if ((defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13) || \
         (defined(__clang__) && __clang_major__ < 16))
-    #define RVV_OP(op) op
+    #define XXH_RVOP(op) op
+    #define XXH_RVCAST(op) XXH_CONCAT(vreinterpret_v_, op)
 #else
-    #define concat2(X, Y) X ## Y
-    #define concat(X, Y) concat2(X, Y)
-    #define RVV_OP(op) concat(__riscv_, op)
+    #define XXH_RVOP(op) XXH_CONCAT(__riscv_, op)
+    #define XXH_RVCAST(op) XXH_CONCAT(__riscv_vreinterpret_v_, op)
 #endif
 XXH_FORCE_INLINE void
 XXH3_accumulate_512_rvv(  void* XXH_RESTRICT acc,
@@ -5850,37 +5856,26 @@ XXH3_accumulate_512_rvv(  void* XXH_RESTRICT acc,
     {
         // Try to set vector lenght to 512 bits.
         // If this length is unavailable, then maximum available will be used
-        size_t vl = RVV_OP(vsetvl_e64m2)(8);
+        size_t vl = XXH_RVOP(vsetvl_e64m2)(8);
 
         uint64_t*       xacc    = (uint64_t*) acc;
         const uint64_t* xinput  = (const uint64_t*) input;
         const uint64_t* xsecret = (const uint64_t*) secret;
         static const uint64_t swap_mask[16] = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-        vuint64m2_t xswap_mask = RVV_OP(vle64_v_u64m2)(swap_mask, vl);
+        vuint64m2_t xswap_mask = XXH_RVOP(vle64_v_u64m2)(swap_mask, vl);
 
-        // vuint64m2_t is sizeless.
-        // But we can assume that vl can be only 4(vlen=128) or 8(vlen=256,512)
-        size_t i=0;
-        for(; i < XXH_STRIPE_LEN / 8; i += vl){
-            /* acc_vec = xacc[i]; */
-            vuint64m2_t acc_vec = RVV_OP(vle64_v_u64m2)(xacc + i, vl);
-            /* data_vec    = input[i]; */
-            vuint64m2_t data_vec = RVV_OP(vreinterpret_v_u8m2_u64m2)(RVV_OP(vle8_v_u8m2)((const uint8_t*)(xinput + i), vl * 8));
-            /* key_vec     = secret[i]; */
-            vuint64m2_t key_vec = RVV_OP(vreinterpret_v_u8m2_u64m2)(RVV_OP(vle8_v_u8m2)((const uint8_t*)(xsecret + i), vl * 8));
-            /* data_key    = data_vec ^ key_vec; */
-            vuint64m2_t data_key = RVV_OP(vxor_vv_u64m2)(data_vec, key_vec, vl);
-            /* data_key_lo = data_key >> 32; */
-            vuint64m2_t data_key_lo = RVV_OP(vsrl_vx_u64m2)(data_key, 32, vl);
-            /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
-            vuint64m2_t product = RVV_OP(vmul_vv_u64m2)(RVV_OP(vand_vx_u64m2)(data_key, 0xffffffffULL, vl), data_key_lo, vl);
-            /* swap high and low halves */
-            vuint64m2_t data_swap = RVV_OP(vrgather_vv_u64m2)(data_vec, xswap_mask, vl);
-
-            acc_vec = RVV_OP(vadd_vv_u64m2)(acc_vec, product, vl);
-            acc_vec = RVV_OP(vadd_vv_u64m2)(acc_vec, data_swap, vl);
-
-            RVV_OP(vse64_v_u64m2)(xacc + i, acc_vec, vl);
+        size_t i;
+        for (i = 0; i < XXH_STRIPE_LEN/8; i += vl) {
+            vuint64m2_t data_vec = XXH_RVCAST(u8m2_u64m2)(XXH_RVOP(vle8_v_u8m2)((const uint8_t*)(xinput + i), vl * 8));
+            vuint64m2_t key_vec = XXH_RVCAST(u8m2_u64m2)(XXH_RVOP(vle8_v_u8m2)((const uint8_t*)(xsecret + i), vl * 8));
+            vuint64m2_t acc_vec = XXH_RVOP(vle64_v_u64m2)(xacc + i, vl);
+            vuint64m2_t data_key = XXH_RVOP(vxor_vv_u64m2)(data_vec, key_vec, vl);
+            vuint64m2_t data_key_hi = XXH_RVOP(vsrl_vx_u64m2)(data_key, 32, vl);
+            vuint64m2_t data_key_lo = XXH_RVOP(vand_vx_u64m2)(data_key, 0xffffffff, vl);
+            vuint64m2_t data_swap = XXH_RVOP(vrgather_vv_u64m2)(data_vec, xswap_mask, vl); /* swap high and low halves */
+            acc_vec = XXH_RVOP(vmacc_vv_u64m2)(acc_vec, data_key_lo, data_key_hi, vl);
+            acc_vec = XXH_RVOP(vadd_vv_u64m2)(acc_vec, data_swap, vl);
+            XXH_RVOP(vse64_v_u64m2)(xacc + i, acc_vec, vl);
         }
     }
 }
@@ -5890,29 +5885,23 @@ XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(rvv)
 XXH_FORCE_INLINE void
 XXH3_scrambleAcc_rvv(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 {
-    XXH_ASSERT((((size_t)acc) & 63) == 0);
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
     {
-        // Try to set vector lenght to 512 bits.
-        // If this length is unavailable, then maximum available will be used
-        size_t vl = RVV_OP(vsetvl_e64m2)(8);
-        uint64_t*     xacc = (uint64_t*) acc;
-        const uint64_t* xsecret = (const uint64_t*) secret;
-
-        // vuint64m2_t is sizeless.
-        // But we can assume that vl can be only 4(vlen=128) or 8(vlen=256,512)
-        size_t i = 0;
-        for (; i < XXH_STRIPE_LEN / 8; i += vl) {
-            /* xacc[i] ^= (xacc[i] >> 47) */
-            vuint64m2_t acc_vec = RVV_OP(vle64_v_u64m2)(xacc + i, vl);
-            vuint64m2_t shifted = RVV_OP(vsrl_vx_u64m2)(acc_vec, 47, vl);
-            vuint64m2_t key_vec = RVV_OP(vreinterpret_v_u8m2_u64m2)(RVV_OP(vle8_v_u8m2)((const uint8_t*)(xsecret + i), vl * 8));
-            acc_vec = RVV_OP(vxor_vv_u64m2)(acc_vec, shifted, vl);
-            /* xacc[i] ^= xsecret[i]; */
-            acc_vec = RVV_OP(vxor_vv_u64m2)(acc_vec, key_vec, vl);
-
-            /* xacc[i] *= XXH_PRIME32_1; */
-            acc_vec = RVV_OP(vmul_vx_u64m2)(acc_vec, (xxh_u64)XXH_PRIME32_1, vl);
-            RVV_OP(vse64_v_u64m2)(xacc + i, acc_vec, vl);
+        size_t count = XXH_STRIPE_LEN/8;
+        uint64_t* xacc = (uint64_t*)acc;
+        const uint8_t* xsecret = (const uint8_t *)secret;
+        size_t vl;
+        for (; count > 0; count -= vl, xacc += vl, xsecret += vl*8) {
+            vl = XXH_RVOP(vsetvl_e64m2)(count);
+            {
+                vuint64m2_t vkey = XXH_RVCAST(u8m2_u64m2)(XXH_RVOP(vle8_v_u8m2)(xsecret, vl*8));
+                vuint64m2_t vacc = XXH_RVOP(vle64_v_u64m2)(xacc, vl);
+                vuint64m2_t vsrl = XXH_RVOP(vsrl_vx_u64m2)(vacc, 47, vl);
+                vacc = XXH_RVOP(vxor_vv_u64m2)(vacc, vsrl, vl);
+                vacc = XXH_RVOP(vxor_vv_u64m2)(vacc, vkey, vl);
+                vacc = XXH_RVOP(vmul_vx_u64m2)(vacc, XXH_PRIME32_1, vl);
+                XXH_RVOP(vse64_v_u64m2)(xacc, vacc, vl);
+            }
         }
     }
 }
@@ -5920,29 +5909,38 @@ XXH3_scrambleAcc_rvv(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
 XXH_FORCE_INLINE void
 XXH3_initCustomSecret_rvv(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
 {
-    XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
-    XXH_STATIC_ASSERT(XXH_SEC_ALIGN == 64);
-    XXH_ASSERT(((size_t)customSecret & 63) == 0);
+    XXH_STATIC_ASSERT(XXH_SEC_ALIGN >= 8);
+    XXH_ASSERT(((size_t)customSecret & 7) == 0);
+    (void)(&XXH_writeLE64);
     {
-        const uint8_t* kSecretPtr = XXH3_kSecret;
-        size_t XXH3_kSecret_64b_len = XXH_SECRET_DEFAULT_SIZE / 16;
-        size_t i = 0;
-        for(;i < XXH3_kSecret_64b_len;) {
-            size_t vl = RVV_OP(vsetvl_e64m2)(XXH3_kSecret_64b_len - i);
+        size_t count = XXH_SECRET_DEFAULT_SIZE/8;
+        size_t vl;
+        size_t VLMAX = XXH_RVOP(vsetvlmax_e64m2)();
+        int64_t* cSecret = (int64_t*)customSecret;
+        const int64_t* kSecret = (const int64_t*)(const void*)XXH3_kSecret;
+
+#if __riscv_v_intrinsic >= 1000000
+        // ratified v1.0 intrinics version
+        vbool32_t mneg = XXH_RVCAST(u8m1_b32)(
+                         XXH_RVOP(vmv_v_x_u8m1)(0xaa, XXH_RVOP(vsetvlmax_e8m1)()));
+#else
+        // support pre-ratification intrinics, which lack mask to vector casts
+        size_t vlmax = XXH_RVOP(vsetvlmax_e8m1)();
+        vbool32_t mneg = XXH_RVOP(vmseq_vx_u8mf4_b32)(
+                         XXH_RVOP(vand_vx_u8mf4)(
+                         XXH_RVOP(vid_v_u8mf4)(vlmax), 1, vlmax), 1, vlmax);
+#endif
+        vint64m2_t seed = XXH_RVOP(vmv_v_x_i64m2)((int64_t)seed64, VLMAX);
+        seed = XXH_RVOP(vneg_v_i64m2_mu)(mneg, seed, seed, VLMAX);
+
+        for (; count > 0; count -= vl, cSecret += vl, kSecret += vl) {
+            /* make sure vl=VLMAX until last iteration */
+            vl = XXH_RVOP(vsetvl_e64m2)(count < VLMAX ? count : VLMAX);
             {
-                vuint64m2_t vlo = RVV_OP(vlse64_v_u64m2)((const uint64_t*)(const void*)kSecretPtr, 16, vl);
-                vuint64m2_t vhi = RVV_OP(vlse64_v_u64m2)((const uint64_t*)(const void*)(kSecretPtr + 8), 16, vl);
-
-                // vlo += seed64, vhi -= seed64
-                vuint64m2_t lo = RVV_OP(vadd_vx_u64m2)(vlo, seed64, vl);
-                vuint64m2_t hi = RVV_OP(vsub_vx_u64m2)(vhi, seed64, vl);
-
-                RVV_OP(vsse64_v_u64m2)((uint64_t*)customSecret, 16, lo, vl);
-                RVV_OP(vsse64_v_u64m2)((uint64_t*)(void*)((uint8_t*)customSecret + 8), 16, hi, vl);
+                vint64m2_t src = XXH_RVOP(vle64_v_i64m2)(kSecret, vl);
+                vint64m2_t res = XXH_RVOP(vadd_vv_i64m2)(src, seed, vl);
+                XXH_RVOP(vse64_v_i64m2)(cSecret, res, vl);
             }
-            i += vl;
-            kSecretPtr += vl * 16;
-            customSecret = (uint8_t*)customSecret + vl * 16;
         }
     }
 }


### PR DESCRIPTION
This cleans up the RVV code a bit, which also resulted in minor speed improvements, when benchmarked on the BananaPi BPI-F3:

this PR:
```
 ===  benchmarking 4 hash functions  === 
benchmarking large inputs : from 512 bytes (log9) to 128 MB (log27) 
xxh3   ,  1325,  1518,  1602,  1643,  1672,  1684,  1619,  1658,  1673,  1679,  1679,  1678,  1681,  1681,  1679,  1678,  1678,  1677,  1675
XXH32  ,  1301,  1396,  1448,  1461,  1483,  1488,  1480,  1488,  1495,  1499,  1490,  1491,  1492,  1491,  1491,  1492,  1492,  1492,  1492
XXH64  ,   882,  1013,  1094,  1135,  1160,  1172,  1176,  1179,  1183,  1185,  1178,  1179,  1180,  1179,  1179,  1180,  1180,  1180,  1180
XXH128 ,  1188,  1422,  1548,  1613,  1656,  1676,  1610,  1651,  1677,  1688,  1694,  1696,  1691,  1686,  1686,  1687,  1676,  1675,  1674
Throughput small inputs of fixed size (from 1 to 30 bytes): 
xxh3   ,  32993087,  32281167,  32336977,  26437187,  26872428,  26410550,  26428945,  26424569,  20253284,  19772865,  19760430,  19769561,  20256873,  19760616,  19764263,  19775474,  12608205,  12227542,  12217493,  12213965,  12608080,  12227208,  12218211,  12222235,  12614935,  12221085,  12217995,  12221804,  12604499,  12221876
XXH32  ,  23509498,  20013892,  17366561,  21857055,  18557514,  16281874,  14501539,  16796542,  14908432,  13401169,  12176184,  13749846,  12563967,  11345143,  10427742,  15641238,  13442555,  12176024,  11158965,  12405266,  11317984,  10420884,   9683693,  10645794,   9845850,   9162365,   8570976,   9355276,   8729440,   8187892
XXH64  ,  23797900,  20177591,  17290947,  22750928,  19427240,  16947657,  15034763,  19167143,  16295399,  14645306,  13379027,  15423298,  14010026,  12747917,  11533971,  14319471,  12683347,  11571095,  10502423,  11928254,  10924094,  10174444,   9410591,  11111895,  10116412,   9426561,   8776001,   9743800,   9064701,   8493138
XXH128 ,  33695031,  32990892,  33033687,  25440969,  25882311,  25415364,  25442224,  24998408,  16964706,  16618739,  16627833,  16614440,  16972178,  16609440,  16616767,  16619228,  12408772,  12033666,  12031826,  12035017,  12403520,  12028067,  12033737,  12035436,  12406729,  12030119,  12032809,  12034091,  12406320,  12033383
benchmarking random size inputs [1-N] : 
xxh3   ,  32959409,  32635978,  32564379,  29296235,  28030613,  27615741,  27236095,  27093553,  25618250,  24695519,  24110265,  23545355,  22750520,  22488289,  22270284,  21993902,  21055293,  19981279,  19600692,  18597259,  18177222,  17676634,  17278162,  17073658,  16684389,  16221969,  16202642,  15775337,  15984004,  15665105
XXH32  ,  23536115,  20760841,  19910892,  19535073,  18960840,  18036673,  17261355,  17012755,  16523576,  15824700,  15416831,  14982420,  14483972,  14061851,  13766215,  14000576,  13698711,  13282465,  13297825,  13176238,  13012354,  12877204,  12522645,  12416507,  12004378,  11762560,  11617584,  11439494,  11477137,  11129421
XXH64  ,  23789784,  20988606,  19417133,  18889255,  18604624,  17928041,  17517253,  17513300,  17156863,  16638925,  16257196,  15821632,  15307443,  14971909,  14570963,  14536986,  14172960,  13791522,  13626526,  13394091,  13172680,  12971344,  12652200,  12620058,  12302802,  12054920,  11946186,  11666136,  11692670,  11402221
XXH128 ,  33681533,  33294327,  33178165,  29406416,  27849474,  27297426,  26835660,  26707801,  24674233,  23141031,  22828196,  21639950,  20680285,  20361553,  20011772,  19727251,  19084934,  18198175,  18066725,  17396012,  17012521,  16732904,  16354220,  16126847,  15686528,  15349059,  15384525,  15016535,  15250865,  14900088
Latency for small inputs of fixed size : 
xxh3   ,  26910365,  26708867,  26788447,  22777971,  22404806,  22405272,  22503351,  22096101,  18152825,  17594031,  17436935,  17432870,  17457723,  17642247,  17384194,  17707445,  11333761,  11369853,  11441029,  11320267,  11388009,  11385355,  11401925,  11575816,  11374932,  11318536,  11435227,  11408097,  11356619,  11421178
XXH32  ,  21392701,  17691921,  15937267,  19633100,  16007984,  14459638,  12892515,  14917215,  13223463,  11887894,  10929283,  12914456,  11422118,  10293167,   9668183,  13270248,  11653930,  10642241,   9948260,  10933473,   9958204,   9180312,   8646024,   9574424,   8818207,   8241678,   7868379,   8531240,   7833542,   7425612
XXH64  ,  20088752,  17562135,  15338740,  18178180,  15401346,  13599845,  12376223,  14699316,  12748517,  11753500,  10748204,  11858196,  10974534,  10321944,   9500447,  11032633,   9190604,   8875426,  10016459,   8660834,   8006255,   7534275,   7245951,   7842169,   7556734,   7028720,   6583975,   6905070,   6664196,   6365122
XXH128 ,  27091844,  27150226,  27131851,  21521310,  21758317,  21751658,  21843489,  21533197,  15007792,  14941697,  14912296,  14906328,  14869735,  15104213,  14945301,  14973105,  11226638,  11463171,  11314985,  11182973,  11218637,  11245731,  11474861,  11124504,  11155608,  11106930,  11176567,  11162145,  11137835,  11229217
Latency for small inputs of random size [1-N] : 
xxh3   ,  26676551,  26044789,  26019351,  24099448,  23006045,  22775106,  22432893,  22502835,  21371165,  20713477,  20486932,  20033566,  19515149,  19206681,  19080200,  18887482,  18137990,  17459383,  17095222,  16392571,  16005433,  15632430,  15307083,  15160514,  14845830,  14476123,  14373813,  14147392,  14260512,  14036430
XXH32  ,  20780916,  18113532,  16709587,  16689177,  16176479,  15472164,  14731364,  14660821,  14287224,  13712392,  13370948,  13039590,  12688385,  12424883,  12048759,  12223071,  11924993,  11720198,  11719302,  11529091,  11369445,  11236087,  10949849,  10821010,  10523838,  10340611,  10258249,  10077953,  10142991,   9793714
XXH64  ,  20377944,  17926633,  16658043,  16303166,  15831383,  15127178,  14476896,  14369608,  14055222,  13634652,  13236653,  12910736,  12394263,  12144344,  11733330,  11672831,  11336375,  10985263,  10876463,  10673771,  10440931,  10275322,  10037907,   9895165,   9640398,   9416207,   9291733,   9110573,   9172695,   8878873
XXH128 ,  27129111,  26459414,  26401242,  23918316,  22852978,  22602494,  22351032,  22131138,  20817551,  19775159,  19323814,  18603995,  17871109,  17658577,  17374529,  17158622,  16659502,  16039790,  15864153,  15370136,  15048909,  14831919,  14559477,  14344298,  14020012,  13749404,  13779412,  13490319,  13681380,  13384119
```

current upstream:
```
 ===  benchmarking 4 hash functions  === 
benchmarking large inputs : from 512 bytes (log9) to 128 MB (log27) 
xxh3   ,  1302,  1480,  1557,  1612,  1624,  1635,  1565,  1604,  1619,  1630,  1630,  1629,  1627,  1626,  1625,  1625,  1624,  1622,  1621
XXH32  ,  1287,  1373,  1447,  1473,  1482,  1488,  1479,  1489,  1495,  1499,  1495,  1492,  1493,  1491,  1491,  1492,  1492,  1492,  1492
XXH64  ,   877,  1004,  1093,  1139,  1158,  1172,  1175,  1180,  1184,  1185,  1182,  1179,  1180,  1179,  1179,  1180,  1180,  1180,  1180
XXH128 ,  1165,  1385,  1501,  1584,  1609,  1628,  1557,  1604,  1625,  1633,  1639,  1641,  1639,  1632,  1631,  1632,  1622,  1620,  1621
Throughput small inputs of fixed size (from 1 to 30 bytes): 
xxh3   ,  32406318,  31783489,  31765820,  26058574,  26504054,  26067104,  26065473,  26067090,  20304837,  19804836,  19798778,  19801223,  20307225,  19806058,  19795226,  19798196,  12527054,  12152635,  12156641,  12140703,  12538336,  12141248,  12146559,  12138535,  12524476,  12167314,  12140677,  12161558,  12522119,  12139704
XXH32  ,  23214926,  19654783,  17299665,  21281471,  18354501,  16129981,  14385527,  16596391,  14789540,  13303598,  12097723,  13760956,  12375073,  11322197,  10434926,  15490625,  13344395,  12106708,  11097780,  12275527,  11268285,  10364494,   9635079,  10599021,   9798905,   9129515,   8535603,   9302983,   8670300,   8159591
XXH64  ,  23819609,  20177553,  17526319,  22782769,  19442027,  16962710,  15042811,  19202989,  16310207,  14516015,  13128025,  15354488,  13849746,  12521390,  11448987,  14050034,  12475243,  11416984,  10505512,  11990507,  10985067,  10165125,   9399737,  11164699,  10123748,   9433795,   8902740,   9830706,   9098127,   8555368
XXH128 ,  31864023,  32395186,  32398615,  25479130,  25908717,  25471493,  25496101,  25491419,  16996817,  16628363,  16637066,  16634718,  16996401,  16636490,  16623755,  16634903,  12416518,  12043443,  12041817,  12040822,  12417355,  12043021,  12040752,  12044577,  12417866,  12042950,  12043446,  11924110,  12415529,  12042030
benchmarking random size inputs [1-N] : 
xxh3   ,  32422767,  32073519,  32003858,  28431834,  27681376,  27116631,  26797263,  26803056,  25230758,  24344448,  23984925,  23132227,  22537052,  22282532,  21990748,  21806560,  20842502,  19809279,  19451178,  18442972,  18210479,  17547676,  17148465,  16931896,  16584080,  16092900,  16077967,  15661297,  15859668,  15510847
XXH32  ,  23267884,  20892317,  19740058,  19202320,  18780006,  17887794,  17089895,  16870516,  16378499,  15702557,  15288219,  14867596,  14380154,  14040221,  13653221,  13867995,  13607643,  13262927,  13192690,  13084079,  12933648,  12764157,  12446448,  12314447,  11913368,  11682669,  11528021,  11355150,  11402213,  11051381
XXH64  ,  23821711,  21006451,  19405736,  19604610,  18626864,  18000964,  17508790,  17538183,  17154544,  16695052,  16292811,  15848373,  15349858,  14987858,  14563221,  14555082,  14170052,  13796549,  13645832,  13396533,  13178806,  12984873,  12675658,  12628952,  12306210,  12066968,  11955543,  11649868,  11685859,  11410087
XXH128 ,  33087457,  32364286,  32391041,  29015012,  27460452,  26992659,  26591903,  26521952,  24393685,  22953810,  22622758,  21485441,  20619223,  20320661,  19913750,  19694529,  19066001,  18098642,  17942907,  17293700,  16966403,  16679017,  16314904,  16069338,  15704554,  15309751,  15308851,  14963092,  15231558,  14871290
Latency for small inputs of fixed size : 
xxh3   ,  26566938,  26332510,  26424210,  22508455,  22093864,  22388937,  22237506,  21850340,  17968755,  17444937,  17546646,  17317417,  17333600,  17495369,  17503116,  17685322,  11280936,  11309303,  11377794,  11564058,  11339709,  11332828,  11325015,  11511891,  11540318,  11349062,  11371792,  11213282,  11304583,  11400316
XXH32  ,  20429039,  17916308,  15868906,  19409084,  16105486,  14370673,  12711269,  14961726,  13249397,  11961694,  10910353,  12826696,  11354682,  10208776,   9623586,  13231546,  11743329,  10622262,   9971057,  10964886,   9943981,   9229483,   8632711,   9555441,   8750822,   8275464,   7804132,   8602366,   7856657,   7446946
XXH64  ,  20417764,  17377766,  15304296,  18536930,  15186359,  14082437,  12385175,  14719622,  12761805,  11757306,  10759769,  11871775,  10982683,   9678862,   9501020,  11039629,  10023987,   8656304,   8239529,   8997512,   8017634,   7526445,   7248209,   8520504,   7561281,   6905347,   6586104,   6911155,   7115220,   6370663
XXH128 ,  26609397,  26706598,  26852979,  21549772,  21778499,  21780409,  21889604,  22532643,  15024767,  14970130,  14944246,  14934851,  14908082,  15130488,  14977860,  14997883,  11181432,  11473636,  11318579,  11200066,  11234765,  11191419,  11160045,  11143323,  11227100,  11122477,  11191353,  11180577,  11154362,  11156699
Latency for small inputs of random size [1-N] : 
xxh3   ,  26331886,  25698915,  25763684,  23569400,  22828554,  22561743,  22294866,  22197578,  21265612,  20443908,  20248645,  19751027,  19276144,  19045380,  18858502,  18719218,  18060311,  17111009,  16993487,  16357284,  16048127,  15653186,  15339587,  15058895,  14808849,  14418755,  14376565,  14071416,  14241213,  13969036
XXH32  ,  20531465,  18067580,  16658826,  16423208,  15936817,  15303666,  14708390,  14548509,  14198461,  13713229,  13361587,  12981205,  12637599,  12364188,  12008817,  12222392,  11898184,  11644105,  11701096,  11507155,  11405860,  11229485,  10944782,  10821492,  10562116,  10327771,  10275847,  10092029,  10171445,   9793369
XXH64  ,  19942736,  17608077,  16450982,  16422907,  15846387,  15125329,  14501020,  14386076,  14092456,  13642814,  13255436,  12932504,  12422470,  12128581,  11752596,  11685063,  11346960,  11009800,  10891863,  10700881,  10478963,  10276731,  10043868,   9902736,   9617647,   9454764,   9298195,   9102502,   9181480,   8881935
XXH128 ,  26741088,  26038485,  26117671,  23680113,  22739453,  22353405,  22092921,  22090587,  20656229,  19565909,  19178515,  18446191,  17819503,  17639085,  17368297,  17193491,  16631821,  15963183,  15824122,  15389233,  15004387,  14821786,  14522053,  14390310,  14059413,  13753137,  13756315,  13502373,  13686131,  13391254
```

The `make check` tests all pass, I tested VLEN=128/256/512/1024 in qemu.