### PR TITLE
cli: make --quiet work no matter where it's placed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,9 @@ test-xxhsum-c: xxhsum
 	! ./xxhsum -q $(TEST_FILES) 2>&1 | grep Loading
 	# xxhsum does not display "Loading" message into stderr either
 	! ./xxhsum $(TEST_FILES) 2>&1 | grep Loading
+	# --quiet takes effect no matter where it's placed, not just before -c (#1098)
+	test -z "$$(./xxhsum --quiet -c .test.README.md.xxh < README.md)"
+	test -z "$$(./xxhsum -c .test.README.md.xxh --quiet < README.md)"
 	# Check that xxhsum do display filename that it failed to open.
 	LC_ALL=C ./xxhsum nonexistent 2>&1 | grep "Error: Could not open 'nonexistent'"
 	# xxhsum to/from file, shell redirection

--- a/cli/xxhsum.c
+++ b/cli/xxhsum.c
@@ -1550,6 +1550,30 @@ XSUM_API int XSUM_main(int argc, const char* argv[])
     if (strstr(exename, "xxh128sum") != NULL) { algo = g_defaultAlgo = algo_xxh128; algoBitmask = algo_bitmask_xxh128; }
     if (strstr(exename,   "xxh3sum") != NULL) { algo = g_defaultAlgo = algo_xxh3;   algoBitmask = algo_bitmask_xxh3;  }
 
+    /* The loop below stops scanning for options as soon as it hits the first
+     * filename, since it only supports a continuous list of filenames (see
+     * the comment further down). That means a trailing --quiet ends up
+     * swallowed as a bogus filename instead of being applied, e.g.
+     * "xxhsum -c list.xxhash --quiet" stays noisy while
+     * "xxhsum --quiet -c list.xxhash" doesn't (issue #1098). Strip every
+     * --quiet out of argv here first, before that loop runs, so it always
+     * takes effect regardless of where it was passed. Stop at an explicit
+     * "--", since anything after that is a literal filename. */
+    {   int src, dst = 1;
+        for (src=1; src<argc; src++) {
+            if (!strcmp(argv[src], "--")) {
+                for (; src<argc; src++) argv[dst++] = argv[src];
+                break;
+            }
+            if (!strcmp(argv[src], "--quiet")) {
+                XSUM_logLevel--;
+                continue;
+            }
+            argv[dst++] = argv[src];
+        }
+        argc = dst;
+    }
+
     for (i=1; i<argc; i++) {
         const char* argument = argv[i];
         assert(argument != NULL);
@@ -1559,7 +1583,6 @@ XSUM_API int XSUM_main(int argc, const char* argv[])
         if (!strcmp(argument, "--filelist")) { readFilenamesMode = 1; continue; }
         if (!strcmp(argument, "--benchmark-all")) { benchmarkMode = 1; selectBenchIDs = kBenchAll; continue; }
         if (!strcmp(argument, "--bench-all")) { benchmarkMode = 1; selectBenchIDs = kBenchAll; continue; }
-        if (!strcmp(argument, "--quiet")) { XSUM_logLevel--; continue; }
         if (!strcmp(argument, "--little-endian")) { displayEndianness = little_endian; continue; }
         if (!strcmp(argument, "--strict")) { strictMode = 1; continue; }
         if (!strcmp(argument, "--status")) { statusOnly = 1; continue; }


### PR DESCRIPTION
Fixes #1098.

The option-parsing loop in `xxhsum` stops looking for flags as soon as it hits the first filename argument, since `-c`/`--check` treats everything after it as a continuous list of filenames rather than more options mixed in. That means `xxhsum -c list.xxhash --quiet` swallows `--quiet` as if it were just another (nonexistent) filename, while `xxhsum --quiet -c list.xxhash` works as expected. Same root cause explains why other flags placed after a filename get ignored too, but `--quiet` is the one that's been reported.

This adds an earlier pass over `argv` that pulls every `--quiet` out before the main loop runs (stopping at an explicit `--`, since anything past that is meant to be a literal filename), so it takes effect regardless of position.

Verified by reproducing the exact case from the issue against unmodified `dev` first (trailing `--quiet` gets treated as a bogus filename and the check stays noisy), then confirming it's silent both ways with the fix applied. Added two lines to the existing `test-xxhsum-c` Makefile target covering `--quiet` on both sides of `-c`, and ran the full target clean.