### PR TITLE
CLI: --help should list -B (as man page does)

### DIFF
--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1415,6 +1415,9 @@ static int XSUM_usage_advanced(const char* exename)
     XSUM_log( "  -b                   Run benchmark \n");
     XSUM_log( "  -b#                  Bench only algorithm variant # \n");
     XSUM_log( "  -i#                  Number of times to run the benchmark (default: %i) \n", NBLOOPS_DEFAULT);
+    XSUM_log( "  -B#                  Block size to hash per benchmark iteration "
+                                     "(default: %llu B) \n",
+                                     (unsigned long long)XSUM_DEFAULT_SAMPLE_SIZE);
     XSUM_log( "  -q, --quiet          Don't display version header in benchmark mode \n");
     XSUM_log( "\n");
     XSUM_log( "The following five options are useful only when using lists in [files] to verify or generate checksums: \n");


### PR DESCRIPTION
I was futzing around with building my own benchmark until the point where I needed to read up on something on `xxhsum`'s man page, and it turned out `-B` exists :)

Nice!

PR to make that also part of the `--help` output.

ISO C90 in the CI forces me to take the rather inelegant detour through `%llu` rather than just `%zu`.
