### PR TITLE
Update XXHASH_DIR path retrieval in CMakeLists.txt

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -14,10 +14,8 @@ cmake_minimum_required (VERSION 3.10 FATAL_ERROR)
 # absolute, cleaner ones. For example:
 #   /path/xxHash/build/cmake/../..   ->   /path/xxHash
 #
-# We use get_filename_component() twice to step up two levels and store
-# the result in XXHASH_DIR.
-get_filename_component(XXHASH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" DIRECTORY)
-get_filename_component(XXHASH_DIR "${XXHASH_DIR}" DIRECTORY)
+# We use get_filename_component() to step up two levels and store the result in XXHASH_DIR.
+get_filename_component(XXHASH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
 
 file(STRINGS "${XXHASH_DIR}/xxhash.h" XXHASH_VERSION_MAJOR REGEX "^#define XXH_VERSION_MAJOR +([0-9]+) *$")
 string(REGEX REPLACE "^#define XXH_VERSION_MAJOR +([0-9]+) *$" "\\1" XXHASH_VERSION_MAJOR "${XXHASH_VERSION_MAJOR}")

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -7,7 +7,8 @@
 
 cmake_minimum_required (VERSION 3.10 FATAL_ERROR)
 
-set(XXHASH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+get_filename_component(XXHASH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" DIRECTORY)
+get_filename_component(XXHASH_DIR "${XXHASH_DIR}" DIRECTORY)
 
 file(STRINGS "${XXHASH_DIR}/xxhash.h" XXHASH_VERSION_MAJOR REGEX "^#define XXH_VERSION_MAJOR +([0-9]+) *$")
 string(REGEX REPLACE "^#define XXH_VERSION_MAJOR +([0-9]+) *$" "\\1" XXHASH_VERSION_MAJOR "${XXHASH_VERSION_MAJOR}")

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -7,6 +7,15 @@
 
 cmake_minimum_required (VERSION 3.10 FATAL_ERROR)
 
+# This CMakeLists.txt is in a nested directory, which makes relative paths
+# (e.g. ../..) show up in include flags and logs.
+#
+# To keep build output readable, we resolve these relative paths into
+# absolute, cleaner ones. For example:
+#   /path/xxHash/build/cmake/../..   ->   /path/xxHash
+#
+# We use get_filename_component() twice to step up two levels and store
+# the result in XXHASH_DIR.
 get_filename_component(XXHASH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" DIRECTORY)
 get_filename_component(XXHASH_DIR "${XXHASH_DIR}" DIRECTORY)
 


### PR DESCRIPTION
Make compiler flag `-I` shorter / cleaner. Change from `/path/xxHash/build/cmake/../..` to `/path/xxHash`