### PR TITLE
Add -fPIC to the static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,9 @@ $(eval $(call c_program,xxhsum_inlinedXXH,$(CLI_OBJS)))
 # =================================================
 # library
 
+ifeq (,$(filter Windows%,$(OS)))
+libxxhash.a: CFLAGS += -fPIC
+endif
 libxxhash.a:
 $(eval $(call static_library,libxxhash.a,xxhash.o))
 


### PR DESCRIPTION
This is already done for the dynamic library but not for the static one. Currently, building ROOT (https://github.com/root-project/root) when using the static library fails with:

```
[ 59%] Linking CXX shared library ../lib/libCore.so
/cvmfs/sft.cern.ch/lcg/releases/gcc/15.2.0-35657/x86_64-el9/bin/g++ -fPIC  -Wno-implicit-fallthrough -Wno-noexcept-type -pipe  -Wshadow -Wall -W -Woverloaded-virtual -fsigned-char -fsized-deallocation -pthread -O3 -DNDEBUG  -Wl,--no-undefined -Wl,--hash-style="both" -shared -Wl,-soname,libCore.so -o ../lib/libCore.so CMakeFiles/Core.dir/base/src/Match.cxx.o CMakeFiles/Core.dir/base/src/String.cxx.o CMakeFiles/Core.dir/base/src/Stringio.cxx.o CMakeFiles/Core.dir/base/src/TApplication.cxx.o CMakeFiles/Core.dir/base/src/TAtt3D.cxx.o CMakeFiles/Core.dir/base/src/TAttAxis.cxx.o CMakeFiles/Core.dir/base/src/TAttBBox2D.cxx.o CMakeFiles/Core.dir/base/src/TAttBBox.cxx.o CMakeFiles/Core.dir/base/src/TAttFill.cxx.o CMakeFiles/Core.dir/base/src/TAttLine.cxx.o CMakeFiles/Core.dir/base/src/TAttMarker.cxx.o CMakeFiles/Core.dir/base/src/TAttPad.cxx.o CMakeFiles/Core.dir/base/src/TAttText.cxx.o CMakeFiles/Core.dir/base/src/TBase64.cxx.o CMakeFiles/Core.dir/base/src/TBenchmark.cxx.o CMakeFiles/Core.dir/base/src/TBuffer3D.cxx.o CMakeFiles/Core.dir/base/src/TBuffer.cxx.o CMakeFiles/Core.dir/base/src/TColor.cxx.o CMakeFiles/Core.dir/base/src/TColorGradient.cxx.o CMakeFiles/Core.dir/base/src/TDatime.cxx.o CMakeFiles/Core.dir/base/src/TDirectory.cxx.o CMakeFiles/Core.dir/base/src/TEnv.cxx.o CMakeFiles/Core.dir/base/src/TErrorDefaultHandler.cxx.o CMakeFiles/Core.dir/base/src/TException.cxx.o CMakeFiles/Core.dir/base/src/TExec.cxx.o CMakeFiles/Core.dir/base/src/TFileCollection.cxx.o CMakeFiles/Core.dir/base/src/TFileInfo.cxx.o CMakeFiles/Core.dir/base/src/TFolder.cxx.o CMakeFiles/Core.dir/base/src/TInetAddress.cxx.o CMakeFiles/Core.dir/base/src/TListOfTypes.cxx.o CMakeFiles/Core.dir/base/src/TMacro.cxx.o CMakeFiles/Core.dir/base/src/TMathBase.cxx.o CMakeFiles/Core.dir/base/src/TMD5.cxx.o CMakeFiles/Core.dir/base/src/TMemberInspector.cxx.o CMakeFiles/Core.dir/base/src/TMessageHandler.cxx.o CMakeFiles/Core.dir/base/src/TNamed.cxx.o CMakeFiles/Core.dir/base/src/TObject.cxx.o CMakeFiles/Core.dir/base/src/TObjString.cxx.o CMakeFiles/Core.dir/base/src/TParameter.cxx.o CMakeFiles/Core.dir/base/src/TPluginManager.cxx.o CMakeFiles/Core.dir/base/src/TPRegexp.cxx.o CMakeFiles/Core.dir/base/src/TProcessID.cxx.o CMakeFiles/Core.dir/base/src/TProcessUUID.cxx.o CMakeFiles/Core.dir/base/src/TQCommand.cxx.o CMakeFiles/Core.dir/base/src/TQConnection.cxx.o CMakeFiles/Core.dir/base/src/TQObject.cxx.o CMakeFiles/Core.dir/base/src/TRefCnt.cxx.o CMakeFiles/Core.dir/base/src/TRef.cxx.o CMakeFiles/Core.dir/base/src/TRegexp.cxx.o CMakeFiles/Core.dir/base/src/TRemoteObject.cxx.o CMakeFiles/Core.dir/base/src/TROOT.cxx.o CMakeFiles/Core.dir/base/src/TStopwatch.cxx.o CMakeFiles/Core.dir/base/src/TStorage.cxx.o CMakeFiles/Core.dir/base/src/TString.cxx.o CMakeFiles/Core.dir/base/src/TStringLong.cxx.o CMakeFiles/Core.dir/base/src/TStyle.cxx.o CMakeFiles/Core.dir/base/src/TSysEvtHandler.cxx.o CMakeFiles/Core.dir/base/src/TSystem.cxx.o CMakeFiles/Core.dir/base/src/TSystemDirectory.cxx.o CMakeFiles/Core.dir/base/src/TSystemFile.cxx.o CMakeFiles/Core.dir/base/src/TTask.cxx.o CMakeFiles/Core.dir/base/src/TTime.cxx.o CMakeFiles/Core.dir/base/src/TTimer.cxx.o CMakeFiles/Core.dir/base/src/TTimeStamp.cxx.o CMakeFiles/Core.dir/base/src/TUri.cxx.o CMakeFiles/Core.dir/base/src/TUrl.cxx.o CMakeFiles/Core.dir/base/src/TUUID.cxx.o CMakeFiles/Core.dir/base/src/TVirtualFFT.cxx.o CMakeFiles/Core.dir/base/src/TVirtualGL.cxx.o CMakeFiles/Core.dir/base/src/TVirtualMonitoring.cxx.o CMakeFiles/Core.dir/base/src/TVirtualMutex.cxx.o CMakeFiles/Core.dir/base/src/TVirtualPad.cxx.o CMakeFiles/Core.dir/base/src/TVirtualPadEditor.cxx.o CMakeFiles/Core.dir/base/src/TVirtualPadPainter.cxx.o CMakeFiles/Core.dir/base/src/TVirtualPerfStats.cxx.o CMakeFiles/Core.dir/base/src/TVirtualPS.cxx.o CMakeFiles/Core.dir/base/src/TVirtualViewer3D.cxx.o CMakeFiles/Core.dir/base/src/TVirtualX.cxx.o CMakeFiles/Core.dir/cont/src/TArrayC.cxx.o CMakeFiles/Core.dir/cont/src/TArray.cxx.o CMakeFiles/Core.dir/cont/src/TArrayD.cxx.o CMakeFiles/Core.dir/cont/src/TArrayF.cxx.o CMakeFiles/Core.dir/cont/src/TArrayI.cxx.o CMakeFiles/Core.dir/cont/src/TArrayL64.cxx.o CMakeFiles/Core.dir/cont/src/TArrayL.cxx.o CMakeFiles/Core.dir/cont/src/TArrayS.cxx.o CMakeFiles/Core.dir/cont/src/TBits.cxx.o CMakeFiles/Core.dir/cont/src/TBtree.cxx.o CMakeFiles/Core.dir/cont/src/TClassTable.cxx.o CMakeFiles/Core.dir/cont/src/TClonesArray.cxx.o CMakeFiles/Core.dir/cont/src/TCollection.cxx.o CMakeFiles/Core.dir/cont/src/TExMap.cxx.o CMakeFiles/Core.dir/cont/src/THashList.cxx.o CMakeFiles/Core.dir/cont/src/THashTable.cxx.o CMakeFiles/Core.dir/cont/src/TIterator.cxx.o CMakeFiles/Core.dir/cont/src/TList.cxx.o CMakeFiles/Core.dir/cont/src/TMap.cxx.o CMakeFiles/Core.dir/cont/src/TObjArray.cxx.o CMakeFiles/Core.dir/cont/src/TObjectTable.cxx.o CMakeFiles/Core.dir/cont/src/TOrdCollection.cxx.o CMakeFiles/Core.dir/cont/src/TRefArray.cxx.o CMakeFiles/Core.dir/cont/src/TRefTable.cxx.o CMakeFiles/Core.dir/cont/src/TSeqCollection.cxx.o CMakeFiles/Core.dir/cont/src/TSortedList.cxx.o CMakeFiles/Core.dir/foundation/src/FoundationUtils.cxx.o CMakeFiles/Core.dir/foundation/src/RConversionRuleParser.cxx.o CMakeFiles/Core.dir/foundation/src/RError.cxx.o CMakeFiles/Core.dir/foundation/src/RLogger.cxx.o CMakeFiles/Core.dir/foundation/src/StringUtils.cxx.o CMakeFiles/Core.dir/foundation/src/TClassEdit.cxx.o CMakeFiles/Core.dir/foundation/src/TError.cxx.o CMakeFiles/Core.dir/gui/src/InitGui.cxx.o CMakeFiles/Core.dir/gui/src/TApplicationImp.cxx.o CMakeFiles/Core.dir/gui/src/TBrowser.cxx.o CMakeFiles/Core.dir/gui/src/TBrowserImp.cxx.o CMakeFiles/Core.dir/gui/src/TCanvasImp.cxx.o CMakeFiles/Core.dir/gui/src/TClassMenuItem.cxx.o CMakeFiles/Core.dir/gui/src/TContextMenu.cxx.o CMakeFiles/Core.dir/gui/src/TContextMenuImp.cxx.o CMakeFiles/Core.dir/gui/src/TControlBarImp.cxx.o CMakeFiles/Core.dir/gui/src/TGuiFactory.cxx.o CMakeFiles/Core.dir/gui/src/TInspectorImp.cxx.o CMakeFiles/Core.dir/gui/src/TObjectSpy.cxx.o CMakeFiles/Core.dir/gui/src/TToggle.cxx.o CMakeFiles/Core.dir/gui/src/TToggleGroup.cxx.o CMakeFiles/Core.dir/meta/src/TBaseClass.cxx.o CMakeFiles/Core.dir/meta/src/TClass.cxx.o CMakeFiles/Core.dir/meta/src/TClassGenerator.cxx.o CMakeFiles/Core.dir/meta/src/TClassRef.cxx.o CMakeFiles/Core.dir/meta/src/TDataMember.cxx.o CMakeFiles/Core.dir/meta/src/TDataType.cxx.o CMakeFiles/Core.dir/meta/src/TDictAttributeMap.cxx.o CMakeFiles/Core.dir/meta/src/TDictionary.cxx.o CMakeFiles/Core.dir/meta/src/TEnum.cxx.o CMakeFiles/Core.dir/meta/src/TEnumConstant.cxx.o CMakeFiles/Core.dir/meta/src/TFunction.cxx.o CMakeFiles/Core.dir/meta/src/TFunctionTemplate.cxx.o CMakeFiles/Core.dir/meta/src/TGenericClassInfo.cxx.o CMakeFiles/Core.dir/meta/src/TGlobal.cxx.o CMakeFiles/Core.dir/meta/src/TInterpreter.cxx.o CMakeFiles/Core.dir/meta/src/TIsAProxy.cxx.o CMakeFiles/Core.dir/meta/src/TListOfDataMembers.cxx.o CMakeFiles/Core.dir/meta/src/TListOfEnums.cxx.o CMakeFiles/Core.dir/meta/src/TListOfEnumsWithLock.cxx.o CMakeFiles/Core.dir/meta/src/TListOfFunctions.cxx.o CMakeFiles/Core.dir/meta/src/TListOfFunctionTemplates.cxx.o CMakeFiles/Core.dir/meta/src/TMethod.cxx.o CMakeFiles/Core.dir/meta/src/TMethodArg.cxx.o CMakeFiles/Core.dir/meta/src/TMethodCall.cxx.o CMakeFiles/Core.dir/meta/src/TProtoClass.cxx.o CMakeFiles/Core.dir/meta/src/TRealData.cxx.o CMakeFiles/Core.dir/meta/src/TSchemaRule.cxx.o CMakeFiles/Core.dir/meta/src/TSchemaRuleSet.cxx.o CMakeFiles/Core.dir/meta/src/TStatusBitsChecker.cxx.o CMakeFiles/Core.dir/meta/src/TStreamerElement.cxx.o CMakeFiles/Core.dir/meta/src/TViewPubDataMembers.cxx.o CMakeFiles/Core.dir/meta/src/TViewPubFunctions.cxx.o CMakeFiles/Core.dir/meta/src/TVirtualStreamerInfo.cxx.o CMakeFiles/Core.dir/textinput/src/Getline_color.cxx.o CMakeFiles/Core.dir/textinput/src/Getline.cxx.o CMakeFiles/Core.dir/textinput/src/textinput/Editor.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/History.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/KeyBinding.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/Range.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/SignalHandler.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/StreamReader.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/StreamReaderUnix.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/StreamReaderWin.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/TerminalConfigUnix.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/TerminalDisplay.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/TerminalDisplayUnix.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/TerminalDisplayWin.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/TextInputContext.cpp.o CMakeFiles/Core.dir/textinput/src/textinput/TextInput.cpp.o CMakeFiles/Core.dir/zip/src/Bits.c.o CMakeFiles/Core.dir/zip/src/ZDeflate.c.o CMakeFiles/Core.dir/zip/src/ZTrees.c.o CMakeFiles/Core.dir/zip/src/ZInflate.c.o CMakeFiles/Core.dir/zip/src/Compression.cxx.o CMakeFiles/Core.dir/zip/src/RZip.cxx.o CMakeFiles/Core.dir/lzma/src/ZipLZMA.c.o CMakeFiles/Core.dir/lz4/src/ZipLZ4.cxx.o CMakeFiles/Core.dir/zstd/src/ZipZSTD.cxx.o CMakeFiles/Core.dir/unix/src/TUnixSystem.cxx.o clib/CMakeFiles/Clib.dir/src/attach.c.o clib/CMakeFiles/Clib.dir/src/detach.c.o clib/CMakeFiles/Clib.dir/src/getpagesize.c.o clib/CMakeFiles/Clib.dir/src/keys.c.o clib/CMakeFiles/Clib.dir/src/mcalloc.c.o clib/CMakeFiles/Clib.dir/src/mfree.c.o clib/CMakeFiles/Clib.dir/src/mmalloc.c.o clib/CMakeFiles/Clib.dir/src/mmapsup.c.o clib/CMakeFiles/Clib.dir/src/mmcheck.c.o clib/CMakeFiles/Clib.dir/src/mrealloc.c.o clib/CMakeFiles/Clib.dir/src/sbrksup.c.o clib/CMakeFiles/Clib.dir/src/snprintf.c.o clib/CMakeFiles/Clib.dir/src/strlcat.c.o clib/CMakeFiles/Clib.dir/src/strlcpy.c.o CMakeFiles/G__Core.dir/G__Core.cxx.o  -Wl,-rpath,"\$ORIGIN:/build/jenkins/workspace/lcg_nightly_pipeline/install/dev3/pcre2/10.42/x86_64-el9-gcc15-opt/lib64::" -ldl /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3/pcre2/10.42/x86_64-el9-gcc15-opt/lib64/libpcre2-8.so /usr/lib64/libz.so /usr/lib64/liblzma.so /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3/xxHash/0.8.3/x86_64-el9-gcc15-opt/lib/libxxhash.a /usr/lib64/liblz4.so /usr/lib64/libzstd.so
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3/xxHash/0.8.3/x86_64-el9-gcc15-opt/lib/libxxhash.a(xxhash.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```
I left the Windows check since that is how it is done for the dynamic library.
Alternatively we could change CFLAGS, but given that it is already there for the dynamic library I made this PR.