### PR TITLE
Fix building for ARM with GCC < 8

### DIFF
--- a/xxhash.h
+++ b/xxhash.h
@@ -6034,7 +6034,7 @@ XXH3_accumulate_512_scalar(void* XXH_RESTRICT acc,
 {
     size_t i;
     /* ARM GCC refuses to unroll this loop, resulting in a 24% slowdown on ARMv6. */
-#if defined(__GNUC__) && !defined(__clang__) \
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 \
   && (defined(__arm__) || defined(__thumb2__)) \
   && defined(__ARM_FEATURE_UNALIGNED) /* no unaligned access just wastes bytes */ \
   && XXH_SIZE_OPT <= 0


### PR DESCRIPTION
The pragma GCC unroll is only available since GCC 8; skip it when building with older compilers.